### PR TITLE
[FIX] Удаляем из РРТ вентиляторы

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Tools/tools.yml
@@ -24,7 +24,7 @@
     - ADTGasVentPump
     - ADTGasValve
     - ADTGasVentScrubber
-    - ADTAtmosDeviceFanTiny
+    # - ADTAtmosDeviceFanTiny Удалено в целях баланса
     - ADTGasPassiveGate
     - ADTGasDualPortVentPump
     - ADTSignalControlledValve

--- a/Resources/Prototypes/ADT/Recipes/Construction/Graph/utilities/tiny_fan.yml
+++ b/Resources/Prototypes/ADT/Recipes/Construction/Graph/utilities/tiny_fan.yml
@@ -1,0 +1,52 @@
+- type: constructionGraph
+  id: ADTFan
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: litleFan
+      steps:
+      - material: Plasteel
+        amount: 10
+        doAfter: 5
+    - to: directionalFan
+      steps:
+      - material: Plasteel
+        amount: 10
+        doAfter: 5
+
+  - node: litleFan
+    entity: AtmosDeviceFanTiny
+    edges:
+    - to: start
+      # conditions:
+      # - !type:EntityAnchored
+      #   anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetPlasteel1
+        amount: 6
+      - !type:DeleteEntity
+      steps:
+      - tool: Screwing
+        doAfter: 5
+      - tool: Welding
+        doAfter: 5
+
+  - node: directionalFan
+    entity: AtmosDeviceFanDirectional
+    edges:
+    - to: start
+      # conditions:
+      # - !type:EntityAnchored
+      #   anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetPlasteel1
+        amount: 6
+      - !type:DeleteEntity
+      steps:
+      - tool: Screwing
+        doAfter: 5
+      - tool: Welding
+        doAfter: 5

--- a/Resources/Prototypes/ADT/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/ADT/Recipes/Construction/utilities.yml
@@ -1,0 +1,28 @@
+# FAN
+- type: construction
+  name: little fan
+  id: ADTLitleFan
+  description: Fan to hold the air in and space outside.
+  graph: ADTFan
+  startNode: start
+  targetNode: litleFan
+  category: construction-category-utilities
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  icon:
+    sprite: Structures/Piping/Atmospherics/tinyfan.rsi
+    state: icon
+
+- type: construction
+  name: little directional fan
+  id: ADTLitleDirectionalFan
+  description: Fan to hold the air in and space outside.
+  graph: ADTFan
+  startNode: start
+  targetNode: directionalFan
+  category: construction-category-utilities
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  icon:
+    sprite: Structures/Piping/Atmospherics/directionalfan.rsi
+    state: icon

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
@@ -31,6 +31,11 @@
     delay: 2
     fx: EffectRCDDeconstruct2
   # ADT-RPD-End
+  # ADT-Tweak-Start
+  - type: Construction
+    graph: ADTFan
+    node: litleFan
+  # ADT-Tweak-End
 
 - type: entity
   id: AtmosDeviceFanDirectional
@@ -60,3 +65,8 @@
   - type: Tag
     tags:
       - SpreaderIgnore
+  # ADT-Tweak-Start
+  - type: Construction
+    graph: ADTFan
+    node: directionalFan
+  # ADT-Tweak-End


### PR DESCRIPTION
## Описание PR
Удалил из меню РРТ вентилятор
Добавил крафты в меню крафта для маленького вентилятора и для вентилятора направленного

## Почему / Баланс
Чтобы не ломали атмосферу на станции и получали другие избыточные плюшки, спамя вентилями

:cl: Петр
- remove: Из меню РРТ удален крафт вентилятора. Причина - спам ими на станции и вызываемые этим проблемы.
- add: В меню крафта в раздел "утилиты" добавлены крафты для малого вентилятора и направленного вентилятора.
