### PR TITLE
пытаемси забороть спам шаттлами

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -163,7 +163,7 @@
     weight: 6.5
     earliestStart: 40
     reoccurrenceDelay: 20
-    minimumPlayers: 20
+    minimumPlayers: 30 #ADT-Tweak 20 >>> 30
     duration: null
   - type: SpaceSpawnRule
     spawnDistance: 0
@@ -471,7 +471,7 @@
   - type: StationEvent
     earliestStart: 35
     weight: 5.5
-    minimumPlayers: 20
+    minimumPlayers: 30 #ADT-Tweak 20 >>> 30
     duration: 1
   - type: RuleGrids
   - type: LoadMapRule

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -320,7 +320,7 @@
   - type: BasicStationEventScheduler
     minimumTimeUntilFirstEvent: 2700 # 45 mins #shows up like half way through shift.
     minMaxEventTiming:
-      min: 1200 # 20 mins
+      min: 3600 # ADT_Tweak 20 >> 60 min
       max: 7200 # 120 mins # you probably arent getting a second visitor shuttle in one round, but it is possible.
     scheduledGameRules: !type:NestedSelector
       tableId: SpaceTrafficControlTable
@@ -332,8 +332,8 @@
   - type: BasicStationEventScheduler
     minimumTimeUntilFirstEvent: 1200 # 20 mins
     minMaxEventTiming:
-      min: 600 # 10 mins
-      max: 1800 # 30 mins
+      min: 3600 # ADT_Tweak 10 >> 60 min
+      max: 7200 # ADT_Tweak 10 >> 120 min
     scheduledGameRules: !type:NestedSelector
       tableId: UnknownShuttlesFriendlyTable
 


### PR DESCRIPTION
## Описание PR
Увеличил время между спавнами шаттлов с гостролями и увеличил минимальное число игроков для лон опса и дракона

## Почему / Баланс
Лон Опс и Дракон для 20 лиц на сервере - смэрт

А шаттлов с гостролями со старта гадит нереально много

:cl:
- tweak: Изменено минимальное число игроков для события дракона и одиночного оперативника до 30
- tweak: Увеличен интервал между спавнами шаттлов с гостролями
