### PR TITLE
[ADMIN] Update Overlay admin

### DIFF
--- a/Content.Client/Administration/AdminNameOverlay.cs
+++ b/Content.Client/Administration/AdminNameOverlay.cs
@@ -3,9 +3,7 @@ using Content.Client.Administration.Systems;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
-using Robust.Shared;
 using Robust.Shared.Enums;
-using Robust.Shared.Configuration;
 
 namespace Content.Client.Administration;
 

--- a/Content.Client/Administration/AdminNameOverlay.cs
+++ b/Content.Client/Administration/AdminNameOverlay.cs
@@ -17,6 +17,9 @@ internal sealed class AdminNameOverlay : Overlay
     private readonly EntityLookupSystem _entityLookup;
     private readonly IUserInterfaceManager _userInterfaceManager;
     private readonly Font _font;
+    private int? _notes;
+    private int? _bans;
+    private int? _roleBans;
 
     public AdminNameOverlay(AdminSystem system, IEntityManager entityManager, IEyeManager eyeManager, IResourceCache resourceCache, EntityLookupSystem entityLookup, IUserInterfaceManager userInterfaceManager)
     {
@@ -70,6 +73,43 @@ internal sealed class AdminNameOverlay : Overlay
             // }
             // args.ScreenHandle.DrawString(_font, screenCoordinates+lineoffset, playerInfo.Username, uiScale, playerInfo.Connected ? Color.Yellow : Color.White);
             // args.ScreenHandle.DrawString(_font, screenCoordinates, playerInfo.CharacterName, uiScale, playerInfo.Connected ? Color.Aquamarine : Color.White);
+            // ADT-STart-Tweak: Переписываю нормальный оверлей
+            var currentOffset = Vector2.Zero;
+            if (playerInfo.Antag)
+            {
+                args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, "ANTAG", uiScale, Color.OrangeRed);
+                currentOffset += lineoffset;
+            }
+            args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, playerInfo.Username, uiScale, playerInfo.Connected ? Color.Yellow : Color.White);
+            currentOffset += lineoffset;
+            args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, playerInfo.CharacterName, uiScale, playerInfo.Connected ? Color.Aquamarine : Color.White);
+            currentOffset += lineoffset;
+            if (!string.IsNullOrEmpty(playerInfo.PlaytimeString))
+            {
+                args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, playerInfo.PlaytimeString, uiScale, playerInfo.Connected ? Color.Red : Color.White);
+                currentOffset += lineoffset;
+            }
+            if (playerInfo.Sponsor != null)
+            {
+                args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, "Sponsor", uiScale, playerInfo.Connected ? Color.Gold : Color.White);
+                currentOffset += lineoffset;
+            }
+            if (_notes.HasValue)
+            {
+                args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, $"Notes: {_notes.Value}", uiScale, playerInfo.Connected ? Color.Yellow : Color.White);
+                currentOffset += lineoffset;
+            }
+            if (_bans.HasValue)
+            {
+                args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, $"Bans: {_bans.Value}", uiScale, playerInfo.Connected ? Color.Red : Color.White);
+                currentOffset += lineoffset;
+            }
+            if (_roleBans.HasValue)
+            {
+                args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, $"Role Bans: {_roleBans.Value}", uiScale, playerInfo.Connected ? Color.Purple : Color.White);
+                currentOffset += lineoffset;
+            }
+            // ADT-END
         }
     }
 }

--- a/Content.Client/Administration/AdminNameOverlay.cs
+++ b/Content.Client/Administration/AdminNameOverlay.cs
@@ -64,7 +64,7 @@ internal sealed class AdminNameOverlay : Overlay
             var screenCoordinates = _eyeManager.WorldToScreen(aabb.Center +
                                                               new Angle(-_eyeManager.CurrentEye.Rotation).RotateVec(
                                                                   aabb.TopRight - aabb.Center)) + new Vector2(1f, 7f);
-            // if (playerInfo.Antag)
+            // if (playerInfo.Antag) // Я ЭТО КОМЕНЧУ ПОТОМУ ЧТО ТУТ НАПИСАНА ПОЕБОТА ПОЛНАЯ БЛЯТЬ, КТО ТАК делАеТ НАХУЙ
             // {
             //     args.ScreenHandle.DrawString(_font, screenCoordinates + (lineoffset * 2), "ANTAG", uiScale, Color.OrangeRed);
             // }

--- a/Content.Client/Administration/AdminNameOverlay.cs
+++ b/Content.Client/Administration/AdminNameOverlay.cs
@@ -6,6 +6,7 @@ using Robust.Client.UserInterface;
 using Robust.Shared;
 using Robust.Shared.Enums;
 using Robust.Shared.Configuration;
