### PR TITLE
UI Бриг-Таймера

### DIFF
--- a/Content.Client/MachineLinking/UI/SignalTimerWindow.xaml
+++ b/Content.Client/MachineLinking/UI/SignalTimerWindow.xaml
@@ -1,16 +1,20 @@
 <DefaultWindow xmlns="https://spacestation14.io"
             Title="{Loc signal-timer-menu-title}">
-    <BoxContainer Orientation="Vertical" SeparationOverride="4" MinWidth="150">
+    <BoxContainer Orientation="Vertical" SeparationOverride="8" MinWidth="260">
         <BoxContainer Name="TextEdit" Orientation="Horizontal">
             <Label Name="CurrentLabel" Text="{Loc signal-timer-menu-label}" />
-            <LineEdit Name="CurrentTextEdit" MinWidth="80" />
+            <LineEdit Name="CurrentTextEdit" MinWidth="360" />
         </BoxContainer>
+        <BoxContainer Name="TextEditAnother" Orientation="Horizontal"> <!-- ADT START -->
+            <Label Name="CurrentLabelAnother" Text="{Loc signal-timer-menu-label-another}" />
+            <LineEdit Name="CurrentTextEditAnother" MinWidth="260" />
+        </BoxContainer> <!-- ADT END -->
         <BoxContainer Name="DelayEdit" Orientation="Horizontal">
             <Label Name="CurrentDelay" Text="{Loc signal-timer-menu-delay}" />
             <LineEdit Name="CurrentDelayEditMinutes" MinWidth="32" />
             <Label Name="Colon" Text=":" />
             <LineEdit Name="CurrentDelayEditSeconds" MinWidth="32" />
-            <Label Name="DelayInfo" Text=" (mm:ss)" />
+            <Label Name="DelayInfo" Text=" (мин:сек)" />
         </BoxContainer>
         <Button Name="StartTimer" Text="{Loc signal-timer-menu-start}" />
     </BoxContainer>

--- a/Content.Client/MachineLinking/UI/SignalTimerWindow.xaml
+++ b/Content.Client/MachineLinking/UI/SignalTimerWindow.xaml
@@ -1,13 +1,13 @@
 <DefaultWindow xmlns="https://spacestation14.io"
             Title="{Loc signal-timer-menu-title}">
-    <BoxContainer Orientation="Vertical" SeparationOverride="8" MinWidth="260">
+    <BoxContainer Orientation="Vertical" SeparationOverride="8" MinWidth="260"> <!-- Некоторые фичи ADT для размера окна -->
         <BoxContainer Name="TextEdit" Orientation="Horizontal">
             <Label Name="CurrentLabel" Text="{Loc signal-timer-menu-label}" />
-            <LineEdit Name="CurrentTextEdit" MinWidth="360" />
+            <LineEdit Name="CurrentTextEdit" MinWidth="80" />
         </BoxContainer>
         <BoxContainer Name="TextEditAnother" Orientation="Horizontal"> <!-- ADT START -->
             <Label Name="CurrentLabelAnother" Text="{Loc signal-timer-menu-label-another}" />
-            <LineEdit Name="CurrentTextEditAnother" MinWidth="260" />
+            <LineEdit Name="CurrentTextEditAnother" MinWidth="240" />
         </BoxContainer> <!-- ADT END -->
         <BoxContainer Name="DelayEdit" Orientation="Horizontal">
             <Label Name="CurrentDelay" Text="{Loc signal-timer-menu-delay}" />

--- a/Content.Client/MachineLinking/UI/SignalTimerWindow.xaml
+++ b/Content.Client/MachineLinking/UI/SignalTimerWindow.xaml
@@ -14,7 +14,7 @@
             <LineEdit Name="CurrentDelayEditMinutes" MinWidth="32" />
             <Label Name="Colon" Text=":" />
             <LineEdit Name="CurrentDelayEditSeconds" MinWidth="32" />
