### PR TITLE
нерф спринтера

### DIFF
--- a/Resources/Prototypes/ADT/Traits/quirks.yml
+++ b/Resources/Prototypes/ADT/Traits/quirks.yml
@@ -26,7 +26,7 @@
   components:
     - type: Sprinter
       modifier: 1.05
-  cost: 6
+  cost: 4
 
 - type: trait
   id: ADTFastLockers

--- a/Resources/Prototypes/ADT/Traits/quirks.yml
+++ b/Resources/Prototypes/ADT/Traits/quirks.yml
@@ -25,8 +25,8 @@
   category: Quirks
   components:
     - type: Sprinter
-      modifier: 1.1
-  cost: 2
+      modifier: 1.05
+  cost: 6
 
 - type: trait
   id: ADTFastLockers

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -34,7 +34,7 @@
     - type: Narcolepsy
       timeBetweenIncidents: 300, 600
       durationOfIncident: 10, 30
-  cost: -2  # ADT Quirks
+  cost: -1  # ADT Quirks
 
 - type: trait
   id: Unrevivable

--- a/Resources/Prototypes/Traits/quirks.yml
+++ b/Resources/Prototypes/Traits/quirks.yml
@@ -26,6 +26,6 @@
   category: Quirks
   components:
   - type: Snoring
-  cost: -1  # ADT quirks
+  cost: 0  # ADT quirks
   speciesBlacklist:
   - IPC


### PR DESCRIPTION
Вторая часть QoL-пр вчерашнего

Спринтер понерфлен - дает +5% к скорости вместо +10%. Стоит теперь 4 очка 

:cl:
- tweak: Способность спринтера стоит теперь 4 очка и дает +5% к скорости вместо +10%. 
- tweak: Способность "храп" теперь стоит 0 очков. 
- tweak: Способность "нарколепсия" теперь стоит -1 очков. 
