### PR TITLE
[Fix] Ops.. Фикс кол зарядов Кэпгана

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -625,8 +625,8 @@
     proto: ADTCapitanRedLaser # Tweak RedMediumLaser -> ADTCapitanRedLaser
     fireCost: 100
   - type: Battery # New - ADT TWEAK
-    maxCharge: 500
-    startingCharge: 500
+    maxCharge: 1500
+    startingCharge: 1500
 # End ADT Tweak
   - type: BatterySelfRecharger
     autoRecharge: true


### PR DESCRIPTION
## Описание PR
Не так понял ПР. Не на 5, а плюс 5.
Увеличил кол зарядов антикварного лазерного пистолета до 15

## Чейнджлог
:cl: NameLunar
- fix: Кол. зарядов антикварного лазерного пистолета поднято до 15. 