-            <Label Name="DelayInfo" Text=" (мин:сек)" />
+            <Label Name="DelayInfo" Text="{Loc signal-timer-menu-min-sec-another}" /> <!--ADT Changes-->
         </BoxContainer>
         <Button Name="StartTimer" Text="{Loc signal-timer-menu-start}" />
     </BoxContainer>

--- a/Content.Client/MachineLinking/UI/SignalTimerWindow.xaml.cs
+++ b/Content.Client/MachineLinking/UI/SignalTimerWindow.xaml.cs
@@ -12,12 +12,12 @@ public sealed partial class SignalTimerWindow : DefaultWindow
 {
     [Dependency] private readonly IGameTiming _timing = default!;
 
-    private const int MaxTextLength = 5; // для объявлений нарушений куда больше ? ADT
-    private const int MaxTextLengthAnother = 19; // для заметок ADT TextEdit
+    private const int MaxTextLength = 5;
+    private const int MaxTextLengthAnother = 19; // ADT Статьи
     
 
-    public event Action<string>? OnCurrentTextChanged; // для номеров нарушений
-    public event Action<string>? OnCurrentTextChangedAnother; // остальной текст
+    public event Action<string>? OnCurrentTextChanged;
+    public event Action<string>? OnCurrentTextChangedAnother; // ADT остальной текст
     public event Action<string>? OnCurrentDelayMinutesChanged;
     public event Action<string>? OnCurrentDelaySecondsChanged;
 
@@ -81,7 +81,7 @@ public sealed partial class SignalTimerWindow : DefaultWindow
         OnCurrentTextChanged?.Invoke(text);
     }
 
-    public void OnCurrentTextChangeAnother(string text) //TextEdit
+    public void OnCurrentTextChangeAnother(string text) // ADT START
     {
         if (CurrentTextEditAnother.Text.Length > MaxTextLengthAnother)
         {
@@ -90,7 +90,7 @@ public sealed partial class SignalTimerWindow : DefaultWindow
         }
 
         OnCurrentTextChangedAnother?.Invoke(text);
-    }
+    } // ADT END
 
     public void OnCurrentDelayMinutesChange(string text)
     {

--- a/Content.Client/MachineLinking/UI/SignalTimerWindow.xaml.cs
+++ b/Content.Client/MachineLinking/UI/SignalTimerWindow.xaml.cs
@@ -12,9 +12,12 @@ public sealed partial class SignalTimerWindow : DefaultWindow
 {
     [Dependency] private readonly IGameTiming _timing = default!;
 
-    private const int MaxTextLength = 5;
+    private const int MaxTextLength = 5; // для объявлений нарушений куда больше ? ADT
+    private const int MaxTextLengthAnother = 19; // для заметок ADT TextEdit
+    
 
-    public event Action<string>? OnCurrentTextChanged;
+    public event Action<string>? OnCurrentTextChanged; // для номеров нарушений
+    public event Action<string>? OnCurrentTextChangedAnother; // остальной текст
     public event Action<string>? OnCurrentDelayMinutesChanged;
     public event Action<string>? OnCurrentDelaySecondsChanged;
 
@@ -30,6 +33,7 @@ public sealed partial class SignalTimerWindow : DefaultWindow
         IoCManager.InjectDependencies(this);
 
         CurrentTextEdit.OnTextChanged += e => OnCurrentTextChange(e.Text);
+        CurrentTextEditAnother.OnTextChanged += e => OnCurrentTextChangeAnother(e.Text); // ADT CurrentTextEdit
         CurrentDelayEditMinutes.OnTextChanged += e => OnCurrentDelayMinutesChange(e.Text);
         CurrentDelayEditSeconds.OnTextChanged += e => OnCurrentDelaySecondsChange(e.Text);
         StartTimer.OnPressed += _ => StartTimerWeh();
@@ -67,7 +71,7 @@ public sealed partial class SignalTimerWindow : DefaultWindow
         }
     }
 
