### PR TITLE
[Fix] Маленькие изменения системы подарков

### DIFF
--- a/Content.Server/Holiday/Christmas/RandomGiftComponent.cs
+++ b/Content.Server/Holiday/Christmas/RandomGiftComponent.cs
@@ -26,8 +26,8 @@ public sealed partial class RandomGiftComponent : Component
     /// <summary>
     /// Whether or not the gift should be limited only to actual items.
     /// </summary>
-    [DataField("insaneMode", required: true), ViewVariables(VVAccess.ReadWrite)]
-    public bool InsaneMode;
+    [DataField("insaneMode"), ViewVariables(VVAccess.ReadWrite)] // По умолчанию тип bool с required: true
+    public string? InsaneMode;
 
     /// <summary>
     /// What entities are allowed to examine this gift to see its contents.

--- a/Content.Server/Holiday/Christmas/RandomGiftSystem.cs
+++ b/Content.Server/Holiday/Christmas/RandomGiftSystem.cs
@@ -29,6 +29,7 @@ public sealed class RandomGiftSystem : EntitySystem
 
     private readonly List<string> _possibleGiftsSafe = new();
     private readonly List<string> _possibleGiftsUnsafe = new();
+    private readonly List<string> _possibleGiftsUnsafeADT = new();
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -73,8 +74,12 @@ public sealed class RandomGiftSystem : EntitySystem
 
     private void OnGiftMapInit(EntityUid uid, RandomGiftComponent component, MapInitEvent args)
     {
-        if (component.InsaneMode)
+        if (component.InsaneMode == "Unsafe")
             component.SelectedEntity = _random.Pick(_possibleGiftsUnsafe);
+        else if (component.InsaneMode == "Safe")
+            component.SelectedEntity = _random.Pick(_possibleGiftsSafe);
+        else if (component.InsaneMode == "ADTUnsafe")
+            component.SelectedEntity = _random.Pick(_possibleGiftsUnsafeADT);
         else
             component.SelectedEntity = _random.Pick(_possibleGiftsSafe);
     }
@@ -100,6 +105,20 @@ public sealed class RandomGiftSystem : EntitySystem
 
             _possibleGiftsUnsafe.Add(proto.ID);
 
+            // Начало говнокода
+            try
+            {
+                string check = proto.Components["Physics"].Mapping[0].Value.ToString();
+                if (check == "Static" || check == "KinematicController" || check == "Kinematic")
+                    continue;
+                _possibleGiftsUnsafeADT.Add(proto.ID);
+            }
+            catch
+            {
+                _possibleGiftsUnsafeADT.Add(proto.ID);
+            }
+            //Его конец
+            
             if (!proto.Components.ContainsKey(itemCompName))
                 continue;
 

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/NewYears/Catalog/Fills/Boxes/gift.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/NewYears/Catalog/Fills/Boxes/gift.yml
@@ -67,7 +67,7 @@
   suffix: Filled Insane, New Year
   components:
   - type: RandomGift
-    insaneMode: true
+    insaneMode: ADTUnSafe
   - type: Sprite
     sprite: ADT/ADTGlobalEvents/NewYears/Objects/Fun/new_year_present.rsi
     layers:
@@ -98,4 +98,4 @@
     rarePrototypes: #временный прикол, который стоит потом убрать.
       - toyC4Package
       - ADTPresentRandomInsaneSyndicate
-    rareChance: 0.25
+    rareChance: 0.10 #Был 0.25. Даже с таким слишком часто падает.

--- a/Resources/Prototypes/Entities/Objects/Decoration/present.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/present.yml
@@ -26,7 +26,7 @@
     wrapper: PresentTrash
     sound:
       path: /Audio/Effects/unwrap.ogg
-    insaneMode: false
+    insaneMode: Unsafe
     contentsViewers:
       components:
       - Ghost
@@ -38,7 +38,7 @@
   suffix: Filled, any entity
   components:
     - type: RandomGift
-      insaneMode: true
+      insaneMode: Unsafe
 
 - type: entity
   id: PresentRandom


### PR DESCRIPTION
## Описание PR
Изменения системы подарков для баланса вселенной.

## Почему / Баланс

-- Почему? 
-- Потому что не хочется, чтобы человек бегал с газодобытчиком плазмы!

## Техническая информация
Изменён компонент "InsaneMode" с типа bool на string.
Теперь при использование этого компонента в подарках надо вписывать Safe/Unsafe/ADTUnsafe. 
Safe - безопасные подарки. По больше степени игрушки
Unsafe - абсолютно любые подарки, которые можно брать в руки. (Да, тот самый газодобытчик плазмы из подарка на новый год)
ADTUnsafe - Опасные предметы. От карты кэпа до скафандра киберсана. (Без газодобытчиков одним словом)

## Требования

- [X] Я прочитал(а) и следую [Руководство по созданию пулл реквестов](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). Я понимаю, что в противном случае мой ПР может быть закрыт по усмотрению мейнтейнера.
- [X] Я добавил скриншоты/видео к этому пулл реквесту, демонстрирующие его изменения в игре, **или** этот пулл реквест не требует демонстрации в игре

## Критические изменения
Изменён компонент "InsaneMode" с типа bool на string для системы выдачи предметов в новогодних подарках.

**Чейнджлог**

Например: :cl: NameLunar
- fix: Теперь из новогодних ADT подарков нельзя выбить ручной газодобытчик плазмы!
