### PR TITLE
[TWEAK] Шапки и фляги, фляги и шапки

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/Head/hats.yml
@@ -484,6 +484,9 @@
     sprite: ADT/Clothing/Head/Hats/beanies/darkbeanie.rsi
   - type: Clothing
     sprite: ADT/Clothing/Head/Hats/beanies/darkbeanie.rsi
+  - type: TemperatureProtection
+    heatingCoefficient: 1.025
+    coolingCoefficient: 0.5
 
 - type: entity
   parent: ClothingHeadBase
@@ -495,6 +498,9 @@
     sprite: ADT/Clothing/Head/Hats/beanies/bluebeanie.rsi
   - type: Clothing
     sprite: ADT/Clothing/Head/Hats/beanies/bluebeanie.rsi
+  - type: TemperatureProtection
+    heatingCoefficient: 1.025
+    coolingCoefficient: 0.5
 
 - type: entity
   parent: ClothingHeadBase
@@ -506,6 +512,9 @@
     sprite: ADT/Clothing/Head/Hats/beanies/greenbeanie.rsi
   - type: Clothing
     sprite: ADT/Clothing/Head/Hats/beanies/greenbeanie.rsi
+  - type: TemperatureProtection
+    heatingCoefficient: 1.025
+    coolingCoefficient: 0.5
 
 - type: entity
   parent: ClothingHeadBase
@@ -517,6 +526,9 @@
     sprite: ADT/Clothing/Head/Hats/beanies/purplebeanie.rsi
   - type: Clothing
     sprite: ADT/Clothing/Head/Hats/beanies/purplebeanie.rsi
+  - type: TemperatureProtection
+    heatingCoefficient: 1.025
+    coolingCoefficient: 0.5
 
 - type: entity
   parent: ClothingHeadBase
@@ -528,6 +540,9 @@
     sprite: ADT/Clothing/Head/Hats/beanies/redbeanie.rsi
   - type: Clothing
     sprite: ADT/Clothing/Head/Hats/beanies/redbeanie.rsi
+  - type: TemperatureProtection
+    heatingCoefficient: 1.025
+    coolingCoefficient: 0.5
 
 - type: entity
   parent: ClothingHeadBase
@@ -577,3 +592,6 @@
     - state: icon-up
       map: ["foldedLayer"]
       visible: false
+  - type: TemperatureProtection
+    heatingCoefficient: 1.025
+    coolingCoefficient: 0.5

--- a/Resources/Prototypes/ADT/Entities/Mobs/Species/Vulpkanin.yml
+++ b/Resources/Prototypes/ADT/Entities/Mobs/Species/Vulpkanin.yml
@@ -38,7 +38,7 @@
       soundHit:
         path: /Audio/Weapons/pierce.ogg
       angle: 30
-      animation: WeaponArcPunch
+      animation: WeaponArcClaw
       damage:
         types:
           Piercing: 5

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -522,6 +522,9 @@
     - state: icon-up
       map: ["foldedLayer"]
       visible: false
+  - type: TemperatureProtection ##ADT-Tweak
+    heatingCoefficient: 1.025
+    coolingCoefficient: 0.5
 
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -522,9 +522,9 @@
     - state: icon-up
       map: ["foldedLayer"]
       visible: false
-  - type: TemperatureProtection ##ADT-Tweak
+  - type: TemperatureProtection ##ADT-Tweak start
     heatingCoefficient: 1.025
-    coolingCoefficient: 0.5
+    coolingCoefficient: 0.5 ##ADT-Tweak end
 
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_flasks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_flasks.yml
@@ -9,10 +9,10 @@
       Steel: 300
   - type: FitsInDispenser
     solution: drink
-  - type: SolutionContainerManager ##ADT-Tweak
+  - type: SolutionContainerManager ##ADT-Tweak start
     solutions:
       drink:
-        maxVol: 60
+        maxVol: 60 ##ADT-Tweak end
 
 - type: entity
   parent: FlaskBase
@@ -102,10 +102,10 @@
   components:
   - type: Sprite
     sprite: Objects/Consumable/Drinks/vacuumflask.rsi
-  - type: SolutionContainerManager
+  - type: SolutionContainerManager ##ADT-Tweak start
     solutions:
       drink:
-        maxVol: 90
+        maxVol: 90 ##ADT-Tweak end
 
 - type: entity
   parent: FlaskBase

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_flasks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_flasks.yml
@@ -9,6 +9,10 @@
       Steel: 300
   - type: FitsInDispenser
     solution: drink
+  - type: SolutionContainerManager ##ADT-Tweak
+    solutions:
+      drink:
+        maxVol: 60
 
 - type: entity
   parent: FlaskBase
@@ -98,6 +102,10 @@
   components:
   - type: Sprite
     sprite: Objects/Consumable/Drinks/vacuumflask.rsi
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 90
 
 - type: entity
   parent: FlaskBase


### PR DESCRIPTION
## Описание PR
Добавил ушанкам и шапкам защиту от холода, защита такая же как и у зимних ботинков, увеличил количество жидкости помещаемое в фляги на 60, в то время как в термосе все 90 единиц, а также изменил то, что я думаю давно должно было быть таким, атака у вульп теперь выглядит так, как и обязана, как я думаю

## Почему / Баланс
Поступил вот такой вот [заказ](https://discord.com/channels/901772674865455115/1350433053402464268) на защиту от холода, Вот такая вот [публикация](https://discord.com/channels/901772674865455115/1342231294557556776) в переносе контента, а также просто так, ибо, почему бы и нет

## Чейнджлог
:cl: Shizik
- tweak: Шапки из одеждомата, а также шапки ушанки вспомнили о том, что они шапки, и обязаны защищать от холода
- tweak: Нанотрейзен решили усовершенствовать их фляги и термосы, увеличив вместительность
- tweak: Вульпканины вспомнили, что у них есть когти, и они могут ими атаковать (Лишь визуальное изменение.)