-    public void OnCurrentTextChange(string text)
+    public void OnCurrentTextChange(string text) 
     {
         if (CurrentTextEdit.Text.Length > MaxTextLength)
         {
@@ -75,6 +79,17 @@ public sealed partial class SignalTimerWindow : DefaultWindow
             CurrentTextEdit.CursorPosition = MaxTextLength;
         }
         OnCurrentTextChanged?.Invoke(text);
+    }
+
+    public void OnCurrentTextChangeAnother(string text) //TextEdit
+    {
+        if (CurrentTextEditAnother.Text.Length > MaxTextLengthAnother)
+        {
+            CurrentTextEditAnother.Text = CurrentTextEditAnother.Text.Remove(MaxTextLengthAnother);
+            CurrentTextEditAnother.CursorPosition = MaxTextLengthAnother;
+        }
+
+        OnCurrentTextChangedAnother?.Invoke(text);
     }
 
     public void OnCurrentDelayMinutesChange(string text)

--- a/Resources/Locale/ru-RU/ADT/machine-linking/components/signal-timer-component.ftl
+++ b/Resources/Locale/ru-RU/ADT/machine-linking/components/signal-timer-component.ftl
@@ -1,0 +1,2 @@
+signal-timer-menu-label-another = Статьи:
+signal-timer-menu-min-sec-another = (мин:сек)

--- a/Resources/Locale/ru-RU/machine-linking/components/signal-timer-component.ftl
+++ b/Resources/Locale/ru-RU/machine-linking/components/signal-timer-component.ftl
@@ -2,6 +2,3 @@ signal-timer-menu-title = Таймер
 signal-timer-menu-label = Метка:
 signal-timer-menu-delay = Задержка:
 signal-timer-menu-start = Старт
-
-# ADT:
-signal-timer-menu-label-another = Статьи:

--- a/Resources/Locale/ru-RU/machine-linking/components/signal-timer-component.ftl
+++ b/Resources/Locale/ru-RU/machine-linking/components/signal-timer-component.ftl
@@ -2,3 +2,4 @@ signal-timer-menu-title = Таймер
 signal-timer-menu-label = Метка:
 signal-timer-menu-delay = Задержка:
 signal-timer-menu-start = Старт
+signal-timer-menu-label-another = Статьи:

--- a/Resources/Locale/ru-RU/machine-linking/components/signal-timer-component.ftl
+++ b/Resources/Locale/ru-RU/machine-linking/components/signal-timer-component.ftl
@@ -2,4 +2,6 @@ signal-timer-menu-title = Таймер
 signal-timer-menu-label = Метка:
 signal-timer-menu-delay = Задержка:
 signal-timer-menu-start = Старт
+
+# ADT:
 signal-timer-menu-label-another = Статьи:


### PR DESCRIPTION
## Описание PR
+ Добавлена новая строчка "Статьи:" 
+ перевод "(mm:ss)" в "(мин:сек)"
+ Изменено расширение окна на более широкую версию для удобства

## Почему / Баланс
Попросили uwu
https://discord.com/channels/901772674865455115/1302356853853786255

## Техническая информация
+ В комментариях кода будет объяснение

## Медиа
       
![Снимок экрана 2024-11-04 000751](https://github.com/user-attachments/assets/a99af922-8bf2-4746-a9ce-43ac89ac43c5)


## Требования
- [x] Я прочитал(а) и следую [Руководство по созданию пулл реквестов](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). Я понимаю, что в противном случае мой ПР может быть закрыт по усмотрению мейнтейнера.
- [x] Я добавил скриншоты/видео к этому пулл реквесту, демонстрирующие его изменения в игре, **или** этот пулл реквест не требует демонстрации в игре

**Чейнджлог**

:cl:Kasey [Adnoda] Bitboxxer
- add: Добавлено у Бриг-Таймера: строчка "Статьи:" 
- tweak: Изменен Бриг-Таймер: окно стало шире и изменено описание минут, секунд

