### PR TITLE
Vox-Slime-Skeleton-Fix

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -113,6 +113,9 @@
   - type: Tag
     tags:
     - Unimplantable
+    - CanPilot
+    - DoorBumpOpener
+    - FootstepSound
 # ADT-Tweak-end
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -29,6 +29,10 @@
   - type: Tag
     tags:
       - ADTSlimeEmotes
+      - CanPilot
+      - DoorBumpOpener
+      - AnomalyHost
+      - FootstepSound
   # ADT-Tweak-SlimeEmotes-END
   - type: UserInterface
     interfaces:

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -48,6 +48,9 @@
   - type: Tag
     tags:
       - ADTVoxEmotes
+      - CanPilot
+      - DoorBumpOpener
+      - FootstepSound
   # ADT-Tweak End
   - type: DamageVisuals
     damageOverlayGroups:

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -51,6 +51,7 @@
       - CanPilot
       - DoorBumpOpener
       - FootstepSound
+      - AnomalyHost
   # ADT-Tweak End
   - type: DamageVisuals
     damageOverlayGroups:


### PR DESCRIPTION
## Описание PR
fix: Теперь воксы, скелеты, слаймолюды могут открывать шлюзы и пилотировать. (и не только)
## Почему / Баланс
Просили - сделали.
https://discord.com/channels/901772674865455115/1347074260614516788/1347074260614516788

## Чейнджлог
:cl: WsWiss
- fix: Теперь Воксы, слаймолюды и скелеты могут открывать шлюзы и пилотировать шаттлы

