### PR TITLE
Шкуры голиафов, кости и крафт утилизаторского скафандра. И аномалия мартышек.

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/anomaly.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/anomaly.yml
@@ -22,6 +22,7 @@
     - AnomalyFlora
     - AnomalyShadow
     - AnomalyTech
+    - ADTAnomalyMonkey # ADT Tweak
     #- AnomalySanta 
     rareChance: 0.3
     rarePrototypes:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -90,7 +90,7 @@
     - id: FoodMeatGoliath
       amount: 3
     - id: MaterialGoliathHide1
-      amount: 1 # ADT tweak 6>>1
+      amount: 1 # ADT tweak 3>>1
     # ADT tweak start
     - id: MaterialBones1 
       minAmount: 1 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -90,7 +90,9 @@
     - id: FoodMeatGoliath
       amount: 3
     - id: MaterialGoliathHide1
-      amount: 3
+      amount: 1 # ADT tweak 6>>1
+    - id: MaterialBones1 # ADT tweak
+      ammount: 1 # ADT tweak
   - type: Fauna # ADT tweak
   - type: AshStormImmune # ADT tweak
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -93,8 +93,7 @@
       amount: 1 # ADT tweak 3>>1
     # ADT tweak start
     - id: MaterialBones1 
-      minAmount: 1 
-      maxAmount: 4
+      maxAmount: 5
     # ADT tweak end
   - type: Fauna # ADT tweak
   - type: AshStormImmune # ADT tweak

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -92,7 +92,7 @@
     - id: MaterialGoliathHide1
       amount: 1 # ADT tweak 6>>1
     - id: MaterialBones1 # ADT tweak
-      ammount: 1 # ADT tweak
+      amount: 1 # ADT tweak
   - type: Fauna # ADT tweak
   - type: AshStormImmune # ADT tweak
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -93,8 +93,8 @@
       amount: 1 # ADT tweak 3>>1
     # ADT tweak start
     - id: MaterialBones1 
-      MinAmount: 1 
-      MaxAmount: 4
+      minAmount: 1 
+      maxAmount: 4
     # ADT tweak end
   - type: Fauna # ADT tweak
   - type: AshStormImmune # ADT tweak

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -93,8 +93,8 @@
       amount: 1 # ADT tweak 3>>1
     # ADT tweak start
     - id: MaterialBones1 
-      minAmount: 1 
-      maxAmount: 4
+      MinAmount: 1 
+      MaxAmount: 4
     # ADT tweak end
   - type: Fauna # ADT tweak
   - type: AshStormImmune # ADT tweak

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -91,8 +91,11 @@
       amount: 3
     - id: MaterialGoliathHide1
       amount: 1 # ADT tweak 6>>1
-    - id: MaterialBones1 # ADT tweak
-      amount: 1 # ADT tweak
+    # ADT tweak start
+    - id: MaterialBones1 
+      minAmount: 1 
+      maxAmount: 4
+    # ADT tweak end
   - type: Fauna # ADT tweak
   - type: AshStormImmune # ADT tweak
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
@@ -69,6 +69,13 @@
     interactFailureString: petting-failure-generic
     interactSuccessSound:
       path: /Audio/Animals/lizard_happy.ogg
+  # ADT tweak start
+  - type: Butcherable
+    spawned:
+    - id: MaterialBones1 
+      minAmount: 1 
+      maxAmount: 3
+  # ADT tweak end
   - type: Fauna # ADT tweak
   - type: AshStormImmune # ADT tweak
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
@@ -73,7 +73,6 @@
   - type: Butcherable
     spawned:
     - id: MaterialBones1 
-      minAmount: 1 
       maxAmount: 3
   # ADT tweak end
   - type: Fauna # ADT tweak

--- a/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
@@ -73,8 +73,8 @@
   - type: Butcherable
     spawned:
     - id: MaterialBones1 
-      MinAmount: 1 
-      MaxAmount: 3
+      minAmount: 1 
+      maxAmount: 3
   # ADT tweak end
   - type: Fauna # ADT tweak
   - type: AshStormImmune # ADT tweak

--- a/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
@@ -73,8 +73,8 @@
   - type: Butcherable
     spawned:
     - id: MaterialBones1 
-      minAmount: 1 
-      maxAmount: 3
+      MinAmount: 1 
+      MaxAmount: 3
   # ADT tweak end
   - type: Fauna # ADT tweak
   - type: AshStormImmune # ADT tweak

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/goliath_hardsuit.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/goliath_hardsuit.yml
@@ -16,9 +16,7 @@
         amount: 5
         doAfter: 10
       - material: GoliathHide
-        # ADT tweak start Понизил количество шкур для крафта
-        amount: 6
+        amount: 4 # ADT tweak
         doAfter: 10
-        # ADT tweak end Понизил количество шкур для крафта
   - node: hardsuitGoliath
     entity: ClothingOuterHardsuitGoliath

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/goliath_hardsuit.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/goliath_hardsuit.yml
@@ -16,7 +16,9 @@
         amount: 5
         doAfter: 10
       - material: GoliathHide
-        amount: 12
+        # ADT tweak start Понизил количество шкур для крафта
+        amount: 6
         doAfter: 10
+        # ADT tweak end Понизил количество шкур для крафта
   - node: hardsuitGoliath
     entity: ClothingOuterHardsuitGoliath

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/goliath_hardsuit.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/goliath_hardsuit.yml
@@ -16,7 +16,7 @@
         amount: 5
         doAfter: 10
       - material: GoliathHide
-        amount: 4 # ADT tweak
+        amount: 4 # ADT tweak 12 >> 4
         doAfter: 10
   - node: hardsuitGoliath
     entity: ClothingOuterHardsuitGoliath


### PR DESCRIPTION
## Описание PR
Добавил случайное количество костей при разделке голиафов и наблюдателей, а так же понизил количество шкур с голиафов с 3 до 1. Понизил количество шкур для крафта скафандра утилизаторов с 12 до 4. А так же добавил аномалию мартышек в спавнер аномалий.

## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс. -->
Т.к крафты дешёвые, а так же дать возможность делать костяное оружие 
## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог
:cl: RedLis
- tweak: Из-за плохого питания голиафы стали обрастать меньшим количеством шкур.
- tweak: Из-за этого утилизаторам пришлось облегчить схему создания скафандра с шкурами голиафов.
- add: А так же в руководство по разделке для утилизаторов НТ были добавлены обучающие материалы о том как при разделке голиафов и наблюдателей получить кости. 
- fix: Добавил аномалию мартышек в спавнер аномалий.
