### PR TITLE
Отключение из пулла Аллеи.

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -36,4 +36,4 @@
   - ADT_Gemini
   - ADT_Aspid
   - ADT_Moose
-  - ADT_Alley
+  # - ADT_Alley до ремонта


### PR DESCRIPTION
## Описание PR
Отключение Аллеи

## Почему / Баланс
Карта не готова. Абсолютно. В атмосе нет переносных скрубберов, в коридорах нет воздушной сигнализации, пожарной тревоги. В случае утечки или разгерметизации пожарные шлюзы не будут закрываться, ведь тревогу НИЧЕГО не включает. Карта не готова быть полноценно игровой


Отметьте поля ниже, чтобы подтвердить, что Вы действительно видели их (поставьте X в скобках, например [X]):
-->
- [x] Я прочитал(а) и следую [Руководство по созданию пулл реквестов](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). Я понимаю, что в противном случае мой ПР может быть закрыт по усмотрению мейнтейнера.
- [x] Я добавил скриншоты/видео к этому пулл реквесту, демонстрирующие его изменения в игре, **или** этот пулл реквест не требует демонстрации в игре


**Чейнджлог**
:cl:
- tweak: Аллея временно выведена из пулла карт, до переработки. 