+using Content.Shared.Administration;
 
 namespace Content.Client.Administration;
 
@@ -17,11 +18,9 @@ internal sealed class AdminNameOverlay : Overlay
     private readonly EntityLookupSystem _entityLookup;
     private readonly IUserInterfaceManager _userInterfaceManager;
     private readonly Font _font;
-    private int? _notes;
-    private int? _bans;
-    private int? _roleBans;
+    private readonly PlayerPanelEuiState _playerPanelEuiState;
 
-    public AdminNameOverlay(AdminSystem system, IEntityManager entityManager, IEyeManager eyeManager, IResourceCache resourceCache, EntityLookupSystem entityLookup, IUserInterfaceManager userInterfaceManager)
+    public AdminNameOverlay(AdminSystem system, IEntityManager entityManager, IEyeManager eyeManager, IResourceCache resourceCache, EntityLookupSystem entityLookup, IUserInterfaceManager userInterfaceManager, PlayerPanelEuiState playerPanelEuiState) // ADT-Tweak
     {
         _system = system;
         _entityManager = entityManager;
@@ -30,6 +29,7 @@ internal sealed class AdminNameOverlay : Overlay
         _userInterfaceManager = userInterfaceManager;
         ZIndex = 200;
         _font = new VectorFont(resourceCache.GetResource<FontResource>("/Fonts/NotoSans/NotoSans-Regular.ttf"), 10);
+        _playerPanelEuiState = playerPanelEuiState; // ADT-Tweak
     }
 
     public override OverlaySpace Space => OverlaySpace.ScreenSpace;
@@ -94,19 +94,19 @@ internal sealed class AdminNameOverlay : Overlay
                 args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, "Sponsor", uiScale, playerInfo.Connected ? Color.Gold : Color.White);
                 currentOffset += lineoffset;
             }
-            if (_notes.HasValue)
+            if (_playerPanelEuiState.TotalNotes.HasValue)
             {
-                args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, $"Notes: {_notes.Value}", uiScale, playerInfo.Connected ? Color.Yellow : Color.White);
+                args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, $"Notes: {_playerPanelEuiState.TotalNotes}", uiScale, playerInfo.Connected ? Color.Yellow : Color.White);
                 currentOffset += lineoffset;
             }
-            if (_bans.HasValue)
+            if (_playerPanelEuiState.TotalBans.HasValue)
             {
-                args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, $"Bans: {_bans.Value}", uiScale, playerInfo.Connected ? Color.Red : Color.White);
+                args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, $"Bans: {_playerPanelEuiState.TotalBans}", uiScale, playerInfo.Connected ? Color.Red : Color.White);
                 currentOffset += lineoffset;
             }
-            if (_roleBans.HasValue)
+            if (_playerPanelEuiState.TotalRoleBans.HasValue)
             {
-                args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, $"Role Bans: {_roleBans.Value}", uiScale, playerInfo.Connected ? Color.Purple : Color.White);
+                args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, $"Role Bans: {_playerPanelEuiState.TotalRoleBans}", uiScale, playerInfo.Connected ? Color.Purple : Color.White);
                 currentOffset += lineoffset;
             }
             // ADT-END

--- a/Content.Client/Administration/AdminNameOverlay.cs
+++ b/Content.Client/Administration/AdminNameOverlay.cs
@@ -6,7 +6,6 @@ using Robust.Client.UserInterface;
 using Robust.Shared;
 using Robust.Shared.Enums;
 using Robust.Shared.Configuration;
-using Content.Shared.Administration;
 
 namespace Content.Client.Administration;
 
@@ -18,9 +17,8 @@ internal sealed class AdminNameOverlay : Overlay
     private readonly EntityLookupSystem _entityLookup;
     private readonly IUserInterfaceManager _userInterfaceManager;
     private readonly Font _font;
-    private readonly PlayerPanelEuiState _playerPanelEuiState;
 
-    public AdminNameOverlay(AdminSystem system, IEntityManager entityManager, IEyeManager eyeManager, IResourceCache resourceCache, EntityLookupSystem entityLookup, IUserInterfaceManager userInterfaceManager, PlayerPanelEuiState playerPanelEuiState) // ADT-Tweak
+    public AdminNameOverlay(AdminSystem system, IEntityManager entityManager, IEyeManager eyeManager, IResourceCache resourceCache, EntityLookupSystem entityLookup, IUserInterfaceManager userInterfaceManager)
     {
         _system = system;
         _entityManager = entityManager;
@@ -29,7 +27,6 @@ internal sealed class AdminNameOverlay : Overlay
         _userInterfaceManager = userInterfaceManager;
         ZIndex = 200;
         _font = new VectorFont(resourceCache.GetResource<FontResource>("/Fonts/NotoSans/NotoSans-Regular.ttf"), 10);
-        _playerPanelEuiState = playerPanelEuiState; // ADT-Tweak
     }
 
     public override OverlaySpace Space => OverlaySpace.ScreenSpace;
