### PR TITLE
Изменения требования для пиков карт

### DIFF
--- a/Resources/Prototypes/ADT/Maps/ADTMaps/adt_alley.yml
+++ b/Resources/Prototypes/ADT/Maps/ADTMaps/adt_alley.yml
@@ -4,7 +4,7 @@
   mapPath: /Maps/ADTMaps/ADTStations/adt_alley.yml
   maxRandomOffset: 0
   randomRotation: false
-  minPlayers: 30
+  minPlayers: 60
   stations:
     ADT_Alley:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/ADT/Maps/ADTMaps/adt_astra.yml
+++ b/Resources/Prototypes/ADT/Maps/ADTMaps/adt_astra.yml
@@ -4,7 +4,7 @@
   mapPath: /Maps/ADTMaps/ADTStations/adt_astra.yml
   maxRandomOffset: 0
   randomRotation: false
-  minPlayers: 30
+  minPlayers: 50
   stations:
     ADT_Astra:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/ADT/Maps/ADTMaps/adt_avrite.yml
+++ b/Resources/Prototypes/ADT/Maps/ADTMaps/adt_avrite.yml
@@ -4,7 +4,7 @@
   mapPath: /Maps/ADTMaps/ADTStations/adt_avrite.yml
   maxRandomOffset: 0
   randomRotation: false
-  minPlayers: 30
+  minPlayers: 60
   stations:
     ADT_Avrit:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/ADT/Maps/ADTMaps/adt_box.yml
+++ b/Resources/Prototypes/ADT/Maps/ADTMaps/adt_box.yml
@@ -2,7 +2,7 @@
   id: ADT_Box
   mapName: 'Box Station'
   mapPath: /Maps/ADTMaps/ADTStations/adt_box.yml
-  minPlayers: 20
+  minPlayers: 30
   stations:
     ADT_Boxstation:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/ADT/Maps/ADTMaps/adt_core.yml
+++ b/Resources/Prototypes/ADT/Maps/ADTMaps/adt_core.yml
@@ -2,7 +2,7 @@
   id: ADT_Core
   mapName: 'Core'
   mapPath: /Maps/ADTMaps/ADTStations/adt_core.yml
-  minPlayers: 20
+  minPlayers: 25
   maxPlayers: 80
   stations:
     ADT_Core:

--- a/Resources/Prototypes/ADT/Maps/ADTMaps/adt_delta.yml
+++ b/Resources/Prototypes/ADT/Maps/ADTMaps/adt_delta.yml
@@ -4,7 +4,7 @@
   mapPath: /Maps/ADTMaps/ADTStations/adt_delta.yml
   maxRandomOffset: 0
   randomRotation: false
-  minPlayers: 40
+  minPlayers: 55
   stations:
     Delta:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/ADT/Maps/ADTMaps/adt_fland.yml
+++ b/Resources/Prototypes/ADT/Maps/ADTMaps/adt_fland.yml
@@ -2,7 +2,7 @@
   id: ADT_Fland
   mapName: 'Fland Installation'
   mapPath: /Maps/ADTMaps/ADTStations/adt_fland.yml
-  minPlayers: 25
+  minPlayers: 35
   stations:
     ADT_Fland:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/ADT/Maps/ADTMaps/adt_gemini.yml
+++ b/Resources/Prototypes/ADT/Maps/ADTMaps/adt_gemini.yml
@@ -4,7 +4,7 @@
   mapPath: /Maps/ADTMaps/ADTStations/adt_gemini.yml
   maxRandomOffset: 0
   randomRotation: false
-  minPlayers: 20
+  minPlayers: 25
   stations:
     Gemini:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/ADT/Maps/ADTMaps/adt_kilo.yml
+++ b/Resources/Prototypes/ADT/Maps/ADTMaps/adt_kilo.yml
@@ -2,7 +2,7 @@
   id: ADT_kilo
   mapName: 'kilostation'
   mapPath: /Maps/ADTMaps/ADTStations/adt_kilostation.yml
-  minPlayers: 10
+  minPlayers: 30
   maxPlayers: 80
   stations:
     ADT_kilo:

--- a/Resources/Prototypes/ADT/Maps/ADTMaps/adt_kilo.yml
+++ b/Resources/Prototypes/ADT/Maps/ADTMaps/adt_kilo.yml
@@ -2,7 +2,7 @@
   id: ADT_kilo
   mapName: 'kilostation'
   mapPath: /Maps/ADTMaps/ADTStations/adt_kilostation.yml
-  minPlayers: 30
+  minPlayers: 10
   maxPlayers: 80
   stations:
     ADT_kilo:

--- a/Resources/Prototypes/ADT/Maps/ADTMaps/adt_meta.yml
+++ b/Resources/Prototypes/ADT/Maps/ADTMaps/adt_meta.yml
@@ -2,7 +2,8 @@
   id: ADT_Meta
   mapName: 'Meta Station'
   mapPath: /Maps/ADTMaps/ADTStations/adt_meta.yml
-  minPlayers: 10
+  minPlayers: 30
+  maxPlayers: 80
   stations:
     ADT_Meta:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/ADT/Maps/ADTMaps/adt_meta.yml
+++ b/Resources/Prototypes/ADT/Maps/ADTMaps/adt_meta.yml
@@ -2,7 +2,7 @@
   id: ADT_Meta
   mapName: 'Meta Station'
   mapPath: /Maps/ADTMaps/ADTStations/adt_meta.yml
-  minPlayers: 30
+  minPlayers: 10
   maxPlayers: 80
   stations:
     ADT_Meta:

--- a/Resources/Prototypes/ADT/Maps/ADTMaps/adt_oasis.yml
+++ b/Resources/Prototypes/ADT/Maps/ADTMaps/adt_oasis.yml
@@ -2,7 +2,7 @@
   id: ADT_Oasis
   mapName: 'Oasis'
   mapPath: /Maps/ADTMaps/ADTStations/adt_oasis.yml
-  minPlayers: 25
+  minPlayers: 45
   stations:
     ADT_Oasis:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/ADT/Maps/ADTMaps/adt_oasis.yml
+++ b/Resources/Prototypes/ADT/Maps/ADTMaps/adt_oasis.yml
@@ -2,7 +2,7 @@
   id: ADT_Oasis
   mapName: 'Oasis'
   mapPath: /Maps/ADTMaps/ADTStations/adt_oasis.yml
-  minPlayers: 45
+  minPlayers: 40
   stations:
     ADT_Oasis:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
:cl: Filo
- tweak: Alley теперь требует 60 игроков для выбора карты
- tweak: Astra теперь требует 50 игроков для выбора карты
- tweak: Avrite теперь требует 60 игроков для выбора карты
- tweak: Box теперь требует 30 игроков для выбора карты
- tweak: Core теперь требует 25 игроков для выбора карты
- tweak: Delta теперь требует 55 игроков для выбора карты
- tweak: Gemini Теперь требует 25 игроков для выбора карты
- tweak: Fland Теперь требует 35 игроков для выбора карты
- tweak: Oasis Теперь требует 40 игроков для выбора карты