### PR TITLE
чутка добавления БИ и переиначивание осщ

### DIFF
--- a/Content.Server/ADT/Combat/ComboEffects.cs
+++ b/Content.Server/ADT/Combat/ComboEffects.cs
@@ -1,0 +1,21 @@
+using Robust.Shared.Serialization;
+using Content.Server.Chat.Systems;
+using Content.Shared.ADT.Combat;
+namespace Content.Server.ADT.Combat;
+
+/// <summary>
+/// заставляет юзера кричать крутую фразу
+/// </summary>
+[Serializable]
+public sealed partial class ComboSpeechEffect : IComboEffect
+{
+    [DataField]
+    public string Speech;
+
+    public void DoEffect(EntityUid user, EntityUid target, IEntityManager entMan)
+    {
+        var chat = entMan.System<ChatSystem>();
+
+        chat.TrySendInGameICMessage(user, Speech, InGameICChatType.Speak, true, true, checkRadioPrefix: false);  //Speech that isn't sent to chat or adminlogs
+    }
+}

--- a/Content.Shared/ADT/Combat/Systems/ComboSystem.cs
+++ b/Content.Shared/ADT/Combat/Systems/ComboSystem.cs
@@ -56,7 +56,7 @@ public abstract class SharedComboSystem : EntitySystem
         TryDoCombo(uid, args.HitEntities[0], comp);
     }
 
-    private void OnGrab(EntityUid uid, ComboComponent comp, GrabStageChangedEvent args)
+    private void OnGrab(EntityUid uid, ComboComponent comp, ref GrabStageChangedEvent args)
     {
         if (args.Puller.Owner != uid)
             return;
@@ -69,7 +69,8 @@ public abstract class SharedComboSystem : EntitySystem
             comp.CurrestActions.RemoveAt(0);
         }
 
-        TryDoCombo(args.Puller.Owner, args.Pulling.Owner, comp);
+        if (TryDoCombo(args.Puller.Owner, args.Pulling.Owner, comp))
+            args.NewStage = 0;
     }
     private void UseEventOnTarget(EntityUid user, EntityUid target, CombatMove combo)
     {
@@ -78,11 +79,11 @@ public abstract class SharedComboSystem : EntitySystem
             comboEvent.DoEffect(user, target, EntityManager);
         }
     }
