### PR TITLE
Фикс ревенанта, небольшой ребаланс

### DIFF
--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
@@ -43,6 +43,7 @@ using Robust.Shared.Map.Components;
 using Content.Shared.Whitelist;
 using Content.Shared.ADT.Silicon.Components;
 using Content.Shared.Stunnable;
+using Content.Server.Power.Components; // ADT-Revenant-Tweak
 
 namespace Content.Server.Revenant.EntitySystems;
 
@@ -61,7 +62,7 @@ public sealed partial class RevenantSystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly SharedDoorSystem _door = default!;
-    [Dependency] private readonly WeldableSystem _weld = default!;
+//    [Dependency] private readonly WeldableSystem _weld = default!;     ADT-Revenant-Tweak
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
 
@@ -454,7 +455,9 @@ public sealed partial class RevenantSystem
                 continue;
             if (!TryComp<DoorBoltComponent>(ent, out var boltsComp))
                 continue;
-            if (!boltsComp.BoltWireCut && door.State == DoorState.Closed && !boltsComp.BoltsDown)
+            if (!TryComp<ApcPowerReceiverComponent>(ent, out var powerComp))
+                continue;
+            if (!boltsComp.BoltWireCut && door.State == DoorState.Closed && !boltsComp.BoltsDown && powerComp.Powered)
             {
                 _door.SetBoltsDown((ent, boltsComp), true, uid);
                 _audio.PlayPvs(component.LockSound, ent);

--- a/Content.Shared/Revenant/Components/RevenantComponent.cs
+++ b/Content.Shared/Revenant/Components/RevenantComponent.cs
@@ -232,7 +232,7 @@ public sealed partial class RevenantComponent : Component
     /// The amount of essence that is needed to use the ability.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("hysteriaCost")]
-    public FixedPoint2 HysteriaCost = -60;
+    public FixedPoint2 HysteriaCost = 60;
 
     /// <summary>
     /// The status effects applied after the ability
@@ -316,7 +316,7 @@ public sealed partial class RevenantComponent : Component
     /// The amount of essence that is needed to use the ability.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("lockCost")]
-    public FixedPoint2 LockCost = -50;
+    public FixedPoint2 LockCost = 50;
 
     /// <summary>
     /// The status effects applied after the ability

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1546,7 +1546,7 @@
   icon: { sprite: /Textures/Clothing/OuterClothing/Armor/syndie-raid.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateRaidBundle
   cost:
-    Telecrystal: 12 # ADT-Tweak 8>13
+    Telecrystal: 8 # ADT-Tweak
   categories:
   - UplinkWearables
   conditions:

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -386,7 +386,6 @@
         Slash: 0.85
         Piercing: 0.85
         Heat: 0.85
-    staminaModifier: 0.3  # ADT-Tweak
 
 #Bone Helmet
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -30,6 +30,12 @@
           Slash: 1
           Piercing: 1
           Heat: 1
+      # ADT-Tweak-Start
+    - type: ClothingSpeedModifier
+      walkModifier: 0.8
+      sprintModifier: 0.7
+    - type: HeldSpeedModifier
+      # ADT-Tweak-End
     - type: Damageable
       damageContainer: Shield
     - type: Destructible
@@ -451,6 +457,11 @@
         flatReductions:
           Heat: 1
           Piercing: 1
+      # ADT-Tweak-Start
+    - type: ClothingSpeedModifier
+      walkModifier: 1
+      sprintModifier: 1
+      # ADT-Tweak-End
     - type: Appearance
     - type: Damageable
       damageContainer: Shield

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -244,10 +244,12 @@
     boltClosed: null
   - type: Gun
     fireRate: 5.5
-    minAngle: 1
-    maxAngle: 6
-    angleIncrease: 1.5
-    angleDecay: 6
+    # ADT-Tweak-Start
+    minAngle: 10
+    maxAngle: 30
+    angleIncrease: 4.0
+    angleDecay: 14
+    # ADT-Tweak-End
     selectedMode: FullAuto
     shotsPerBurst: 5
     availableModes:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -244,12 +244,10 @@
     boltClosed: null
   - type: Gun
     fireRate: 5.5
-    # ADT-Tweak-Start
-    minAngle: 10
-    maxAngle: 30
-    angleIncrease: 4.0
-    angleDecay: 14
-    # ADT-Tweak-End
+    minAngle: 1
+    maxAngle: 6
+    angleIncrease: 1.5
+    angleDecay: 6
     selectedMode: FullAuto
     shotsPerBurst: 5
     availableModes:


### PR DESCRIPTION
## Почему / Баланс
нерф щитов а то пипяо
## Требования
<!--
В связи с наплывом ПР'ов нам необходимо убедиться, что ПР'ы следуют правильным рекомендациям.

Пожалуйста, уделите время прочтению, если делаете пулл реквест (ПР) впервые.

Отметьте поля ниже, чтобы подтвердить, что Вы действительно видели их (поставьте X в скобках, например [X]):
-->
- [x] Я прочитал(а) и следую [Руководство по созданию пулл реквестов](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). Я понимаю, что в противном случае мой ПР может быть закрыт по усмотрению мейнтейнера.
- [x] Я добавил скриншоты/видео к этому пулл реквесту, демонстрирующие его изменения в игре, **или** этот пулл реквест не требует демонстрации в игре

**Чейнджлог**
<!--
Здесь Вы можете заполнить журнал изменений, который будет автоматически добавлен в игру при мердже Вашего пулл реквест.

Чтобы игроки узнали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в журнал изменений.

Не считайте суффикс типа записи (например, add) "частью" предложения:
плохо: - add: новый инструмент для инженеров
хорошо: - add: добавлен новый инструмент для инженеров

Помещение имени после символа :cl: изменит имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub).
Например: :cl: AruMoon
-->

:cl:
- add: Добавлено замедление щитам
- tweak: Снижена цена рейдерской брони с 12 до 8 ТК
- fix: Исправлен баг, который позволял ревенанту отожрать пузо и болтировать обесточенные шлюзы 
