### PR TITLE
Исправление бага + Локализация Numb

### DIFF
--- a/Resources/Locale/ru-RU/traits/traits.ftl
+++ b/Resources/Locale/ru-RU/traits/traits.ftl
@@ -39,3 +39,5 @@ trait-french-name = Французский акцент
 trait-french-desc = Ваш акцент, похоже, имеет определённый «je ne sais quoi».
 trait-spanish-name = Испанский акцент
 trait-spanish-desc = Hola señor, как пройти в la biblioteca.
+trait-painnumbness-name = Онемевший
+trait-painnumbness-desc = У вас отсутствует какое-либо ощущение боли, вы не осознаете, насколько вам может быть больно.

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -83,7 +83,7 @@
   id: PainNumbness
   name: trait-painnumbness-name
   description: trait-painnumbness-desc
-  category: Quirks #ADT Quirks; mod by Prunt
+  category: Quirks #ADT Quirks; fix by Prunt
   components:
   - type: PainNumbness
   cost: -2 # ADT Quirks; add by Prunt

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -83,6 +83,8 @@
   id: PainNumbness
   name: trait-painnumbness-name
   description: trait-painnumbness-desc
-  category: Disabilities
+  category: Quirks #ADT Quirks; mod by Prunt
   components:
   - type: PainNumbness
+  cost: -2 # ADT Quirks; add by Prunt
+  quirk: true # ADT Quirks; add by Prunt


### PR DESCRIPTION
## Описание PR
Исправление бага с Numb

## Почему / Баланс
Потому-что нада
**Ссылка на публикацию в Discord**

- [Баги](https://discord.com/channels/901772674865455115/1342536015507755109)


## Техническая информация
![image](https://github.com/user-attachments/assets/096a20b4-fa59-4aa9-840e-63d37d7a8e59)

## Медиа
![image](https://github.com/user-attachments/assets/44c0bc01-81a0-4fae-9eac-c90968d907af)

## Требования
<!--
В связи с наплывом ПР'ов нам необходимо убедиться, что ПР'ы следуют правильным рекомендациям.

Пожалуйста, уделите время прочтению, если делаете пулл реквест (ПР) впервые.

Отметьте поля ниже, чтобы подтвердить, что Вы действительно видели их (поставьте X в скобках, например [X]):
-->
- [x] Я прочитал(а) и следую [Руководство по созданию пулл реквестов](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). Я понимаю, что в противном случае мой ПР может быть закрыт по усмотрению мейнтейнера.
- [x] Я добавил скриншоты/видео к этому пулл реквесту, демонстрирующие его изменения в игре, **или** этот пулл реквест не требует демонстрации в игре

## Критические изменения
<!--
Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей, переименования прототипов, и предоставьте инструкции по их исправлению.
-->

**Чейнджлог**

:cl: Prunt 
- fix: Numb был перенесен в категорию Quirks
- add: Добавлена цена за навык как Негативный навык дающий +2 очка к выбору положительного навыка
- add: Добавлена Русская локализация для Numb