@@ -94,21 +91,23 @@ internal sealed class AdminNameOverlay : Overlay
                 args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, "Sponsor", uiScale, playerInfo.Connected ? Color.Gold : Color.White);
                 currentOffset += lineoffset;
             }
-            if (_playerPanelEuiState.TotalNotes.HasValue)
-            {
-                args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, $"Notes: {_playerPanelEuiState.TotalNotes}", uiScale, playerInfo.Connected ? Color.Yellow : Color.White);
-                currentOffset += lineoffset;
-            }
-            if (_playerPanelEuiState.TotalBans.HasValue)
-            {
-                args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, $"Bans: {_playerPanelEuiState.TotalBans}", uiScale, playerInfo.Connected ? Color.Red : Color.White);
-                currentOffset += lineoffset;
-            }
-            if (_playerPanelEuiState.TotalRoleBans.HasValue)
-            {
-                args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, $"Role Bans: {_playerPanelEuiState.TotalRoleBans}", uiScale, playerInfo.Connected ? Color.Purple : Color.White);
-                currentOffset += lineoffset;
-            }
+
+
+            // if (_playerPanelEuiState.TotalNotes.HasValue)
+            // {
+            //     args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, $"Notes: {_playerPanelEuiState.TotalNotes}", uiScale, playerInfo.Connected ? Color.Yellow : Color.White);
+            //     currentOffset += lineoffset;
+            // }
+            // if (_playerPanelEuiState.TotalBans.HasValue)
+            // {
+            //     args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, $"Bans: {_playerPanelEuiState.TotalBans}", uiScale, playerInfo.Connected ? Color.Red : Color.White);
+            //     currentOffset += lineoffset;
+            // }
+            // if (_playerPanelEuiState.TotalRoleBans.HasValue)
+            // {
+            //     args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, $"Role Bans: {_playerPanelEuiState.TotalRoleBans}", uiScale, playerInfo.Connected ? Color.Purple : Color.White);
+            //     currentOffset += lineoffset;
+            // }
             // ADT-END
         }
     }

--- a/Content.Client/Administration/AdminNameOverlay.cs
+++ b/Content.Client/Administration/AdminNameOverlay.cs
@@ -62,14 +62,15 @@ internal sealed class AdminNameOverlay : Overlay
             var screenCoordinates = _eyeManager.WorldToScreen(aabb.Center +
                                                               new Angle(-_eyeManager.CurrentEye.Rotation).RotateVec(
                                                                   aabb.TopRight - aabb.Center)) + new Vector2(1f, 7f);
-            // if (playerInfo.Antag) // Я ЭТО КОМЕНЧУ ПОТОМУ ЧТО ТУТ НАПИСАНА ПОЕБОТА ПОЛНАЯ БЛЯТЬ, КТО ТАК делАеТ НАХУЙ
+            // if (playerInfo.Antag) // ADT-TWEAK: Я ЭТО КОМЕНЧУ ПОТОМУ ЧТО ТУТ НАПИСАНА ПОЕБОТА ПОЛНАЯ БЛЯТЬ, КТО ТАК делАеТ НАХУЙ
             // {
             //     args.ScreenHandle.DrawString(_font, screenCoordinates + (lineoffset * 2), "ANTAG", uiScale, Color.OrangeRed);
             // }
             // args.ScreenHandle.DrawString(_font, screenCoordinates+lineoffset, playerInfo.Username, uiScale, playerInfo.Connected ? Color.Yellow : Color.White);
             // args.ScreenHandle.DrawString(_font, screenCoordinates, playerInfo.CharacterName, uiScale, playerInfo.Connected ? Color.Aquamarine : Color.White);
+
             // ADT-STart-Tweak: Переписываю нормальный оверлей
-            var currentOffset = Vector2.Zero;
+            Vector2 currentOffset = Vector2.Zero;
             if (playerInfo.Antag)
             {
                 args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, "ANTAG", uiScale, Color.OrangeRed);

