### PR TITLE
[ADMIN] adjstationjob возращается?

### DIFF
--- a/Content.Server/ADT/Administration/Commands/AdjustStationJobCommand.cs
+++ b/Content.Server/ADT/Administration/Commands/AdjustStationJobCommand.cs
@@ -1,0 +1,86 @@
+using Content.Server.Administration;
+using Content.Server.Commands;
+using Content.Server.Station.Components;
+using Content.Server.Station.Systems;
+using Content.Shared.Administration;
+using Content.Shared.Roles;
+using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
+
+
+namespace Content.Server.ADT.Administration.Commands;
+
+[AdminCommand(AdminFlags.Round)]
+public sealed class AdjustStationJobCommand : IConsoleCommand
+{
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IEntitySystemManager _entSysManager = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+    public string Command => "adjstationjob";
+
+    public string Description => "Adjust the job manifest on a station.";
+
+    public string Help => "adjstationjob <station id> <job id> <amount>";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length != 3)
+        {
+            shell.WriteError(Loc.GetString("shell-wrong-arguments-number"));
+            return;
+        }
+
+        var stationJobs = _entSysManager.GetEntitySystem<StationJobsSystem>();
+
+        if (!EntityUid.TryParse(args[0], out var station) || !_entityManager.HasComponent<StationDataComponent>(station))
+        {
+            shell.WriteError(Loc.GetString("shell-argument-station-id-invalid", ("index", 1)));
+            return;
+        }
+
+        if (!_prototypeManager.TryIndex<JobPrototype>(args[1], out var job))
+        {
+            shell.WriteError(Loc.GetString("shell-argument-must-be-prototype",
+                ("index", 2), ("prototypeName", nameof(JobPrototype))));
+            return;
+        }
+
+        if (!int.TryParse(args[2], out var amount) || amount < -1)
+        {
+            shell.WriteError(Loc.GetString("shell-argument-number-must-be-between",
+                ("index", 3), ("lower", -1), ("upper", int.MaxValue)));
+            return;
+        }
+
+        if (amount == -1)
+        {
+            stationJobs.MakeJobUnlimited(station, job);
+            return;
+        }
+
+        stationJobs.TrySetJobSlot(station, job, amount, true);
+    }
+
+    public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+        {
+            var options = ContentCompletionHelper.StationIds(_entityManager);
+            return CompletionResult.FromHintOptions(options, "<station id>");
+        }
+
+        if (args.Length == 2)
+        {
+            var options = CompletionHelper.PrototypeIDs<JobPrototype>();
+            return CompletionResult.FromHintOptions(options, "<job id>");
+        }
+
+        if (args.Length == 3)
+        {
+            return CompletionResult.FromHint("<amount>");
+        }
+
+        return CompletionResult.Empty;
+    }
+}

--- a/Resources/Locale/ru-RU/ADT/administration/commands.ftl
+++ b/Resources/Locale/ru-RU/ADT/administration/commands.ftl
@@ -42,3 +42,7 @@ set-mind-swap-command-help-text = Использование: { $command } <enti
 set-mind-swap-success-message = Сознания успешно поменялись между собой.
 set-mind-swap-command-minds-not-found = Ошибка: сознания не найдены или сущности некорректны.
 set-mind-swap-command-target-has-no-mind-message = У одной из указанных сущностей нет компонента MindContainerComponent.
+
+# Комманда: adjstationjob
+cmd-adjstationjob-desc = Изменить манифест рабочих мест на станции.
+cmd-adjstationjob-help = Использование: adjstationjob <station id> <job id> <amount>


### PR DESCRIPTION
## Описание PR
Добавлена команда администратора для изменения манифеста рабочих мест на станции.

Использование: `adjstationjob <station id> <job id> <amount>`

## Почему / Баланс
Команда позволяет администраторам менять количество слотов для определённых профессий на станции в реальном времени.

## Медиа
Не требуется.

## Требования
- [X] Я прочитал(а) и следую [Руководству по созданию пулл реквестов](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил скриншоты/видео к этому пулл реквесту, демонстрирующие его изменения в игре, **или** этот пулл реквест не требует демонстрации в игре.

## Критические изменения
Нет.

**Чейнджлог**
:cl: Шрёдька
- add: Возращена команда `adjstationjob` для изменения слотов профессий на станции.