### PR TITLE
мелкий QoL патч

### DIFF
--- a/Resources/Locale/ru-RU/ADT/Preferences/loadout-groups.ftl
+++ b/Resources/Locale/ru-RU/ADT/Preferences/loadout-groups.ftl
@@ -17,6 +17,7 @@ loadout-group-blueshield-back = ОСЩ, рюкзак
 # Engineering
 loadout-group-atmospheric-technician-neck = Атмосферный техник, плащ
 loadout-group-atmospheric-technician-gasmask = Атмосферный техник, противогаз
+loadout-group-atmospheric-technician-head = Атмосферный техник, голова
 # Science
 loadout-group-roboticist-jumpsuit = Робототехник, комбинезон
 loadout-group-roboticist-outerclothing = Робототехник, верхняя одежда

--- a/Resources/Prototypes/ADT/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Jobs/Civilian/janitor.yml
@@ -31,7 +31,7 @@
   - !type:GroupLoadoutEffect
     proto: ADTJanitorialMaidDress50hours
   equipment:
-    jumpsuit: ClothingUniformJumpskirtJanimaid
+    jumpsuit: ADTClothingUniformJumpskirtJanimaid
 
 - type: loadout
   id: ADTJanitorJumpsuitJanimaidmini

--- a/Resources/Prototypes/ADT/Loadouts/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Jobs/Command/head_of_personnel.yml
@@ -48,3 +48,13 @@
   effects:
   - !type:GroupLoadoutEffect
     proto: ProfessionalHoP
+
+#Head
+
+- type: loadout
+  id: ADTHatBeretHOP
+  equipment:
+    head: ADTClothingHeadHatsBeretHOP
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: ProfessionalHoP

--- a/Resources/Prototypes/ADT/Loadouts/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Jobs/Engineering/atmospheric_technician.yml
@@ -34,3 +34,9 @@
   effects:
   - !type:GroupLoadoutEffect
     proto: ADTMasterAtmos
+
+# Head
+- type: loadout
+  id: ADTHatBeretAtmos
+  equipment:
+    head: ADTClothingHeadHatsBeretAtmos

--- a/Resources/Prototypes/ADT/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/ADT/Loadouts/loadout_groups.yml
@@ -206,7 +206,7 @@
   loadouts:
   - ADTSecurityCadetNeck
 
-#Плащ и маска атмосианина
+#Плащ, берет и маска атмосианина
 
 - type: loadoutGroup
   id: ADTAtmosphericTechnicianNeck
@@ -219,3 +219,9 @@
   name: loadout-group-atmospheric-technician-gasmask
   loadouts:
   - ADTMaskGasAtmosian
+
+- type: loadoutGroup
+  id: ADTAtmosphericTechnicianHead
+  name: loadout-group-atmospheric-technician-head
+  loadouts:
+  - ADTHatBeretAtmos

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -159,8 +159,8 @@
     parent: true
     components:
     - type: Stealth
-      minVisibility: 0.03 #ADT_Tweak
-      lastVisibility: 0.03 #ADT_Tweak
+      minVisibility: -0.4 #ADT_Tweak
+      lastVisibility: -0.4 #ADT_Tweak
   - type: PowerCellDraw
     drawRate: 1.8 # 200 seconds on the default cell
   - type: ToggleCellDraw

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -136,6 +136,9 @@
   minLimit: 0
   loadouts:
   - HoPHead
+  # ADT-Loadouts-Start
+  - ADTHatBeretHOP
+  # ADT-Loadouts-End
 
 - type: loadoutGroup
   id: HoPJumpsuit

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -298,11 +298,12 @@
   groups:
   - Inventory # Corvax-Loadouts
   - GroupTankHarness
+  - ADTAtmosphericTechnicianHead # ADT-Loadouts
+  - ADTAtmosphericTechnicianNeck # ADT-Loadouts
+  - ADTAtmosphericTechnicianGasMask # ADT-Loadouts
   - AtmosphericTechnicianJumpsuit
   - AtmosphericTechnicianBackpack
   - AtmosphericTechnicianOuterClothing
-  - ADTAtmosphericTechnicianNeck # ADT-Loadouts
-  - ADTAtmosphericTechnicianGasMask # ADT-Loadouts
   - AtmosphericTechnicianShoes
   - SurvivalExtended
   - Trinkets


### PR DESCRIPTION
## Описание PR
Добавил в лодауты атмос-техника и ГП их береты
Апнул стелс у ниндзи - дымку еще меньше видно

## Почему / Баланс
Береты - потому что раньше были в шкафчиках

Ап стелса - чтобы по мете меньше ниндзю гоняли

:cl:
- add: Добавлены береты в лодауты ниндзи и главы персонала
- tweak: Изменен костюм горничной в лодауте уборщика на наш
- tweak: Улучшен стелс костюма ниндзи