### PR TITLE
Удаление подкреплений у одинокого оперативника

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -127,6 +127,18 @@
   suffix: 60 TC, LoneOps
   components:
   - type: Store
+    name: store-preset-name-uplink #ADT-Tweak-start
+    categories:
+    - UplinkWeaponry
+    - UplinkAmmo
+    - UplinkExplosives
+    - UplinkChemicals
+    - UplinkDeception
+    - UplinkDisruption
+    - UplinkImplants
+    - UplinkWearables
+    - UplinkJob
+    - UplinkPointless #ADT-Tweak-end
     balance:
       Telecrystal: 60
   - type: Tag


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл реквесте? -->
Удалена ветка подкреплений у аплинка ОДИНОКОГО оперативника
## Почему / Баланс
Одинокий оперативник изначально был задуман как ОДИНОКИЙ оперативник. Не раз наблюдается ситуация, как ОДИНОКИЙ оперативник идет ТОЛПОЙ на штурм станции, имея в качестве поддержки либо борга, либо нескольких кентов. Так не должно быть.

## Требования
<!--
В связи с наплывом ПР'ов нам необходимо убедиться, что ПР'ы следуют правильным рекомендациям.

Пожалуйста, уделите время прочтению, если делаете пулл реквест (ПР) впервые.

Отметьте поля ниже, чтобы подтвердить, что Вы действительно видели их (поставьте X в скобках, например [X]):
-->
- [x] Я прочитал(а) и следую [Руководство по созданию пулл реквестов](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). Я понимаю, что в противном случае мой ПР может быть закрыт по усмотрению мейнтейнера.
- [x] Я добавил скриншоты/видео к этому пулл реквесту, демонстрирующие его изменения в игре, **или** этот пулл реквест не требует демонстрации в игре

**Чейнджлог**
<!--
Здесь Вы можете заполнить журнал изменений, который будет автоматически добавлен в игру при мердже Вашего пулл реквест.

Чтобы игроки узнали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в журнал изменений.

Не считайте суффикс типа записи (например, add) "частью" предложения:
плохо: - add: новый инструмент для инженеров
хорошо: - add: добавлен новый инструмент для инженеров

Помещение имени после символа :cl: изменит имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub).
Например: :cl: AruMoon
-->

:cl: Friskis
- tweak: У одинокого оперативника удалена ветка подкреплений в аплинке.

