### PR TITLE
Убираем сокращение на эмоцию

### DIFF
--- a/Content.Server/Chat/Managers/ChatSanitizationManager.cs
+++ b/Content.Server/Chat/Managers/ChatSanitizationManager.cs
@@ -29,7 +29,7 @@ public sealed class ChatSanitizationManager : IChatSanitizationManager
         { "рофл", "chatsan-laughs" },
         { "яхз", "chatsan-shrugs" },
         { ":0", "chatsan-surprised" },
-        { ":р", "chatsan-stick-out-tongue" }, // cyrillic р
+// ADT-remove for radiochannel        { ":р", "chatsan-stick-out-tongue" }, // cyrillic р
         { "кек", "chatsan-laughs" },
         { "T_T", "chatsan-cries" },
         { "Т_Т", "chatsan-cries" }, // cyrillic T


### PR DESCRIPTION
Был убран :р который вызывал эмоцию показывания языка, так как это конфликтует с вызовом рации.
https://discord.com/channels/901772674865455115/1306162156839895111
:cl:  Filo
- remove: Вырезано сокращение :р, конфликтующее с вызовом рации, что не позволяло использовать родной канал