### PR TITLE
Ревенант больше не заваривает шлюзы, а болтирует их

### DIFF
--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
@@ -435,14 +435,30 @@ public sealed partial class RevenantSystem
             return;
 
         args.Handled = true;
+        /* Revenant tweak
 
+                foreach (var ent in _lookup.GetEntitiesInRange(uid, component.LockRadius))
+                {
+                    if (!TryComp<DoorComponent>(ent, out var door))
+                        continue;
+                    if (door.State == DoorState.Closed)
+                        _weld.SetWeldedState(ent, true);
+                    _audio.PlayPvs(component.LockSound, ent);
+                }
+            }
+
+        */
         foreach (var ent in _lookup.GetEntitiesInRange(uid, component.LockRadius))
         {
             if (!TryComp<DoorComponent>(ent, out var door))
                 continue;
-            if (door.State == DoorState.Closed)
-                _weld.SetWeldedState(ent, true);
-            _audio.PlayPvs(component.LockSound, ent);
+            if (!TryComp<DoorBoltComponent>(ent, out var boltsComp))
+                continue;
+            if (!boltsComp.BoltWireCut && door.State == DoorState.Closed && !boltsComp.BoltsDown)
+            {
+                _door.SetBoltsDown((ent, boltsComp), true, uid);
+                _audio.PlayPvs(component.LockSound, ent);
+            }
         }
     }
     // ADT Revenant abilities end


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл реквесте? -->
Ревенант больше не заваривает шлюзы, а болтирует их
## Почему / Баланс
<!-- Почему оно было изменено? Ссылайтесь на любые обсуждения или вопросы здесь. Пожалуйста, обсудите, как это повлияет на игровой баланс. -->
Потому

## Требования
<!--
В связи с наплывом ПР'ов нам необходимо убедиться, что ПР'ы следуют правильным рекомендациям.

Пожалуйста, уделите время прочтению, если делаете пулл реквест (ПР) впервые.

Отметьте поля ниже, чтобы подтвердить, что Вы действительно видели их (поставьте X в скобках, например [X]):
-->
- [х] Я прочитал(а) и следую [Руководство по созданию пулл реквестов](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). Я понимаю, что в противном случае мой ПР может быть закрыт по усмотрению мейнтейнера.
- [х] Я добавил скриншоты/видео к этому пулл реквесту, демонстрирующие его изменения в игре, **или** этот пулл реквест не требует демонстрации в игре

**Чейнджлог**
<!--
Здесь Вы можете заполнить журнал изменений, который будет автоматически добавлен в игру при мердже Вашего пулл реквест.

Чтобы игроки узнали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в журнал изменений.

Не считайте суффикс типа записи (например, add) "частью" предложения:
плохо: - add: новый инструмент для инженеров
хорошо: - add: добавлен новый инструмент для инженеров

Помещение имени после символа :cl: изменит имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub).
Например: :cl: AruMoon
-->
:cl: Inconnu
- tweak: теперь ревенант болтирует шлюзы вместо заваривания