### PR TITLE
[ADMIN] Add option to disable bwoink sound.

### DIFF
--- a/Content.Client/Options/UI/Tabs/AudioTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AudioTab.xaml
@@ -26,6 +26,7 @@
                 <CheckBox Name="RestartSoundsCheckBox" Text="{Loc 'ui-options-restart-sounds'}" />
                 <CheckBox Name="EventMusicCheckBox" Text="{Loc 'ui-options-event-music'}" />
                 <CheckBox Name="AdminSoundsCheckBox" Text="{Loc 'ui-options-admin-sounds'}" />
+                <CheckBox Name="BwoinkSoundCheckBox" Text="{Loc 'ui-options-bwoink-sound'}" />
             </BoxContainer>
         </BoxContainer>
         <ui:OptionsTabControlRow Name="Control" Access="Public" />

--- a/Content.Client/Options/UI/Tabs/AudioTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AudioTab.xaml.cs
@@ -11,7 +11,6 @@ using Robust.Shared;
 using Robust.Shared.Configuration;
 using Content.Shared.ADT.CCVar;
 
-
 namespace Content.Client.Options.UI.Tabs;
 
 [GenerateTypedNameReferences]

--- a/Content.Client/Options/UI/Tabs/AudioTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AudioTab.xaml.cs
@@ -1,4 +1,6 @@
+using Content.Client.Administration.Managers;
 using Content.Client.Audio;
+using Content.Shared.Administration;
 using Content.Shared.CCVar;
 using Content.Shared.Corvax.CCCVars;
 using Robust.Client.Audio;
@@ -9,6 +11,7 @@ using Robust.Shared;
 using Robust.Shared.Configuration;
 using Content.Shared.ADT.CCVar;
 
+
 namespace Content.Client.Options.UI.Tabs;
 
 [GenerateTypedNameReferences]
@@ -16,6 +19,7 @@ public sealed partial class AudioTab : Control
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IAudioManager _audio = default!;
+    [Dependency] private readonly IClientAdminManager _admin = default!;
 
     public AudioTab()
     {
@@ -85,8 +89,28 @@ public sealed partial class AudioTab : Control
         Control.AddOptionCheckBox(CCVars.RestartSoundsEnabled, RestartSoundsCheckBox);
         Control.AddOptionCheckBox(CCVars.EventMusicEnabled, EventMusicCheckBox);
         Control.AddOptionCheckBox(CCVars.AdminSoundsEnabled, AdminSoundsCheckBox);
+        Control.AddOptionCheckBox(CCVars.BwoinkSoundEnabled, BwoinkSoundCheckBox);
 
         Control.Initialize();
+    }
+
+    protected override void EnteredTree()
+    {
+        base.EnteredTree();
+        _admin.AdminStatusUpdated += UpdateAdminButtonsVisibility;
+        UpdateAdminButtonsVisibility();
+    }
+
+    protected override void ExitedTree()
+    {
+        base.ExitedTree();
+        _admin.AdminStatusUpdated -= UpdateAdminButtonsVisibility;
+    }
+
+
+    private void UpdateAdminButtonsVisibility()
+    {
+        BwoinkSoundCheckBox.Visible = _admin.IsActive() && _admin.HasFlag(AdminFlags.Permissions); // ADT-Tweak
     }
 
     private void OnMasterVolumeSliderChanged(float value)

--- a/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
+++ b/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
@@ -45,6 +45,7 @@ public sealed class AHelpUIController: UIController, IOnSystemChanged<BwoinkSyst
     public IAHelpUIHandler? UIHelper;
     private bool _discordRelayActive;
     private bool _hasUnreadAHelp;
+    private bool _bwoinkSoundEnabled;
     private string? _aHelpSound;
 
     public override void Initialize()
@@ -56,6 +57,7 @@ public sealed class AHelpUIController: UIController, IOnSystemChanged<BwoinkSyst
 
         _adminManager.AdminStatusUpdated += OnAdminStatusUpdated;
         _config.OnValueChanged(CCVars.AHelpSound, v => _aHelpSound = v, true);
+        _config.OnValueChanged(CCVars.BwoinkSoundEnabled, v => _bwoinkSoundEnabled = v, true);
     }
 
     public void UnloadButton()
@@ -135,7 +137,7 @@ public sealed class AHelpUIController: UIController, IOnSystemChanged<BwoinkSyst
         }
         if (message.PlaySound && localPlayer.UserId != message.TrueSender)
         {
-            if (_aHelpSound != null)
+            if (_aHelpSound != null && (_bwoinkSoundEnabled || !_adminManager.IsActive()))
                 _audio.PlayGlobal(_aHelpSound, Filter.Local(), false);
             _clyde.RequestWindowAttention();
         }

--- a/Content.Shared/CCVar/CCVars.Sounds.cs
+++ b/Content.Shared/CCVar/CCVars.Sounds.cs
@@ -21,6 +21,9 @@ public sealed partial class CCVars
     public static readonly CVarDef<bool> AdminSoundsEnabled =
         CVarDef.Create("audio.admin_sounds_enabled", true, CVar.ARCHIVE | CVar.CLIENTONLY);
 
+    public static readonly CVarDef<bool> BwoinkSoundEnabled =
+        CVarDef.Create("audio.bwoink_sound_enabled", true, CVar.ARCHIVE | CVar.CLIENTONLY);
+
     public static readonly CVarDef<string> AdminChatSoundPath =
         CVarDef.Create("audio.admin_chat_sound_path",
             "/Audio/Items/pop.ogg",

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -37,6 +37,7 @@ ui-options-lobby-music = Lobby & Round-end Music
 ui-options-restart-sounds = Round Restart Sounds
 ui-options-event-music = Event Music
 ui-options-admin-sounds = Play Admin Sounds
+ui-options-bwoink-sound = Play AHelp Notification Sound
 ui-options-volume-label = Volume
 
 ## Graphics menu


### PR DESCRIPTION
## About the PR
The title.

This is mainly for admins that have access to the AHelp, but who shouldn't be answering there.

## Why / Balance
Some game staff say they don't want to hear this sound all the time.
`cvar audio.ahelp_sound ""` is working, but it's hard to reset it.

## Technical details
Was referring to the `AdminSoundsCheckBox` for this.

## Media
Option:
![image](https://github.com/user-attachments/assets/1fa0a5c9-2b45-48ed-bbc2-c39f5f288f5c)

AHelp symbol still changes it's color:
![image](https://github.com/user-attachments/assets/881b67fe-3e93-482b-9fca-804abea13524)

## Requirements
 I have read and am following the Pull Request and Changelog Guidelines.
 I have added media to this PR or it does not require an ingame showcase.
Breaking changes
None

no cl, no fun

Changelog
Only for admins, because I don't think the players should be interested in it.

- add: Added an option to disable the bwoink sound!




## Тех. подробности
Просто пораньше подтянули этот пр https://github.com/space-wizards/space-station-14/pull/33782
но с небольшими изменениями, только тем у кого флаг Permission доступна данная фича

огромное спасибо @c4llv07e 💖