### PR TITLE
sec tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
@@ -29,8 +29,9 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 3
-        Heat: 16
+        Piercing: 14 #ADT tweak
+        # Blunt: 3 ADT tweak
+        # Heat: 16 ADT tweak
 
 - type: entity
   id: BulletLightRifleUranium

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -29,8 +29,9 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 3
-        Heat: 32
+        Piercing: 32 #ADT tweak
+        # Blunt: 3 ADT tweak
+        # Heat: 32 ADT tweak
 
 - type: entity
   id: BulletMagnumAP

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -29,7 +29,8 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 10 #ADT tweak 3->10
+        Piercing: 10 #ADT tweak
+        # Blunt: 3 ADT twea
         # Heat: 14
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -29,8 +29,8 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 2
-        Heat: 14
+        Blunt: 10 #ADT tweak 3->10
+        # Heat: 14
 
 - type: entity
   id: BulletPistolUranium

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -29,8 +29,9 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 2
-        Heat: 15
+        Piercing: 15
+        # Blunt: 15 ADT tweak
+        # Heat: 15 ADT tweak
 
 - type: entity
   id: BulletRifleUranium

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -64,7 +64,8 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 7 #ADT tweak 3-> 7
+        Piercing: 7 #ADT tweak
+        # Blunt: 3 ADT tweak
         # Heat: 7 ADT tweak
   - type: IgnitionSource
     ignited: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -64,8 +64,8 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 3
-        Heat: 7
+        Blunt: 7 #ADT tweak 3-> 7
+        # Heat: 7 ADT tweak
   - type: IgnitionSource
     ignited: true
 

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -6,12 +6,10 @@
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 54000 #15 hrs # ADT-RoleTime
-# ADT-Tweak
-    # - !type:DepartmentTimeRequirement
-    #   department: Security
-    #   time: 72000 #20 hrs # Corvax-RoleTime
-    #   inverted: true # stop playing intern if you're good at security!
-# ADT-Tweak
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 72000 #20 hrs # Corvax-RoleTime
+      inverted: true # stop playing intern if you're good at security!
 # ADT Restrict Start
     - !type:SpeciesRequirement
       inverted: true


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл реквесте? -->
зажигательные больше не наносят настолько много хит урона
кадеты вновь недоступны игрокам с 10+ часов на сб
## Почему / Баланс
<!-- Почему оно было изменено? Ссылайтесь на любые обсуждения или вопросы здесь. Пожалуйста, обсудите, как это повлияет на игровой баланс. -->
**Ссылка на публикацию в Discord**
<!-- Укажите ссылки на соответствующие обсуждения, проблемы, баги, заказы в разработку или предложения
- [Технические проблемы](ссылка)
- [Баги](ссылка)
- [Заказы-разработка](ссылка)
- [Предложения](ссылка)
- [Перенос контента](ссылка)-->

зажигательные патроны становились чуть ли не бронебойками благодаря тому, что от хит урона почти нету защиты, за исключением элитки

в обычном составе сб должно быть ~7-9 человек. Благодаря же постоянно открытым кадетам число сб постоянно доходило до 14, что слишком душно, да и оружия на столько человек нету


## Требования
<!--
В связи с наплывом ПР'ов нам необходимо убедиться, что ПР'ы следуют правильным рекомендациям.

Пожалуйста, уделите время прочтению, если делаете пулл реквест (ПР) впервые.

Отметьте поля ниже, чтобы подтвердить, что Вы действительно видели их (поставьте X в скобках, например [X]):
-->
- [x] Я прочитал(а) и следую [Руководство по созданию пулл реквестов](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). Я понимаю, что в противном случае мой ПР может быть закрыт по усмотрению мейнтейнера.
- [x] Я добавил скриншоты/видео к этому пулл реквесту, демонстрирующие его изменения в игре, **или** этот пулл реквест не требует демонстрации в игре


**Чейнджлог**

🆑 Ratyyy
- tweak: В связи с изменением конструкции, зажигательные снаряды больше не наносят прямой урон ожогами, а исключительно поджигают человека в дополнение к простому урону!
- tweak: Прожжённых офицеров больше не пускают на должность кадетов!
