### PR TITLE
[ERT-QoL] Пинпоинтеры для ОБР

### DIFF
--- a/Resources/Prototypes/ADT/Roles/Jobs/Fun/emergenctresponceteam.yml
+++ b/Resources/Prototypes/ADT/Roles/Jobs/Fun/emergenctresponceteam.yml
@@ -18,6 +18,7 @@
     - BoxSurvivalEngineering
     - BoxZiptie
     - CrowbarRed
+    - PinpointerNuclear
 
 - type: startingGear
   id: ADTERTLeaderGearEVA
@@ -40,6 +41,7 @@
     - BoxSurvivalEngineering
     - BoxZiptie
     - CrowbarRed
+    - PinpointerNuclear
 
 - type: job
   id: ERTLeader
@@ -76,6 +78,7 @@
     - BoxSurvivalEngineering
     - BoxZiptie
     - CrowbarRed
+    - PinpointerNuclear
 
 #engie
 
@@ -108,6 +111,7 @@
     - SheetSteel
     - SheetGlass
     - GasAnalyzer
+    - PinpointerNuclear
 
 - type: startingGear
   id: ADTERTEngineerGearEVA
@@ -139,6 +143,7 @@
     - SheetSteel
     - SheetGlass
     - GasAnalyzer
+    - PinpointerNuclear
 
 - type: job
   id: ERTEngineer
@@ -184,6 +189,7 @@
     - SheetSteel
     - SheetGlass
     - GasAnalyzer
+    - PinpointerNuclear
 
 # Security
 
@@ -207,6 +213,7 @@
     - BoxSurvivalEngineering
     - BoxZiptie
     - CrowbarRed
+    - PinpointerNuclear
 
 - type: startingGear
   id: ADTERTSecurityGearEVA
@@ -229,6 +236,7 @@
     - BoxSurvivalEngineering
     - BoxZiptie
     - CrowbarRed
+    - PinpointerNuclear
 
 - type: job
   id: ERTSecurity
@@ -267,6 +275,7 @@
     - BoxSurvivalEngineering
     - BoxZiptie
     - CrowbarRed
+    - PinpointerNuclear
 
 
 # Medical
@@ -295,6 +304,7 @@
     - OmnizineChemistryBottle
     - EpinephrineChemistryBottle
     - EpinephrineChemistryBottle
+    - PinpointerNuclear
 
 - type: startingGear
   id: ADTERTMedicalGearEVA
@@ -321,6 +331,7 @@
     - OmnizineChemistryBottle
     - EpinephrineChemistryBottle
     - EpinephrineChemistryBottle
+    - PinpointerNuclear
 
 - type: job
   id: ERTMedical
@@ -361,6 +372,7 @@
     - OmnizineChemistryBottle
     - EpinephrineChemistryBottle
     - EpinephrineChemistryBottle
+    - PinpointerNuclear
 
 #Janitor
 
@@ -387,6 +399,7 @@
     - Soap
     - CrowbarRed
     - AdvMopItem
+    - PinpointerNuclear
 
 - type: startingGear
   id: ADTERTJanitorGearEVA
@@ -412,6 +425,7 @@
     - Soap
     - CrowbarRed
     - AdvMopItem
+    - PinpointerNuclear
 
 - type: job
   id: ERTJanitor
@@ -451,3 +465,4 @@
     - Soap
     - CrowbarRed
     - AdvMopItem
+    - PinpointerNuclear


### PR DESCRIPTION
## Описание PR
Были добавлены пинпоинтеры всем ОБРовцам. Базовому, RIOT, ЯО.

## Почему / Баланс

Потому что ОБР без Пинпоинтера - кринж. Как им искать диск или кэпа?

**Ссылка на публикацию в Discord:**
- [Заказы-разработка](https://discord.com/channels/901772674865455115/1284599810653028465)

## Техническая информация
Отсутствует. Одну и ту же строчку добавил в YAMLиках.

## Медиа
![image](https://github.com/user-attachments/assets/862e16ed-5157-4558-8138-04386105c5db)


## Требования
<!--
В связи с наплывом ПР'ов нам необходимо убедиться, что ПР'ы следуют правильным рекомендациям.

Пожалуйста, уделите время прочтению, если делаете пулл реквест (ПР) впервые.

Отметьте поля ниже, чтобы подтвердить, что Вы действительно видели их (поставьте X в скобках, например [X]):
-->
- [x] Я прочитал(а) и следую [Руководство по созданию пулл реквестов](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). Я понимаю, что в противном случае мой ПР может быть закрыт по усмотрению мейнтейнера.
- [x] Я добавил скриншоты/видео к этому пулл реквесту, демонстрирующие его изменения в игре, **или** этот пулл реквест не требует демонстрации в игре

## Критические изменения
<!--
Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей, переименования прототипов, и предоставьте инструкции по их исправлению.
-->

**Чейнджлог**
:cl: eddiemercury
- add: Руководство NanoTrasen вспомнило, что ОБР без пинпоинтера - как дварф без пива. В базовое снаряжение всех ОБРовцев, включая Базовых и RIOT, включены пинпоинтеры.
