### PR TITLE
теперь дефибриллятор не обращает стадию гниения

### DIFF
--- a/Content.Server/Medical/DefibrillatorSystem.cs
+++ b/Content.Server/Medical/DefibrillatorSystem.cs
@@ -180,7 +180,7 @@ public sealed class DefibrillatorSystem : EntitySystem
             _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-rotten"),
                 InGameICChatType.Speak, true);
         }
-        if (HasComp<EmbalmedComponent>(target)) //ADT-Medicine
+        else if (HasComp<EmbalmedComponent>(target)) //ADT-Medicine
         {
             _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-embalmed"),
                 InGameICChatType.Speak, true);


### PR DESCRIPTION
## Описание PR
<!-- теперь дефибриллятор не обращает стадию гниения. -->


## Почему / Баланс
<!-- Так не должно было быть. -->

## Техническая информация
<!-- Две конструкции if вместо одной, тоесть сначала если труп гниёт отправляется сообщение, потом проводится проверка на всё кроме гниения, и т.к. ифы не связаны труп встаёт. -->

- [X] Я прочитал(а) и следую [Руководство по созданию пулл реквестов](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). Я понимаю, что в противном случае мой ПР может быть закрыт по усмотрению мейнтейнера.
- [X] Я добавил скриншоты/видео к этому пулл реквесту, демонстрирующие его изменения в игре, **или** этот пулл реквест не требует демонстрации в игре

:cl: WsWiss
- tweak: Теперь дефибриллятор не обращает стадию гниения.

