### PR TITLE
[FIX][ХЕЛЛОУИН] Хеллоуинский баллон можно на спину + фикс

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Clothing/Uniforms/Jumpsuits.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/Uniforms/Jumpsuits.yml
@@ -1135,7 +1135,7 @@
     sprite: ADT/Clothing/Uniforms/Jumpsuit/bad_police.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, AllowSuitStorageClothing]
+  parent: ClothingUniformBase
   id: ADTHalloweenLethalCompanySuit
   name: Lethal Company suit
   description: Lethal Company suit

--- a/Resources/Prototypes/ADT/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Tools/gas_tanks.yml
@@ -15,6 +15,9 @@
       temperature: 293.15
   - type: Clothing
     sprite: ADT/Objects/Tanks/lethal_company_tanks.rsi
+    quickEquip: false
+    slots:
+    - back
   - type: MeleeWeapon
     attackRate: 0.9
     damage:
@@ -34,3 +37,6 @@
     sprite: ADT/Objects/Tanks/lethal_company_tanks.rsi
   - type: Clothing
     sprite: ADT/Objects/Tanks/lethal_company_tanks.rsi
+    quickEquip: false
+    slots:
+    - back


### PR DESCRIPTION
## Описание PR
Баллон из леталки теперь можно надеть на спину без скафа или броника

## Почему / Баланс
-

**Ссылка на публикацию в Discord**
-

## Техническая информация
-

## Медиа
-

## Требования
- [ ] Я прочитал(а) и следую [Руководство по созданию пулл реквестов](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). Я понимаю, что в противном случае мой ПР может быть закрыт по усмотрению мейнтейнера.
- [ ] Я добавил скриншоты/видео к этому пулл реквесту, демонстрирующие его изменения в игре, **или** этот пулл реквест не требует демонстрации в игре

## Критические изменения
-

**Чейнджлог**
- fix: Теперь баллон из леталки можно надеть на спину