### PR TITLE
Запрет ролей для Резоми.

### DIFF
--- a/Resources/Prototypes/ADT/Roles/Jobs/Command/blueshieldofficer.yml
+++ b/Resources/Prototypes/ADT/Roles/Jobs/Command/blueshieldofficer.yml
@@ -15,6 +15,12 @@
       time: 18000 #5 hrs
     - !type:AgeRequirement
       requiredAge: 21
+    # ADT Restrict Start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Resomi
+  # ADT RESTRICT End
   weight: 15
   startingGear: ADTBlueShieldOfficerGear
   icon: "JobIconADTBlueShieldOfficer"

--- a/Resources/Prototypes/ADT/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/ADT/Roles/Jobs/Security/brigmedic.yml
@@ -10,6 +10,12 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 18000 #5 hrs #ADT-RoleTime
+  # ADT Restrict Start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Resomi
+  # ADT RESTRICT End
   startingGear: BrigmedicGear
   icon: "JobIconBrigmedic"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/ADT/Roles/Jobs/Security/guard_officer.yml
+++ b/Resources/Prototypes/ADT/Roles/Jobs/Security/guard_officer.yml
@@ -7,6 +7,12 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 102000 # 28,33 hrs #ADT-RoleTime
+    # ADT Restrict Start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Resomi
+  # ADT RESTRICT End
   startingGear: GuardOfficerGear
   icon: "JobIconADTGuardOfficer"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/ADT/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/ADT/Roles/Jobs/Security/senior_officer.yml
@@ -16,6 +16,12 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 234000 # 65 hrs #ADT-RoleTime
+    # ADT Restrict Start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Resomi
+  # ADT RESTRICT End
   startingGear: SeniorOfficerGear
   icon: "JobIconSeniorOfficer"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Corvax/Roles/Jobs/Security/pilot.yml
+++ b/Resources/Prototypes/Corvax/Roles/Jobs/Security/pilot.yml
@@ -7,6 +7,12 @@
   - !type:DepartmentTimeRequirement
     department: Security
     time: 72000 #20 hrs
+  # ADT Restrict Start
+  - !type:SpeciesRequirement
+    inverted: true
+    species:
+    - Resomi
+  # ADT RESTRICT End
   startingGear: PilotGear
   icon: "JobIconPilot"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -9,6 +9,12 @@
       time: 10800 # 3 hrs
 #    - !type:OverallPlaytimeRequirement
 #      time: 36000 #10 hrs
+# ADT Restrict Start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Resomi
+  # ADT RESTRICT End
   icon: "JobIconShaftMiner"
   startingGear: SalvageSpecialistGear
   supervisors: job-supervisors-qm

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -18,6 +18,13 @@
 #      time: 54000 # 15 hours
     - !type:OverallPlaytimeRequirement
       time: 504000 #140 hrs # Corvax-RoleTime
+  # ADT Restrict Start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Resomi
+      - Vox
+  # ADT RESTRICT End
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -7,6 +7,12 @@
   - !type:DepartmentTimeRequirement
     department: Security
     time: 90000 #25 hrs # ADT-RoleTime
+  # ADT Restrict Start
+  - !type:SpeciesRequirement
+    inverted: true
+    species:
+    - Resomi
+  # ADT RESTRICT End
   startingGear: DetectiveGear
   icon: "JobIconDetective"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -15,6 +15,12 @@
       time: 198000 #55 hrs # ADT-RoleTime
 #    - !type:OverallPlaytimeRequirement
 #      time: 144000 #40 hrs
+      # ADT Restrict Start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Resomi
+  # ADT RESTRICT End
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -12,6 +12,12 @@
     #   time: 72000 #20 hrs # Corvax-RoleTime
     #   inverted: true # stop playing intern if you're good at security!
 # ADT-Tweak
+# ADT Restrict Start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Resomi
+    # ADT RESTRICT End
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"
   supervisors: job-supervisors-security

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -7,6 +7,12 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 54000 #15 hrs # ADT-RoleTime
+  # ADT Restrict Start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Resomi
+  # ADT RESTRICT End
   startingGear: SecurityOfficerGear
   icon: "JobIconSecurityOfficer"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -7,6 +7,12 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 198000 #55 hrs # ADT-RoleTime
+  # ADT Restrict Start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Resomi
+  # ADT RESTRICT End
   startingGear: WardenGear
   icon: "JobIconWarden"
   supervisors: job-supervisors-hos


### PR DESCRIPTION
## Описание PR
Убрал возможность для резоми брать сб, капитана, осщ и утилей.
у воксов убрана возможность стать капитаном.
![image](https://github.com/user-attachments/assets/78656afa-f2d0-4a26-ade4-c1a2f37ea241)

**Чейнжлоги**
:cl: Filo
- tweak: Резоми были ограничены в выборе ролей.
- tweak: Вокс не станет капитаном
