### PR TITLE
Добавил проверку, не держат ли при рандомном телепорте в системе Shadekin

### DIFF
--- a/Content.Server/ADT/Shadekin/ShadekinSystem.cs
+++ b/Content.Server/ADT/Shadekin/ShadekinSystem.cs
@@ -153,13 +153,19 @@ public sealed partial class ShadekinSystem : EntitySystem
         var coordsValid = false;
         EntityCoordinates coords = Transform(uid).Coordinates;
 
+        if (TryComp<PullableComponent>(uid, out var pullable) && pullable.BeingPulled)
+        {
+            comp.MaxedPowerAccumulator = 0f;
+            return;
+        }
+
         while (!coordsValid)
         {
             var newCoords = new EntityCoordinates(Transform(uid).ParentUid, coords.X + _random.NextFloat(-5f, 5f), coords.Y + _random.NextFloat(-5f, 5f));
             if (_interaction.InRangeUnobstructed(uid, newCoords, -1f))
             {
                 TryUseAbility(uid, 40, false);
-                if (TryComp<PullerComponent>(uid, out var puller) && puller.Pulling != null && TryComp<PullableComponent>(puller.Pulling, out var pullable))
+                if (TryComp<PullerComponent>(uid, out var puller) && puller.Pulling != null && pullable != null)
                     _pulling.TryStopPull(puller.Pulling.Value, pullable);
                 _alert.ShowAlert(uid, _proto.Index<AlertPrototype>("ShadekinPower"), (short) Math.Clamp(Math.Round(comp.PowerLevel / 50f), 0, 4));
                 _transform.SetCoordinates(uid, newCoords);

--- a/Content.Server/ADT/Shadekin/ShadekinSystem.cs
+++ b/Content.Server/ADT/Shadekin/ShadekinSystem.cs
@@ -20,6 +20,8 @@ using Content.Shared.Alert;
 using Robust.Shared.Prototypes;
 using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Movement.Pulling.Components;
+using Content.Server.Cuffs;
+using Content.Shared.Cuffs.Components;
 
 namespace Content.Server.ADT.Shadekin;
 
@@ -37,6 +39,7 @@ public sealed partial class ShadekinSystem : EntitySystem
     [Dependency] private readonly AlertsSystem _alert = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly PullingSystem _pulling = default!;
+    [Dependency] private readonly CuffableSystem _cuffable = default!;
 
     public override void Initialize()
     {
@@ -153,10 +156,14 @@ public sealed partial class ShadekinSystem : EntitySystem
         var coordsValid = false;
         EntityCoordinates coords = Transform(uid).Coordinates;
 
-        if (TryComp<PullableComponent>(uid, out var mainEntityPullable) && mainEntityPullable.BeingPulled)
+        if (TryComp<CuffableComponent>(uid, out var cuffable) && _cuffable.IsCuffed((uid, cuffable), true))
         {
             comp.MaxedPowerAccumulator = 0f;
             return;
+        }
+
+        if (TryComp<PullableComponent>(uid, out var mainEntityPullable) && _pulling.IsPulled(uid, mainEntityPullable)) {
+            _pulling.TryStopPull(uid, mainEntityPullable);
         }
 
         while (!coordsValid)

--- a/Content.Server/ADT/Shadekin/ShadekinSystem.cs
+++ b/Content.Server/ADT/Shadekin/ShadekinSystem.cs
@@ -153,7 +153,7 @@ public sealed partial class ShadekinSystem : EntitySystem
         var coordsValid = false;
         EntityCoordinates coords = Transform(uid).Coordinates;
 
-        if (TryComp<PullableComponent>(uid, out var pullable) && pullable.BeingPulled)
+        if (TryComp<PullableComponent>(uid, out var mainEntityPullable) && mainEntityPullable.BeingPulled)
         {
             comp.MaxedPowerAccumulator = 0f;
             return;
@@ -165,7 +165,7 @@ public sealed partial class ShadekinSystem : EntitySystem
             if (_interaction.InRangeUnobstructed(uid, newCoords, -1f))
             {
                 TryUseAbility(uid, 40, false);
-                if (TryComp<PullerComponent>(uid, out var puller) && puller.Pulling != null && pullable != null)
+                if (TryComp<PullerComponent>(uid, out var puller) && puller.Pulling != null && TryComp<PullableComponent>(puller.Pulling, out var pullable))
                     _pulling.TryStopPull(puller.Pulling.Value, pullable);
                 _alert.ShowAlert(uid, _proto.Index<AlertPrototype>("ShadekinPower"), (short) Math.Clamp(Math.Round(comp.PowerLevel / 50f), 0, 4));
                 _transform.SetCoordinates(uid, newCoords);


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->
Не буду повторяться, это баг и надо было как-то его пофиксить. Я принял решение простейшее - не предпринимать проверку, обнуляя энергию.

**Ссылка на публикацию в Discord**
<!-- Укажите ссылки на соответствующие обсуждения, проблемы, баги, заказы в разработку или предложения 

Если ссылки отсутствуют или этот PR ваша личная инициатива, данный раздел описания можно удалить. -->
- [Баги](https://discord.com/channels/901772674865455115/1283294949328294022)


**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт. -->

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [ ] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят.

В журнал изменений следует помещать только то, что действительно важно игрокам.

В списке изменений тип значка не является часть предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров

Вы можете указать своё имя после символа :cl: именно оно будет отображаться в журнале изменений (иначе будет использоваться ваше имя на GitHub)
Например: :cl: Ian

-->

:cl:
- tweak: Теперь при попытке непроизвольной телепортации сумеречник не сможет это сделать, если его держат.
