### PR TITLE
Решение энергетического кризиса станций

### DIFF
--- a/Content.Server/Solar/Components/SolarPanelComponent.cs
+++ b/Content.Server/Solar/Components/SolarPanelComponent.cs
@@ -15,7 +15,7 @@ namespace Content.Server.Solar.Components
         /// Maximum supply output by this panel (coverage = 1)
         /// </summary>
         [DataField("maxSupply")]
-        public int MaxSupply = 750;
+        public int MaxSupply = 1875; ///ADT_Tweak
 
         /// <summary>
         /// Current coverage of this panel (from 0 to 1).

--- a/Resources/Prototypes/ADT/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/ADT/Catalog/Cargo/cargo_engineering.yml
@@ -17,3 +17,23 @@
   cost: 800
   category: cargoproduct-category-name-engineering
   group: market
+
+- type: cargoProduct
+  id: EngineeringAMEShielding
+  icon:
+    sprite: Objects/Devices/flatpack.rsi
+    state: ame-part
+  product: CrateEngineeringAMEShielding
+  cost: 7500
+  category: cargoproduct-category-name-engineering
+  group: market
+
+- type: cargoProduct
+  id: EngineeringAMEControl
+  icon:
+    sprite: Structures/Power/Generation/ame.rsi
+    state: control
+  product: CrateEngineeringAMEControl
+  cost: 2500
+  category: cargoproduct-category-name-engineering
+  group: market

--- a/Resources/Prototypes/ADT/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/ADT/Catalog/Cargo/cargo_engineering.yml
@@ -17,23 +17,3 @@
   cost: 800
   category: cargoproduct-category-name-engineering
   group: market
-
-- type: cargoProduct
-  id: EngineeringAMEShielding
-  icon:
-    sprite: Objects/Devices/flatpack.rsi
-    state: ame-part
-  product: CrateEngineeringAMEShielding
-  cost: 7500
-  category: cargoproduct-category-name-engineering
-  group: market
-
-- type: cargoProduct
-  id: EngineeringAMEControl
-  icon:
-    sprite: Structures/Power/Generation/ame.rsi
-    state: control
-  product: CrateEngineeringAMEControl
-  cost: 2500
-  category: cargoproduct-category-name-engineering
-  group: market

--- a/Resources/Prototypes/ADT/Catalog/Cargo/cargo_engines.yml
+++ b/Resources/Prototypes/ADT/Catalog/Cargo/cargo_engines.yml
@@ -1,0 +1,20 @@
+
+- type: cargoProduct
+  id: EngineeringAMEShielding
+  icon:
+    sprite: Objects/Devices/flatpack.rsi
+    state: ame-part
+  product: CrateEngineeringAMEShielding
+  cost: 7500
+  category: cargoproduct-category-name-engineering
+  group: market
+
+- type: cargoProduct
+  id: EngineeringAMEControl
+  icon:
+    sprite: Structures/Power/Generation/ame.rsi
+    state: control
+  product: CrateEngineeringAMEControl
+  cost: 2500
+  category: cargoproduct-category-name-engineering
+  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
@@ -9,7 +9,7 @@
   - type: StorageFill
     contents:
       - id: AmePartFlatpack
-        amount: 9
+        amount: 12 #ADT_Tweaks
 
 - type: entity
   id: CrateEngineeringAMEJar


### PR DESCRIPTION
Решение энергокризиса на станции
В ящике компонентов дам 12 штук вместо 9 - можно запустить двухядерник
Соляры вырабатывают в 2.5 раза больше - теперь они значимый источник электроэнергии
Добавлена возможность покупки компонентов ДАМ и контроллера ДАМ

:cl:
- add: Добавлена покупка компонентов ДАМ и контроллера ДАМ в карго
- tweak: Количество компонентов ДАМ в одном ящике увеличено до 12 вместо 9
- tweak: Выработка солнечных батарей увеличена в 2.5 раза
