### PR TITLE
[ADMIN] Опять 1984. Фильтр а-чата... его больше нет.

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
@@ -62,7 +62,6 @@ public sealed partial class ChannelFilterPopup : Popup
             active |= key;
         }
 
-
         return active;
     }
 

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
@@ -38,6 +38,13 @@ public sealed partial class ChannelFilterPopup : Popup
 
     public bool IsActive(ChatChannel channel)
     {
+        // ADT-Tweak-start
+        // AdminChat всегда активен
+        if (channel == ChatChannel.AdminChat)
+        {
+            return true;
+        }
+        // ADT-Tweak-end
         return _filterStates.TryGetValue(channel, out var checkbox) && checkbox.Pressed;
     }
 
@@ -54,19 +61,13 @@ public sealed partial class ChannelFilterPopup : Popup
 
             active |= key;
         }
-        // ADT-Tweak-start
-        // Всегда добавляем ChatChannel.AdminChat в активные каналы
-        active |= ChatChannel.AdminChat;
-        //ADT-Tweak-End
+
+
         return active;
     }
 
     public void SetChannels(ChatChannel channels)
     {
-        // ADT-Tweak-start
-        // Добавляем ChatChannel.AdminChat в активные каналы по умолчанию
-        channels |= ChatChannel.AdminChat;
-        // ADT-Tweak-End
         foreach (var channel in ChannelFilterOrder)
         {
             if (!_filterStates.TryGetValue(channel, out var checkbox))

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
@@ -23,7 +23,7 @@ public sealed partial class ChannelFilterPopup : Popup
         ChatChannel.Dead,
         ChatChannel.Admin,
         ChatChannel.AdminAlert,
-        ChatChannel.AdminChat,
+        // ChatChannel.AdminChat, // ADT-Tweak: Убираем фильтр а-чата. (Должен быть всегда включен)
         ChatChannel.Server
     };
 

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
@@ -54,12 +54,19 @@ public sealed partial class ChannelFilterPopup : Popup
 
             active |= key;
         }
-
+        // ADT-Tweak-start
+        // Всегда добавляем ChatChannel.AdminChat в активные каналы
+        active |= ChatChannel.AdminChat;
+        //ADT-Tweak-End
         return active;
     }
 
     public void SetChannels(ChatChannel channels)
     {
+        // ADT-Tweak-start
+        // Добавляем ChatChannel.AdminChat в активные каналы по умолчанию
+        channels |= ChatChannel.AdminChat;
+        // ADT-Tweak-End
         foreach (var channel in ChannelFilterOrder)
         {
             if (!_filterStates.TryGetValue(channel, out var checkbox))


### PR DESCRIPTION
## Описание PR
Удален фильтр для канала `AdminChat` - `Админ Чат` из интерфейса фильтров чата. Теперь этот канал всегда активен и его невозможно отключить, что предотвращает его скрытие в интерфейсе чата.

## Почему / Баланс
Фильтр для `AdminChat` был убран, так как он должен оставаться всегда активным для пользователей с правами администратора. 1984 короче.

**Ссылка на публикацию в Discord**
- [Вопрос-ответ](https://discord.com/channels/901772674865455115/1309134696508030976/1313872152809705574)

## Техническая информация
Внесены изменения в код, чтобы гарантировать, что канал `AdminChat` всегда остается активным в интерфейсе. Также фильтр для этого канала был удален из списка фильтров, что предотвращает возможность его отключения в интерфейсе чата.

## Медиа
![image](https://github.com/user-attachments/assets/7eed06ff-ea0b-4251-acbd-fa6fb90f277f)

## Требования
- [x] Я прочитал(а) и следую [Руководству по созданию пулл реквестов](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). Я понимаю, что в противном случае мой ПР может быть закрыт по усмотрению мейнтейнера.
- [x] Я добавил скриншоты/видео к этому пулл реквесту, демонстрирующие его изменения в игре, **или** этот пулл реквест не требует демонстрации в игре.

## Критические изменения
Нет

**Чейнджлог**
:cl: Шрёдька
- tweak: Убран фильтр для канала `Админ Чат`. Теперь этот канал всегда активен и отображается в чате.