-    private void TryDoCombo(EntityUid user, EntityUid target, ComboComponent comp)
+    private bool TryDoCombo(EntityUid user, EntityUid target, ComboComponent comp)
     {
         var mainList = comp.CurrestActions;
         if (mainList == null)
-            return;
+            return false;
         var isComboCompleted = false;
         foreach (var combo in comp.AvailableMoves)
         {
@@ -96,6 +97,7 @@ public abstract class SharedComboSystem : EntitySystem
             comp.CurrestActions.Clear();
         if (TryComp<PullableComponent>(target, out var pulled) && isComboCompleted)
             _pullingSystem.TryStopPull(target, pulled, user);
+        return true;
     }
     public static bool ContainsSubsequence<T>(List<T> mainList, List<T> subList)
     {

--- a/Resources/Prototypes/ADT/Entities/Objects/Specific/material_args.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Specific/material_args.yml
@@ -166,6 +166,8 @@
                 - !type:ComboStunEffect
                   stunTime: 4
                   dropItems: false
+                - !type:ComboSpeechEffect
+                  speech: Прямо позади тебя...
             - actionsNeeds:
                 - Hit
                 - Disarm
@@ -183,6 +185,8 @@
                   damage:
                     types:
                       Blunt: 25
+                - !type:ComboSpeechEffect
+                  speech: Лежать!
             - actionsNeeds:
                 - Disarm
                 - Hit
@@ -195,6 +199,8 @@
                     types:
                       Blunt: 20
                 - !type:ComboDropFromHandsEffect
+                - !type:ComboSpeechEffect
+                  speech: Ку-яя!!
             - actionsNeeds:
                 - Grab
                 - Hit
@@ -208,6 +214,8 @@
                 - !type:ComboStunEffect
                   stunTime: 4
                   dropItems: false
+                - !type:ComboSpeechEffect
+                  speech: Отдохни.
             - actionsNeeds:
                 - Disarm
                 - Disarm
@@ -219,6 +227,8 @@
                     types:
                       Blunt: 5
                 - !type:ComboDropFromHandsEffect
+                - !type:ComboSpeechEffect
+                  speech: Не так быстро.
 
 - type: entity
   id: ADTBookPTCR

--- a/Resources/Prototypes/ADT/Entities/Objects/Weapons/Guns/Revolvers/saber_revolvers.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Weapons/Guns/Revolvers/saber_revolvers.yml
@@ -105,3 +105,13 @@
             - ADTLasgunRevolverCell
   - type: AltFireMelee
     attackType: Heavy
+  - type: Tag
+    tags:
+    - ADTBsoWeapon
+  - type: RMCMagneticItem
+  - type: Clothing
+    sprite: ADT/Objects/Weapons/Guns/Revolvers/mateba.rsi
+    quickEquip: false
+    slots:
+    - Belt
+    - suitStorage

--- a/Resources/Prototypes/ADT/Roles/Jobs/Command/blueshieldofficer.yml
+++ b/Resources/Prototypes/ADT/Roles/Jobs/Command/blueshieldofficer.yml
@@ -44,6 +44,106 @@
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]
+  - !type:AddComponentSpecial
+    components:
+      - type: CantShoot
+        popup: combo-cantshoot
+        whitelist:
+          tags:
+          - ADTBsoWeapon
+      - type: Puller
+        grabStats:
+          None:
+            requiredHands: 1
+            doaftersToEscape: 0
+            movementSpeedModifier: 0.9
+            escapeAttemptTime: 0
+            setStageTime: 0
+          Soft:
+            requiredHands: 1
+            doaftersToEscape: 3
+            movementSpeedModifier: 0.8
+            escapeAttemptTime: 1.2
+            setStageTime: 0
+          Hard:
+            requiredHands: 1
+            doaftersToEscape: 4
+            movementSpeedModifier: 0.75
+            escapeAttemptTime: 1.2
+            setStageTime: 0.75
+          Choke:
+            requiredHands: 2
+            doaftersToEscape: 5
+            movementSpeedModifier: 0.7
+            escapeAttemptTime: 1.25
+            setStageTime: 1.25
+      - type: MeleeWeapon
+        animation: WeaponArcFist
+        damage:
+          types:
+            Blunt: 13
+      - type: Combo
+        availableMoves:
+          - actionsNeeds:
+              - Grab
+              - Hit
+            comboEvent:
+              - !type:ComboPopupEffect
+                localeText: combo-slam-end
+              - !type:ComboDamageEffect
+                damage:
+                  types:
+                    Blunt: 10
+              - !type:ComboFallEffect
+          - actionsNeeds:
+              - Hit
+              - Disarm
+              - Hit
+            comboEvent:
+              - !type:ComboMoreDamageToDownedEffect
+                damage:
+                  types:
+                    Blunt: 20
+              - !type:ComboPopupEffect
+                localeText: combo-cqc-kick-end
+              - !type:ComboDamageEffect
+                damage:
+                  types:
+                    Blunt: 15
+              - !type:ComboStunEffect
+                stunTime: 2
+                dropItems: false
+          - actionsNeeds:
+              - Disarm
+              - Grab
+            comboEvent:
+              - !type:ComboPopupEffect
+                localeText: combo-cqc-pressure-end
+              - !type:ComboStaminaDamageEffect
+                staminaDamage: 65
+          - actionsNeeds:
+              - Grab
+              - Grab
+            comboEvent:
+              - !type:ComboPopupEffect
+                localeText: combo-cqc-restain-end
+              - !type:ComboStunEffect
+                stunTime: 4
+          - actionsNeeds:
+              - Disarm
+              - Disarm
+              - Hit
+            comboEvent:
+              - !type:ComboPopupEffect
+                localeText: combo-cqc-consecutive-end
+              - !type:ComboMoreDamageToDownedEffect
+                damage:
+                  types:
+                    Blunt: 25
+              - !type:ComboFallEffect
+              - !type:ComboStaminaDamageEffect
+                staminaDamage: 60
+
 - type: startingGear
   id: ADTBlueShieldOfficerGear
   equipment:

--- a/Resources/Prototypes/ADT/tags.yml
+++ b/Resources/Prototypes/ADT/tags.yml
@@ -546,3 +546,6 @@
 
 - type: Tag
   id: ADTMinerArmor
+
+- type: Tag
+  id: ADTBsoWeapon

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -498,6 +498,7 @@
     tags:
     - Taser
     - Sidearm
+    - ADTBsoWeapon #ADT tweak
 
 - type: entity
   name: disabler
@@ -538,6 +539,7 @@
   - type: Tag
     tags:
       - Taser
+      - ADTBsoWeapon #ADT tweak
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/disabler_smg.rsi
     layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -75,6 +75,10 @@
     fireRate: 10
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/atreides.ogg
+    selectedMode: Burst #ADT tweak start
+    shotsPerBurst: 2
+    availableModes:
+    - Burst #ADT tweak end
   - type: MagazineVisuals
     magState: mag
     steps: 1


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
у осщ забрали возможность стрелять из всего кроме рево-меча
карпу добавлены спичи
атрейдес понёрфлен

## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс. -->
Ссылка на заказ, предложение или баг-репорт
- [Баг-репорт/Заказ/Предложение](ссылка)-->
https://discord.com/channels/901772674865455115/1349062008271671358

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->
https://discord.com/channels/901772674865455115/1186009225680404600/1349138929772662787

## Чейнджлог

🆑 Ratyyy
- tweak: Совет чести решил, что осщ нельзя использовать ничего из дальнобойнего кроме дизаблеров и своего рево-меча!
- add: Мастера спящего карпа научились говорить крутые фразы!
- fix: Захват после комбо больше не начинается с тяжёлого!
- tweak: В результате действий артефакта атрейдес получил режим стрельбы очередями!
- add: Все осщ получили полноценный cqc без надобности читать книги!
- add: Револьверу осщ добавили встроенный магнит!
