### PR TITLE
[ADMIN, BUG] опять 1984, и фикс бага команды ghost

### DIFF
--- a/Content.Server/ADT/Discord/Adminwho/DiscordAdminInfoSenderSystem.cs
+++ b/Content.Server/ADT/Discord/Adminwho/DiscordAdminInfoSenderSystem.cs
@@ -9,6 +9,7 @@ using Robust.Shared.Utility;
 using Content.Server.GameTicking;
 using Content.Server.Afk;
 using Content.Shared.Ghost;
+using Content.Shared.GameTicking;
 
 namespace Content.Server.ADT.Discord.Adminwho;
 
@@ -19,6 +20,7 @@ public sealed class DiscordAdminInfoSenderSystem : EntitySystem
     [Dependency] private readonly IAdminManager _adminMgr = default!;
     [Dependency] private readonly IGameTiming _time = default!;
     [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
+    [Dependency] private readonly IEntityManager _entities = default!;
 
     private TimeSpan _nextSendTime = TimeSpan.MinValue;
     private readonly TimeSpan _delayInterval = TimeSpan.FromMinutes(15);
@@ -47,8 +49,10 @@ public sealed class DiscordAdminInfoSenderSystem : EntitySystem
         {
             if (admin == null)
                 return;
+
             var adminData = _adminMgr.GetAdminData(admin)!;
             DebugTools.AssertNotNull(adminData);
+
             var afk = IoCManager.Resolve<IAfkManager>();
 
             if (adminData.Stealth)
@@ -61,6 +65,10 @@ public sealed class DiscordAdminInfoSenderSystem : EntitySystem
             if (admin.AttachedEntity != null &&
             TryComp<GhostComponent>(admin.AttachedEntity.Value, out var _))
                 sb.Append("[AGhost]");
+
+            var gameTickerAdmin = _entities.System<GameTicker>();
+            if (!gameTickerAdmin.PlayerGameStatuses.TryGetValue(admin.UserId, out var status) || status is not PlayerGameStatus.JoinedGame)
+                sb.Append("[Lobby]");
 
             sb.AppendLine();
         }

--- a/Content.Server/ADT/Discord/Adminwho/DiscordAdminInfoSenderSystem.cs
+++ b/Content.Server/ADT/Discord/Adminwho/DiscordAdminInfoSenderSystem.cs
@@ -60,15 +60,18 @@ public sealed class DiscordAdminInfoSenderSystem : EntitySystem
             sb.Append(admin.Name);
             if (adminData.Title is { } title)
                 sb.Append($": [{title}]");
+
             if (afk.IsAfk(admin))
-                sb.Append("[AFK]");
+                sb.Append("[АФК]");
+
             if (admin.AttachedEntity != null &&
             TryComp<GhostComponent>(admin.AttachedEntity.Value, out var _))
-                sb.Append("[AGhost]");
+                sb.Append("[Агост]");
 
             var gameTickerAdmin = _entities.System<GameTicker>();
-            if (!gameTickerAdmin.PlayerGameStatuses.TryGetValue(admin.UserId, out var status) || status is not PlayerGameStatus.JoinedGame)
-                sb.Append("[Lobby]");
+            if (!gameTickerAdmin.PlayerGameStatuses.TryGetValue(admin.UserId, out var status)
+            || status is not PlayerGameStatus.JoinedGame)
+                sb.Append("[Лобби]");
 
             sb.AppendLine();
         }

--- a/Content.Server/Ghost/GhostCommand.cs
+++ b/Content.Server/Ghost/GhostCommand.cs
@@ -1,7 +1,9 @@
 using Content.Server.Popups;
 using Content.Shared.Administration;
+using Content.Shared.GameTicking;
 using Content.Shared.Mind;
 using Robust.Shared.Console;
+using Content.Server.GameTicking;
 
 namespace Content.Server.Ghost
 {
@@ -20,6 +22,13 @@ namespace Content.Server.Ghost
             if (player == null)
             {
                 shell.WriteLine(Loc.GetString("ghost-command-no-session"));
+                return;
+            }
+
+            var gameTicker = _entities.System<GameTicker>();
+            if (!gameTicker.PlayerGameStatuses.TryGetValue(player.UserId, out var status) || status is not PlayerGameStatus.JoinedGame)
+            {
+                shell.WriteLine("You can't ghost right now. You are not in the game!");
                 return;
             }
 

--- a/Content.Server/Ghost/GhostCommand.cs
+++ b/Content.Server/Ghost/GhostCommand.cs
@@ -24,14 +24,14 @@ namespace Content.Server.Ghost
                 shell.WriteLine(Loc.GetString("ghost-command-no-session"));
                 return;
             }
-
+            // ADT-Tweak-start: fix-bug "ghost"
             var gameTicker = _entities.System<GameTicker>();
             if (!gameTicker.PlayerGameStatuses.TryGetValue(player.UserId, out var status) || status is not PlayerGameStatus.JoinedGame)
             {
                 shell.WriteLine("You can't ghost right now. You are not in the game!");
                 return;
             }
-
+            // ADT-Tweak-end
             if (player.AttachedEntity is { Valid: true } frozen &&
                 _entities.HasComponent<AdminFrozenComponent>(frozen))
             {


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл реквесте? -->

Фикс бага, при котором прописывание команды "ghost" открывало доступ ко всем чатам при этом находясь в лобби

**Ссылка на публикацию в Discord**
- [Баги](https://discord.com/channels/901772674865455115/1310149463989288981)

## Медиа
![image](https://github.com/user-attachments/assets/10fa09ae-a1f9-4639-993f-db26e8800348)

Теперь так
![image](https://github.com/user-attachments/assets/6bb70672-fbd4-42e4-9d84-472b341e0885)


## Требования
<!--
В связи с наплывом ПР'ов нам необходимо убедиться, что ПР'ы следуют правильным рекомендациям.

Пожалуйста, уделите время прочтению, если делаете пулл реквест (ПР) впервые.

Отметьте поля ниже, чтобы подтвердить, что Вы действительно видели их (поставьте X в скобках, например [X]):
-->
- [x] Я прочитал(а) и следую [Руководство по созданию пулл реквестов](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). Я понимаю, что в противном случае мой ПР может быть закрыт по усмотрению мейнтейнера.
- [x] Я добавил скриншоты/видео к этому пулл реквесту, демонстрирующие его изменения в игре, **или** этот пулл реквест не требует демонстрации в игре

## Критические изменения
<!--
Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей, переименования прототипов, и предоставьте инструкции по их исправлению.
-->

**Чейнджлог**
