### PR TITLE
[TWEAK] Убираем радиацию у урановых штук

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pizza.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pizza.yml
@@ -581,9 +581,6 @@
           Quantity: 4
         - ReagentId: Uranium
           Quantity: 16
-  - type: RadiationSource
-    intensity: 0.1
-    slope: 3
 
 - type: entity
   name: slice of spicy rock pizza
@@ -619,9 +616,6 @@
           Quantity: 0.5
         - ReagentId: Uranium
           Quantity: 2
-  - type: RadiationSource
-    intensity: 0.1
-    slope: 3
 
 # Tastes like crust, tomato, cheese, radiation.
 

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -237,14 +237,6 @@
         - ReagentId: Radium
           Quantity: 2
         canReact: false
-  - type: RadiationSource
-    intensity: 0.1
-    slope: 3
-  - type: PointLight
-    radius: 1.2
-    energy: 0.8
-    castShadows: false
-    color: "#9be792"
 
 - type: entity
   parent: SheetUranium

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -452,9 +452,6 @@
         maxRange: 5
       spawns:
       - MobSpawnCrabUranium
-  - type: RadiationSource
-    intensity: 0.2
-    slope: 0.1
 
 - type: entity
   id: AnomalyRockQuartz

--- a/Resources/Prototypes/Entities/Structures/Walls/meteor.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/meteor.yml
@@ -195,9 +195,6 @@
         - map: [ "enum.EdgeLayer.West" ]
           state: rock_asteroid_west
         - state: rock_uranium
-    - type: RadiationSource
-      intensity: 2.3
-      slope: 0.1
 
 - type: entity
   id: MeteorRockBananium


### PR DESCRIPTION
## Описание PR
Убрал радиацию из урановых штук

## Почему / Баланс
Во-первых, механ душное говно
Во-вторых - он создает проблемы с балансом
В-третьих - это уже [сделал](https://github.com/space-wizards/space-station-14/pull/35330) МитолГирСлотх на оффах 

**Чейнджлог**
:cl: Петр
- tweak: Содержащие уран материалы, камни и еда более не фонят
