### PR TITLE
гетерохромия для аркан

### DIFF
--- a/Resources/Locale/ru-RU/ADT/prototypes/Entities/Mobs/Customization/Markings/demon.ftl
+++ b/Resources/Locale/ru-RU/ADT/prototypes/Entities/Mobs/Customization/Markings/demon.ftl
@@ -23,3 +23,5 @@ marking-DemonChestQueenLines = Линии Королевы на груди
 marking-DemonChestTreeLines = Древесные линии на груди
 marking-DemonChestTrinitySpots = Троичные пятна на груди
 marking-DemonGoatee = Козлиная бородка
+marking-ADTDemonrigth_eye = Правый глаз
+marking-ADTDemonleft_eye = Левый глаз

--- a/Resources/Prototypes/ADT/Entities/Mobs/Customization/Markings/demon.yml
+++ b/Resources/Prototypes/ADT/Entities/Mobs/Customization/Markings/demon.yml
@@ -61,3 +61,33 @@
   sprites:
   - sprite: ADT/Mobs/Customization/Demon/custom.rsi
     state: goatee
+
+#Глаза, гетерохромия
+
+- type: marking
+  id: ADTDemonrigth_eye
+  bodyPart: Eyes
+  markingCategory: Head
+  speciesRestriction: [DemonSpecies]
+  coloring:
+    default:
+      type:
+        !type:EyeColoring
+          negative: true
+  sprites:
+  - sprite: Mobs/Customization/tattoos.rsi
+    state: tattoo_eye_r
+
+- type: marking
+  id: ADTDemonleft_eye
+  bodyPart: Eyes
+  markingCategory: Head
+  speciesRestriction: [DemonSpecies]
+  coloring:
+    default:
+      type:
+        !type:EyeColoring
+          negative: true
+  sprites:
+  - sprite: Mobs/Customization/tattoos.rsi
+    state: tattoo_eye_l


### PR DESCRIPTION
Гетерохрмоия для аркан

:cl:
- add: Возможность выбрать в чертах внешности левый и/или правый глаз другого цвета для аркан. Короче - гетерохромия. 
