### PR TITLE
еда для молей

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
@@ -413,6 +413,10 @@
     - state: plain
   - type: SliceableFood
     slice: FoodBreadPlainSlice
+  - type: Tag #ADT_Tweak - делаем хлеб съедобным для молей
+    tags:
+    - Bread
+    - ADTMothFriendlyFood
 
 - type: entity
   name: bread slice
@@ -424,6 +428,11 @@
   - type: Sprite
     layers:
     - state: plain-slice
+  - type: Tag #ADT_Tweak - делаем хлеб съедобным для молей
+    tags:
+    - Bread
+    - Slice
+    - ADTMothFriendlyFood
 
 - type: entity
   name: sausage bread
@@ -700,6 +709,10 @@
     damage:
       types:
         Blunt: 1 # bonk
+  - type: Tag #ADT_Tweak - делаем хлеб съедобным для молей
+    tags:
+    - Bread
+    - ADTMothFriendlyFood
 # Tastes like France.
 
 - type: entity
@@ -723,6 +736,11 @@
           Quantity: 0.1
         - ReagentId: Blackpepper
           Quantity: 0.1
+  - type: Tag #ADT_Tweak - делаем хлеб съедобным для молей
+    tags:
+    - Bread
+    - Slice
+    - ADTMothFriendlyFood
 
 - type: entity
   name: buttered toast
@@ -745,6 +763,11 @@
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 1
+  - type: Tag #ADT_Tweak - делаем хлеб съедобным для молей
+    tags:
+    - Bread
+    - Slice
+    - ADTMothFriendlyFood
 # Tastes like bread, butter.
 
 - type: entity
@@ -792,6 +815,11 @@
           Quantity: 6
         - ReagentId: Vitamin
           Quantity: 5
+  - type: Tag #ADT_Tweak - делаем хлеб съедобным для молей
+    tags:
+    - Bread
+    - Slice
+    - ADTMothFriendlyFood
 # Tastes like garlic, Italy.
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
@@ -130,6 +130,9 @@
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 1
+  - type: Tag  #ADT_Tweak - делаем овсяное печенье съедобным для молей
+    tags:
+    - ADTMothFriendlyFood
 
 - type: entity
   name: raisin cookie
@@ -254,6 +257,7 @@
   - type: Tag
     tags:
     - Pancake
+    - ADTMothFriendlyFood #ADT_Tweak - делаем блинчики съедобными для молей
 
 - type: entity
   name: blueberry pancake
@@ -307,6 +311,7 @@
     tags:
     - Pancake
     - Fruit
+    - ADTMothFriendlyFood #ADT_Tweak - делаем блинчики съедобными для молей
 
 - type: entity
   name: chocolate chip pancake
@@ -385,6 +390,9 @@
           Quantity: 8
         - ReagentId: Vitamin
           Quantity: 1
+  - type: Tag
+    tags:
+    - ADTMothFriendlyFood #ADT_Tweak - делаем вафли съедобными для молей
 
 - type: entity
   name: soy waffles
@@ -456,6 +464,9 @@
   components:
   - type: Sprite
     state: pretzel
+  - type: Tag
+    tags:
+    - ADTMothFriendlyFood #ADT_Tweak - делаем претцли съедобными для молей
 
 - type: entity
   name: cannoli
@@ -658,6 +669,9 @@
             Quantity: 1
           - ReagentId: Vitamin
             Quantity: 1
+    - type: Tag
+      tags:
+      - ADTMothFriendlyFood #ADT_Tweak - делаем луковые кольца съедобными для молей
 
 - type: entity
   name: croissant
@@ -686,3 +700,6 @@
     damage:
       types:
         Blunt: 0 # so the damage stats icon doesn't immediately give away the syndie ones
+  - type: Tag
+    tags:
+    - ADTMothFriendlyFood #ADT_Tweak - делаем круассаны съедобными для молей

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
@@ -926,6 +926,9 @@
           Quantity: 6
         - ReagentId: Vitamin
           Quantity: 3
+  - type: Tag  #ADT_Tweak - делаем тофу-бургер съедобным для молей
+    tags:
+    - ADTMothFriendlyFood
 # Tastes like bun, tofu.
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -626,6 +626,9 @@
         sprite:
           sprite: Objects/Consumable/Food/ingredients.rsi
           state: cheesewheel
