### PR TITLE
Изменения офф кода для работы пульта удаленного управления шаттлами

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -171,11 +171,16 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
         if (!_tags.HasTag(user, "CanPilot") ||
             !TryComp<ShuttleConsoleComponent>(uid, out var component) ||
             !this.IsPowered(uid, EntityManager) ||
-            !Transform(uid).Anchored ||
+        //    !Transform(uid).Anchored || // ADT-TWEAK
             !_blocker.CanInteract(user, uid))
         {
             return false;
         }
+
+        // ADT-Tweak-Start
+        if (!component.IsHandheldConsole && !Transform(uid).Anchored)
+            return false;
+        // ADT-Tweak-End
 
         var pilotComponent = EnsureComp<PilotComponent>(user);
         var console = pilotComponent.Console;

--- a/Content.Shared/Shuttles/Components/SharedShuttleConsoleComponent.cs
+++ b/Content.Shared/Shuttles/Components/SharedShuttleConsoleComponent.cs
@@ -10,6 +10,12 @@ namespace Content.Shared.Shuttles.Components
     public abstract partial class SharedShuttleConsoleComponent : Component
     {
         public static string DiskSlotName = "disk_slot";
+
+        // ADT-TWEAK-START
+        [DataField("IsHandheldConsole")]
+        public bool IsHandheldConsole = false;
+        // ADT-TWEAK-END
+
     }
 
     [Serializable, NetSerializable]

--- a/Content.Shared/Shuttles/Components/SharedShuttleConsoleComponent.cs
+++ b/Content.Shared/Shuttles/Components/SharedShuttleConsoleComponent.cs
@@ -12,7 +12,7 @@ namespace Content.Shared.Shuttles.Components
         public static string DiskSlotName = "disk_slot";
 
         // ADT-TWEAK-START
-        [DataField("IsHandheldConsole")]
+        [DataField("isHandheldConsole")]
         public bool IsHandheldConsole = false;
         // ADT-TWEAK-END
 


### PR DESCRIPTION
## Описание
Добавлено новое поле "IsHandheldConsole" в ShuttleConsoleComponent установив значение True пульт будет работать
## Почему / Баланс
<!-- Почему оно было изменено? Ссылайтесь на любые обсуждения или вопросы здесь. Пожалуйста, обсудите, как это повлияет на игровой баланс. -->
Помощь Пётру

## Требования
<!--
В связи с наплывом ПР'ов нам необходимо убедиться, что ПР'ы следуют правильным рекомендациям.

Пожалуйста, уделите время прочтению, если делаете пулл реквест (ПР) впервые.

Отметьте поля ниже, чтобы подтвердить, что Вы действительно видели их (поставьте X в скобках, например [X]):
-->
- [x] Я прочитал(а) и следую [Руководство по созданию пулл реквестов](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). Я понимаю, что в противном случае мой ПР может быть закрыт по усмотрению мейнтейнера.
- [x] Я добавил скриншоты/видео к этому пулл реквесту, демонстрирующие его изменения в игре, **или** этот пулл реквест не требует демонстрации в игре

**Чейнджлог**
<!--
Здесь Вы можете заполнить журнал изменений, который будет автоматически добавлен в игру при мердже Вашего пулл реквест.

Чтобы игроки узнали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в журнал изменений.

Не считайте суффикс типа записи (например, add) "частью" предложения:
плохо: - add: новый инструмент для инженеров
хорошо: - add: добавлен новый инструмент для инженеров

Помещение имени после символа :cl: изменит имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub).
Например: :cl: AruMoon
-->

<!--
Чтобы шаблон Чейнджлога отображался, уберите его из блока комментариев. Чейнджлог должен содержать :cl: символ, чтобы бот распознал изменения и добавил их в журнал изменений игры.
:cl:
- add: Добавлено веселье!
- remove: Удалено веселье!
- tweak: Изменено веселье!
- fix: Исправлено веселье!
-->
no cl, no fun
