### PR TITLE
Дайте уже loadout-у бригмедикa жить 

### DIFF
--- a/Resources/Prototypes/ADT/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/ADT/Loadouts/role_loadouts.yml
@@ -118,7 +118,7 @@
 
   # brigmedic
 - type: roleLoadout
-  id: job-name-brigmedic
+  id: JobBrigmedic
   groups:
   - Inventory # Corvax-Loadouts
   - GroupTankHarness


### PR DESCRIPTION
О боже больше без тупых правок

## Описание PR
<!-- Что вы изменили в этом пулл реквесте? -->
role_loadouts - id бригмедика

## Почему / Баланс
тупая правка на изменение имени loadout не дает работать loadout бригмедика, с этим изменением все работает 
(проверялось на локалке)
![Screenshot_25](https://github.com/user-attachments/assets/ad605116-c032-47d6-bf8a-0667f379b576)

no cl, no fun