+  - type: Tag  #ADT_Tweak - делаем сыр съедобным для молей
+    tags:
+    - ADTMothFriendlyFood
 
 - type: entity
   name: cheese wedge
@@ -648,6 +651,7 @@
   - type: Tag
     tags:
     - Slice
+    - ADTMothFriendlyFood  #ADT_Tweak - делаем сыр съедобным для молей
   - type: FoodSequenceElement
     sprite:
       sprite: Objects/Consumable/Food/ingredients.rsi

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
@@ -37,6 +37,9 @@
       - potatoes
   - type: Sprite
     state: loadedbakedpotato
+  - type: Tag #ADT_Tweak - делаем картофельные блюда съедобными для молей
+    tags:
+    - ADTMothFriendlyFood
 # Tastes like potato.
 
 - type: entity
@@ -51,6 +54,9 @@
       - salty
   - type: Sprite
     state: fries
+  - type: Tag #ADT_Tweak - делаем картофельные блюда съедобными для молей
+    tags:
+    - ADTMothFriendlyFood
 # Tastes like fries, salt.
 
 - type: entity
@@ -66,6 +72,9 @@
       - cheesy
   - type: Sprite
     state: fries-cheesy
+  - type: Tag #ADT_Tweak - делаем картофельные блюда съедобными для молей
+    tags:
+    - ADTMothFriendlyFood
 # Tastes like fries, cheese.
 
 - type: entity
@@ -83,6 +92,7 @@
   - type: Tag
     tags:
     - CarrotFries
+    - ADTMothFriendlyFood #ADT_Tweak - делаем морковный фри съедобными для молей
   - type: SolutionContainerManager
     solutions:
       food:
@@ -215,6 +225,9 @@
       - potatoes
   - type: Sprite
     state: yakiimo
+  - type: Tag #ADT_Tweak - делаем картофельные блюда съедобными для молей
+    tags:
+    - ADTMothFriendlyFood
 # Tastes like sweet potato.
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/noodles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/noodles.yml
@@ -32,6 +32,9 @@
       - pasta
   - type: Sprite
     state: boiled
+  - type: Tag #ADT_Tweak - делаем пасту съедобной для молей
+    tags:
+    - ADTMothFriendlyFood
 # Tastes like pasta.
 
 - type: entity
@@ -71,6 +74,9 @@
           Quantity: 12
         - ReagentId: Vitamin
           Quantity: 8
+  - type: Tag #ADT_Tweak - делаем пасту съедобной для молей
+    tags:
+    - ADTMothFriendlyFood
 # Tastes like pasta, bad humor.
 
 - type: entity
@@ -168,4 +174,7 @@
           Quantity: 8
         - ReagentId: Vitamin
           Quantity: 1
+  - type: Tag #ADT_Tweak - делаем пасту съедобной для молей
+    tags:
+    - ADTMothFriendlyFood
 # Tastes like pasta, butter.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -515,6 +515,7 @@
   - type: Tag
     tags:
     - Vegetable
+    - ADTMothFriendlyFood #ADT-Tweak - делаем капусту съедобной для молей
   - type: FoodSequenceElement
     sprite:
       sprite: Objects/Specific/Hydroponics/cabbage.rsi

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
@@ -234,6 +234,10 @@
           Quantity: 8
         - ReagentId: Vitamin
           Quantity: 6
+  - type: Tag #ADT_Tweak - делаем салат Цезарь съедобным для молей
+    tags:
+    - ADTMothFriendlyFood
+    - Soup
 
 - type: entity
   name: kimchi salad
@@ -386,6 +390,10 @@
     layers:
     - state: bowl
     - state: rice
+  - type: Tag #ADT_Tweak - делаем салат Цезарь съедобным для молей
+    tags:
+    - ADTMothFriendlyFood
+    - Soup
 
 - type: entity
   name: egg-fried rice
@@ -534,6 +542,10 @@
           Quantity: 2
         - ReagentId: Milk
           Quantity: 10
+  - type: Tag #ADT_Tweak - делаем салат Цезарь съедобным для молей
+    tags:
+    - ADTMothFriendlyFood
+    - Soup
 
 - type: entity
   name: space liberty duff


### PR DESCRIPTION
Разделение вчерашнего ПР по частям
Часть 1 - Добавление в разрешенную для ниан еду

:cl:
- tweak: Расширение доступной еды для ниан - капуста, обычный хлеб, тосты с маслом, еще немного мучного, каши, картошка и морковка-фри, сыр и еще кое-что.
