### PR TITLE
[SHIPBATTLE] Пофиксил видимость профессий для корабельных в консоли айди-карт

### DIFF
--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/Command/captain_kmt.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/Command/captain_kmt.yml
@@ -30,6 +30,7 @@
   supervisors: job-supervisors-kmt-highcommand
   weight: 20
   canBeAntag: false
+  overrideConsoleVisibility: false
   accessGroups:
   - AllAccess
   special:

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/Command/chief_gunner_kmt.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/Command/chief_gunner_kmt.yml
@@ -22,6 +22,7 @@
   supervisors: job-supervisors-kmt-captain
   canBeAntag: false
   weight: 17
+  overrideConsoleVisibility: false
   accessGroups:
   - AllAccess
   special:

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/Command/commander_kmt.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/Command/commander_kmt.yml
@@ -30,6 +30,7 @@
   supervisors: job-supervisors-kmt-captain
   canBeAntag: false
   weight: 19
+  overrideConsoleVisibility: false
   accessGroups:
   - AllAccess
   special:

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/Command/executional_officer_kmt.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/Command/executional_officer_kmt.yml
@@ -30,6 +30,7 @@
   supervisors: job-supervisors-kmt-captain
   canBeAntag: false
   weight: 18
+  overrideConsoleVisibility: false
   accessGroups:
   - AllAccess
   special:

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/Marines/marine_kmt.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/Marines/marine_kmt.yml
@@ -17,6 +17,7 @@
   icon: "JobIconMarineKMT"
   supervisors: job-supervisors-kmt-marine-leutenant
   canBeAntag: false
+  overrideConsoleVisibility: false
   access:
   - Security
   - Brig

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/Marines/marine_leutenant_kmt.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/Marines/marine_leutenant_kmt.yml
@@ -20,6 +20,7 @@
   icon: "JobIconMarineLeutenantKMT"
   joinNotifyCrew: true
   weight: 10
+  overrideConsoleVisibility: false
   supervisors: job-supervisors-kmt-captain
   canBeAntag: false
   accessGroups:

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/ShipCrew/engineer_kmt.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/ShipCrew/engineer_kmt.yml
@@ -17,6 +17,7 @@
   icon: "JobIconEngineerKMT"
   supervisors: job-supervisors-kmt-gunner
   canBeAntag: false
+  overrideConsoleVisibility: false
   access:
   - Security
   - Brig

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/ShipCrew/gunner_kmt.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/ShipCrew/gunner_kmt.yml
@@ -15,6 +15,7 @@
   icon: "JobIconGunnerKMT"
   supervisors: job-supervisors-kmt-gunner
   canBeAntag: false
+  overrideConsoleVisibility: false
   access:
   - Security
   - Brig

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/ShipCrew/medic_kmt.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/ShipCrew/medic_kmt.yml
@@ -17,6 +17,7 @@
   icon: "JobIconMedicKMT"
   supervisors: job-supervisors-kmt-commander
   canBeAntag: false
+  overrideConsoleVisibility: false
   access:
   - Brig
   - Maintenance

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/ShipCrew/navigator_kmt.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/ShipCrew/navigator_kmt.yml
@@ -14,6 +14,7 @@
   icon: "JobIconNavigatorKMT"
   supervisors: job-supervisors-kmt-commander
   canBeAntag: false
+  overrideConsoleVisibility: false
   access:
   - Security
   - Brig

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/ShipCrew/pilot_kmt.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/KMT/ShipCrew/pilot_kmt.yml
@@ -14,6 +14,7 @@
   icon: "JobIconPilotKMT"
   supervisors: job-supervisors-kmt-gunner
   canBeAntag: false
+  overrideConsoleVisibility: false
   access:
   - Security
   - Brig

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/Command/captain_tsf.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/Command/captain_tsf.yml
@@ -30,6 +30,7 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-tsf-highcommand
   weight: 20
+  overrideConsoleVisibility: false
   canBeAntag: false
   accessGroups:
   - AllAccess

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/Command/chief_gunner_tsf.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/Command/chief_gunner_tsf.yml
@@ -23,6 +23,7 @@
   supervisors: job-supervisors-tsf-captain
   canBeAntag: false
   weight: 17
+  overrideConsoleVisibility: false
   accessGroups:
   - AllAccess
   special:

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/Command/commander_tsf.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/Command/commander_tsf.yml
@@ -32,6 +32,7 @@
   supervisors: job-supervisors-tsf-captain
   canBeAntag: false
   weight: 19
+  overrideConsoleVisibility: false
   accessGroups:
   - AllAccess
   special:

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/Command/executional_officer_tsf.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/Command/executional_officer_tsf.yml
@@ -30,6 +30,7 @@
   supervisors: job-supervisors-tsf-captain
   canBeAntag: false
   weight: 18
+  overrideConsoleVisibility: false
   accessGroups:
   - AllAccess
   special:

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/Marines/marine_leutenant_tsf.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/Marines/marine_leutenant_tsf.yml
@@ -22,6 +22,7 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-tsf-captain
   weight: 10
+  overrideConsoleVisibility: false
   canBeAntag: false
   accessGroups:
   - AllAccess

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/Marines/marine_tsf.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/Marines/marine_tsf.yml
@@ -19,6 +19,7 @@
   icon: "JobIconMarineTSF"
   supervisors: job-supervisors-tsf-marine-leutenant
   canBeAntag: false
+  overrideConsoleVisibility: false
   access:
   - Security
   - Brig

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/ShipCrew/engineer_tsf.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/ShipCrew/engineer_tsf.yml
@@ -21,6 +21,7 @@
   icon: "JobIconEngineerTSF"
   supervisors: job-supervisors-tsf-gunner
   canBeAntag: false
+  overrideConsoleVisibility: false
   access:
   - Security
   - Brig

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/ShipCrew/gunner_tsf.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/ShipCrew/gunner_tsf.yml
@@ -17,6 +17,7 @@
   icon: "JobIconGunnerTSF"
   supervisors: job-supervisors-tsf-gunner
   canBeAntag: false
+  overrideConsoleVisibility: false
   access:
   - Security
   - Brig

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/ShipCrew/medic_tsf.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/ShipCrew/medic_tsf.yml
@@ -21,6 +21,7 @@
   icon: "JobIconMedicTSF"
   supervisors: job-supervisors-tsf-commander
   canBeAntag: false
+  overrideConsoleVisibility: false
   access:
   - Brig
   - Maintenance

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/ShipCrew/navigator_tsf.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/ShipCrew/navigator_tsf.yml
@@ -16,6 +16,7 @@
   icon: "JobIconNavigatorTSF"
   supervisors: job-supervisors-tsf-commander
   canBeAntag: false
+  overrideConsoleVisibility: false
   access:
   - Security
   - Brig

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/ShipCrew/pilot_tsf.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Roles/Jobs/TSF/ShipCrew/pilot_tsf.yml
@@ -16,6 +16,7 @@
   icon: "JobIconPilotTSF"
   supervisors: job-supervisors-tsf-gunner
   canBeAntag: false
+  overrideConsoleVisibility: false
   access:
   - Security
   - Brig


### PR DESCRIPTION
## Описание PR
Теперь профессии для корабельных не видны в консоли айди-карт

## Чейнджлог
:cl: Петр
- fix: Фикс видимости профессий для корабельных боёв в консоли айди-карт.