--- a/Content.Client/Administration/AdminNameOverlay.cs
+++ b/Content.Client/Administration/AdminNameOverlay.cs
@@ -64,13 +64,12 @@ internal sealed class AdminNameOverlay : Overlay
             var screenCoordinates = _eyeManager.WorldToScreen(aabb.Center +
                                                               new Angle(-_eyeManager.CurrentEye.Rotation).RotateVec(
                                                                   aabb.TopRight - aabb.Center)) + new Vector2(1f, 7f);
-            if (playerInfo.Antag)
-            {
-                args.ScreenHandle.DrawString(_font, screenCoordinates + (lineoffset * 2), "ANTAG", uiScale, Color.OrangeRed);
-;
-            }
-            args.ScreenHandle.DrawString(_font, screenCoordinates+lineoffset, playerInfo.Username, uiScale, playerInfo.Connected ? Color.Yellow : Color.White);
-            args.ScreenHandle.DrawString(_font, screenCoordinates, playerInfo.CharacterName, uiScale, playerInfo.Connected ? Color.Aquamarine : Color.White);
+            // if (playerInfo.Antag)
+            // {
+            //     args.ScreenHandle.DrawString(_font, screenCoordinates + (lineoffset * 2), "ANTAG", uiScale, Color.OrangeRed);
+            // }
+            // args.ScreenHandle.DrawString(_font, screenCoordinates+lineoffset, playerInfo.Username, uiScale, playerInfo.Connected ? Color.Yellow : Color.White);
+            // args.ScreenHandle.DrawString(_font, screenCoordinates, playerInfo.CharacterName, uiScale, playerInfo.Connected ? Color.Aquamarine : Color.White);
         }
     }
 }

--- a/Content.Client/Administration/AdminNameOverlay.cs
+++ b/Content.Client/Administration/AdminNameOverlay.cs
@@ -81,7 +81,7 @@ internal sealed class AdminNameOverlay : Overlay
             currentOffset += lineoffset;
             if (!string.IsNullOrEmpty(playerInfo.PlaytimeString))
             {
-                args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, playerInfo.PlaytimeString, uiScale, playerInfo.Connected ? Color.Red : Color.White);
+                args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, playerInfo.PlaytimeString, uiScale, playerInfo.Connected ? Color.Orange : Color.White);
                 currentOffset += lineoffset;
             }
             if (playerInfo.Sponsor != null)
@@ -89,23 +89,6 @@ internal sealed class AdminNameOverlay : Overlay
                 args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, "Sponsor", uiScale, playerInfo.Connected ? Color.Gold : Color.White);
                 currentOffset += lineoffset;
             }
-
-
-            // if (_playerPanelEuiState.TotalNotes.HasValue)
-            // {
-            //     args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, $"Notes: {_playerPanelEuiState.TotalNotes}", uiScale, playerInfo.Connected ? Color.Yellow : Color.White);
-            //     currentOffset += lineoffset;
-            // }
-            // if (_playerPanelEuiState.TotalBans.HasValue)
-            // {
-            //     args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, $"Bans: {_playerPanelEuiState.TotalBans}", uiScale, playerInfo.Connected ? Color.Red : Color.White);
-            //     currentOffset += lineoffset;
-            // }
-            // if (_playerPanelEuiState.TotalRoleBans.HasValue)
-            // {
-            //     args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, $"Role Bans: {_playerPanelEuiState.TotalRoleBans}", uiScale, playerInfo.Connected ? Color.Purple : Color.White);
-            //     currentOffset += lineoffset;
-            // }
             // ADT-END
         }
     }

--- a/Content.Client/Administration/AdminNameOverlay.cs
+++ b/Content.Client/Administration/AdminNameOverlay.cs
@@ -90,6 +90,11 @@ internal sealed class AdminNameOverlay : Overlay
                 args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, "Sponsor", uiScale, playerInfo.Connected ? Color.Gold : Color.White);
                 currentOffset += lineoffset;
             }
+            if (playerInfo.StartingJob != null)
+            {
+                args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, Loc.GetString(playerInfo.StartingJob), uiScale, playerInfo.Connected ? Color.GreenYellow : Color.White);
+                currentOffset += lineoffset;
+            }
             // ADT-END
         }
     }

--- a/Content.Client/Administration/Systems/AdminSystem.Overlay.cs
+++ b/Content.Client/Administration/Systems/AdminSystem.Overlay.cs
@@ -3,7 +3,6 @@ using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
 using Robust.Shared.Configuration;
