### PR TITLE
уменьшаем веселье

### DIFF
--- a/Content.Server/StationEvents/Components/BasicStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/BasicStationEventSchedulerComponent.cs
@@ -17,7 +17,7 @@ public sealed partial class BasicStationEventSchedulerComponent : Component
     /// The minimum and maximum time between rule starts in seconds.
     /// </summary>
     [DataField]
-    public MinMax MinMaxEventTiming = new(3 * 60, 10 * 60);
+    public MinMax MinMaxEventTiming = new(6 * 60, 15 * 60); /// ADT-Tweak - 3 * 60 >>> 6 * 60 и 10 * 60 >>> 15 * 60 - тестируем уменьшение частоты событий
 
     /// <summary>
     /// How long until the next check for an event runs, is initially set based on MinimumTimeUntilFirstEvent & MinMaxEventTiming.

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,11 +1,10 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.19
-    Traitor: 0.40
+    Nukeops: 0.24
+    Traitor: 0.45
     Zombie: 0
     Zombieteors: 0
-    Survival: 0.1
     Revolutionary: 0.1
     KesslerSyndrome: 0.01
     Heretic: 0.20


### PR DESCRIPTION
## Описание PR
Убрал выживач из шансов в секрете, повысил значение минимального и максимального времени между событиями

## Почему / Баланс
Жалуются что на станции слишком много бардака

:cl:
- tweak: Совершена злостная попытка уменьшить частоту событий на станции
