### PR TITLE
tweak(src): Изменена сортировка клиентов. Сообщение админ чата отправляется только тем кто имеет флаг AdminChat

### DIFF
--- a/Content.Server/Chat/Managers/ChatManager.cs
+++ b/Content.Server/Chat/Managers/ChatManager.cs
@@ -357,7 +357,12 @@ internal sealed partial class ChatManager : IChatManager
         }
         // End-ADT Tweak
 
-        var clients = _adminManager.ActiveAdmins.Select(p => p.Channel);
+        // var clients = _adminManager.ActiveAdmins.Select(p => p.Channel); // ADT-Comment
+        // ADT-Tweak-start: Сортируем в список клиентов только тех кто имеет флаг Adminchat
+        var clients = _adminManager.ActiveAdmins
+        .Where(admin => _adminManager.GetAdminData(admin)?.Flags.HasFlag(AdminFlags.Adminchat) == true)
+        .Select(p => p.Channel);
+        // ADT-Tweak-end
         var wrappedMessage = Loc.GetString("chat-manager-send-admin-chat-wrap-message",
                                         ("adminChannelName", Loc.GetString("chat-manager-admin-channel-name")),
                                         ("playerName", senderName), ("message", FormattedMessage.EscapeText(message))); // ADT Tweak тут заменил player.Name на senderName


### PR DESCRIPTION
## Описание PR  
Добавлена фильтрация списка активных администраторов, чтобы в `clients` попадали только те, у кого установлен флаг `AdminFlags.Adminchat`.  

## Почему / Баланс  
Ранее `clients` включал всех активных администраторов, вне зависимости от их флагов. Теперь сообщения в админ-чат будут получать только те, у кого есть соответствующий флаг. Это улучшает фильтрацию и предотвращает нежелательную отправку сообщений неподходящим пользователям.  

Ссылка на заказ, предложение или баг-репорт:  
нет такого

## Техническая информация  
- Добавлена фильтрация в `SendAdminChat`, использующая `HasFlag(AdminFlags.Adminchat)`.  
- Теперь `ActiveAdmins` фильтруется по `AdminFlags.Adminchat`, используя `GetAdminData(admin)`.  
- Изменен `Where()` для корректной работы с `Flags`.  

## Медиа  
ъъ

## Чейнджлог  
:cl: Шрёдька
- tweak: Теперь сообщения в админ-чат получают только пользователи с AdminFlags.Adminchat.