-using Content.Shared.Administration;
 
 namespace Content.Client.Administration.Systems
 {
@@ -15,7 +14,6 @@ namespace Content.Client.Administration.Systems
         [Dependency] private readonly IEyeManager _eyeManager = default!;
         [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
         [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;
-        private readonly PlayerPanelEuiState _playerPanelEuiState = default!;
 
         private AdminNameOverlay _adminNameOverlay = default!;
 

--- a/Content.Client/Administration/Systems/AdminSystem.Overlay.cs
+++ b/Content.Client/Administration/Systems/AdminSystem.Overlay.cs
@@ -3,6 +3,7 @@ using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
 using Robust.Shared.Configuration;
+using Content.Shared.Administration;
 
 namespace Content.Client.Administration.Systems
 {
@@ -14,6 +15,7 @@ namespace Content.Client.Administration.Systems
         [Dependency] private readonly IEyeManager _eyeManager = default!;
         [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
         [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;
+        private readonly PlayerPanelEuiState _playerPanelEuiState = default!;
 
         private AdminNameOverlay _adminNameOverlay = default!;
 

--- a/Content.Client/Administration/Systems/AdminSystem.Overlay.cs
+++ b/Content.Client/Administration/Systems/AdminSystem.Overlay.cs
@@ -2,7 +2,6 @@ using Content.Client.Administration.Managers;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
-using Robust.Shared.Configuration;
 
 namespace Content.Client.Administration.Systems
 {

--- a/Content.Server/Administration/PlayerPanelEui.cs
+++ b/Content.Server/Administration/PlayerPanelEui.cs
@@ -222,7 +222,5 @@ public sealed class PlayerPanelEui : BaseEui
         }
 
         StateDirty();
-        // var overlayMessage = new PlayerPanelOverlayDataMessage(_notes, _bans, _roleBans);
-        // _eui.SendMessageToClient(overlayMessage); хуйня
     }
 }

--- a/Content.Server/Administration/PlayerPanelEui.cs
+++ b/Content.Server/Administration/PlayerPanelEui.cs
@@ -222,5 +222,7 @@ public sealed class PlayerPanelEui : BaseEui
         }
 
         StateDirty();
+        // var overlayMessage = new PlayerPanelOverlayDataMessage(_notes, _bans, _roleBans);
+        // _eui.SendMessageToClient(overlayMessage); хуйня
     }
 }

--- a/Content.Shared/Administration/PlayerPanelEuiState.cs
+++ b/Content.Shared/Administration/PlayerPanelEuiState.cs
@@ -1,7 +1,6 @@
 using Content.Shared.Eui;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;
-using YamlDotNet.Serialization.Callbacks;
 
 namespace Content.Shared.Administration;
 


### PR DESCRIPTION
## Описание PR
<!-- Опишите изменения, внесенные в этом пулл-реквесте. -->

- Добавлено отображение общего времени.  
- Добавлено отображение статуса спонсорства.  
- Добавлено отображение стартовой должности.
- Выполнен рефакторинг админского оверлея для упрощения и улучшения отрисовки.  


## Причины изменений / Баланс  
<!-- Объясните, зачем были внесены изменения, и укажите, как они повлияют на игровой баланс. -->

### Причины:  
1. Усовершенствование отображения информации для админов.  
2. Динамическая отрисовка надписей упрощает дальнейшую работу с интерфейсом.  

**Ссылка на обсуждение:**  
- [Предложения](https://discord.com/channels/901772674865455115/1309134696508030976)  


## Техническая информация  
> [!NOTE]
> Небольшой рефакторинг механики админского оверлея:  
> - Динамическая отрисовка линий текста вместо фиксированного порядка.  
> - Улучшено получение и обработка значений.  

## Медиа  
![image](https://github.com/user-attachments/assets/7e6b4422-b698-49cb-8734-885b7d30f5c4)
![image](https://github.com/user-attachments/assets/4cbfa242-a977-42ec-9322-b82defa6ba3b)
![image](https://github.com/user-attachments/assets/ccccb328-1910-443f-a464-36997421c42a)


## Требования  
<!-- Подтвердите, что вы следовали всем необходимым рекомендациям. -->
- [x] Я прочитал(а) и следую [Руководству по созданию пулл реквестов](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).  
- [x] Я добавил(а) скриншоты/видео к этому пулл-реквесту, демонстрирующие изменения, **или** этот пулл-реквест не требует демонстрации в игре.  

---

## Критические изменения  
Рефакторинг и улучшение админского оверлея:  
- Улучшена читаемость кода.  
- Отрисовка линий текста стала более гибкой.  


**Чейнджлог:**  
:cl: Шрёдька
- tweak: Улучшен админский оверлей. Показывает общее время игрока, стартовое время и спонсорство.