### PR TITLE
БиоЗамок "ДНК" на энергоревольвер ОСЩ

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Objects/Weapons/Guns/Revolvers/saber_revolvers.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Weapons/Guns/Revolvers/saber_revolvers.yml
@@ -109,6 +109,7 @@
     tags:
     - ADTBsoWeapon
   - type: RMCMagneticItem
+  - type: DNAGunLocker
   - type: Clothing
     sprite: ADT/Objects/Weapons/Guns/Revolvers/mateba.rsi
     quickEquip: false


### PR DESCRIPTION
## Описание PR
В данном пулл-реквесте был добавлен компонент (`DNAGunLocker`) на энергоревольвер ОСЩ.

## Почему / Баганс
Минимализированны шансы утраты личного оружия ОСЩ. Это по сути единственное чем может пользоваться офицер "синего щита". 

Ссылка на заказ, предложение или баг-репорт:
- [Предложение](https://discord.com/channels/901772674865455115/1350085008349466667)

## Техническая информация
Повесил компонент `DNAGunLocker` на ревик Осщ

## Чейнджлог
:cl: Шрёдька
- add: Энергоревольвер ОСЩ теперь имеет биозамок по Днк.