### PR TITLE
Добавление расцветок шлюзов в краскопульт и изменение пульта командования

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
@@ -29,6 +29,15 @@
   - type: Access
     groups:
     - Command
+    #ADT-Tweak-Start
+    - Security
+    - Armory
+    - Service
+    - Engineering
+    - Medical
+    - Cargo
+    - Research
+    #ADT-Tweak-End
 
 - type: entity
   parent: [DoorRemoteDefault, BaseCommandContraband]

--- a/Resources/Prototypes/Entities/Structures/Doors/airlock_groups.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/airlock_groups.yml
@@ -15,6 +15,16 @@
     science:     Structures/Doors/Airlocks/Standard/science.rsi
     security:    Structures/Doors/Airlocks/Standard/security.rsi
     virology:    Structures/Doors/Airlocks/Standard/virology.rsi
+    #ADT-Tweak-Start
+    bar:         ADT/Structures/Doors/Airlocks/Standard/bar.rsi
+    bathroom:    ADT/Structures/Doors/Airlocks/Standard/bathroom.rsi
+    chaplain:    ADT/Structures/Doors/Airlocks/Standard/chaplain.rsi
+    kitchen:     ADT/Structures/Doors/Airlocks/Standard/kitchen.rsi
+    morgue:      ADT/Structures/Doors/Airlocks/Standard/morgue.rsi
+    robotics:    ADT/Structures/Doors/Airlocks/Standard/robotics.rsi
+    salvage:     ADT/Structures/Doors/Airlocks/Standard/salvage.rsi
+    theatre:     ADT/Structures/Doors/Airlocks/Standard/theatre.rsi
+    #ADT-Tweak-End
 
 - type: AirlockGroup
   id: Glass
@@ -33,6 +43,15 @@
     medical:     Structures/Doors/Airlocks/Glass/medical.rsi
     security:    Structures/Doors/Airlocks/Glass/security.rsi
     virology:    Structures/Doors/Airlocks/Glass/virology.rsi
+    #ADT-Tweak-Start
+    bar:         ADT/Structures/Doors/Airlocks/Glass/bar.rsi
+    bathroom:    ADT/Structures/Doors/Airlocks/Glass/bathroom.rsi
+    chaplain:    ADT/Structures/Doors/Airlocks/Glass/chaplain.rsi
+    kitchen:     ADT/Structures/Doors/Airlocks/Glass/kitchen.rsi
+    robotics:    ADT/Structures/Doors/Airlocks/Glass/robotics.rsi
+    salvage:     ADT/Structures/Doors/Airlocks/Glass/salvage.rsi
+    theatre:     ADT/Structures/Doors/Airlocks/Glass/theatre.rsi
+    #ADT-Tweak-End
 
 - type: AirlockGroup
   id: Windoor
@@ -82,3 +101,13 @@
     science: Science
     security: Security
     virology: Medical
+    #ADT-Tweak-Start
+    bar: Civilian
+    bathroom: Civilian
+    chaplain: Civilian
+    kitchen: Civilian
+    morgue: Medical
+    robotics: Science
+    salvage: Cargo
+    theatre: Civilian
+    #ADT-Tweak-End


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
Новые расцветки шлюзов ВП были добавлены в группу для краскопульта, пульт командования получил возможность взаимодействия с шлюзами всех отделов станции. 
Планировалось также добавить отдельный краскопульт для СИ, который мог бы окрашивать в расцветки шлюзов командования, но у меня не срослось с кодом, возможно позже когда-нибудь реализую всё же.
## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс. -->
Ссылка на заказ, предложение или баг-репорт
- [Предложение](https://discord.com/channels/901772674865455115/1334989231768207512)
- [Предложение](https://discord.com/channels/901772674865455115/1350402952250130497)

## Чейнджлог
:cl: Cethet
- tweak: В краскопульте появились новые раскраски для шлюзов.
- tweak: Дистанционный пульт командования получил возможность управлять шлюзами всех отделов на станции.