### PR TITLE
Zauk'er

### DIFF
--- a/Content.Server/ADT/Atmos/Reactions/BZProductionReaction.cs
+++ b/Content.Server/ADT/Atmos/Reactions/BZProductionReaction.cs
@@ -20,9 +20,9 @@ public sealed partial class BZProductionReaction : IGasReactionEffect
         var environmentEfficiency = mixture.Volume / mixture.Pressure;
         var ratioEfficiency = Math.Min(initialNitrousOxide / initialPlasma, 1);
 
-        var bZFormed = Math.Min(0.01f * ratioEfficiency * environmentEfficiency, Math.Min(initialNitrousOxide * 0.4f, initialPlasma * 0.8f));
+        var bZFormed = Math.Min(ratioEfficiency * environmentEfficiency, Math.Min(initialNitrousOxide * 4f, initialPlasma * 8f));
 
-        if (initialNitrousOxide - bZFormed * 0.4f < 0 || initialPlasma - (0.8f - bZFormed) < 0 || bZFormed <= 0)
+        if (initialNitrousOxide - bZFormed * 4f < 0 || initialPlasma - (8f - bZFormed) < 0 || bZFormed <= 0)
             return ReactionResult.NoReaction;
 
         var oldHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture, true);
@@ -31,14 +31,14 @@ public sealed partial class BZProductionReaction : IGasReactionEffect
         var nitrousOxideDecomposedFactor = Math.Max(4.0f * (initialPlasma / (initialNitrousOxide + initialPlasma) - 0.75f), 0);
         if (nitrousOxideDecomposedFactor > 0)
         {
-            amountDecomposed = 0.4f * bZFormed * nitrousOxideDecomposedFactor;
+            amountDecomposed = 4f * bZFormed * nitrousOxideDecomposedFactor;
             mixture.AdjustMoles(Gas.Oxygen, amountDecomposed);
-            mixture.AdjustMoles(Gas.Nitrogen, 0.5f * amountDecomposed);
+            mixture.AdjustMoles(Gas.Nitrogen, 5f * amountDecomposed);
         }
 
         mixture.AdjustMoles(Gas.BZ, Math.Max(0f, bZFormed * (1.0f - nitrousOxideDecomposedFactor)));
-        mixture.AdjustMoles(Gas.NitrousOxide, -0.4f * bZFormed);
-        mixture.AdjustMoles(Gas.Plasma, -0.8f * bZFormed * (1.0f - nitrousOxideDecomposedFactor));
+        mixture.AdjustMoles(Gas.NitrousOxide, -4f * bZFormed);
+        mixture.AdjustMoles(Gas.Plasma, -8f * bZFormed * (1.0f - nitrousOxideDecomposedFactor));
 
         var energyReleased = bZFormed * (Atmospherics.BZFormationEnergy + nitrousOxideDecomposedFactor * (Atmospherics.NitrousOxideDecompositionEnergy - Atmospherics.BZFormationEnergy));
 

--- a/Content.Server/ADT/Atmos/Reactions/HyperNobliumProductionReaction.cs
+++ b/Content.Server/ADT/Atmos/Reactions/HyperNobliumProductionReaction.cs
@@ -24,7 +24,7 @@ public sealed partial class HyperNobliumProductionReaction : IGasReactionEffect
 
         mixture.AdjustMoles(Gas.Tritium, -5f * nobFormed * reductionFactor);
         mixture.AdjustMoles(Gas.Nitrogen, -10f * nobFormed);
-        mixture.AdjustMoles(Gas.HyperNoblium, nobFormed);
+        mixture.AdjustMoles(Gas.HyperNoblium, 0.1f * nobFormed);
 
         var energyReleased = nobFormed * (Atmospherics.NobliumFormationEnergy / Math.Max(initialBZ, 1));
 

--- a/Content.Server/ADT/Atmos/Reactions/PluoxiumProductionReaction.cs
+++ b/Content.Server/ADT/Atmos/Reactions/PluoxiumProductionReaction.cs
@@ -27,7 +27,7 @@ public sealed partial class PluoxiumProductionReaction : IGasReactionEffect
         mixture.AdjustMoles(Gas.Oxygen, -producedAmount * 0.5f);
         mixture.AdjustMoles(Gas.Tritium, -producedAmount * 0.01f);
         mixture.AdjustMoles(Gas.Pluoxium, producedAmount);
-        mixture.AdjustMoles(Gas.Hydrogen, producedAmount * 0.01f);
+        mixture.AdjustMoles(Gas.Hydrogen, producedAmount * 0.5f);
 
         var energyReleased = producedAmount * Atmospherics.PluoxiumFormationEnergy;
 

--- a/Content.Server/ADT/Atmos/Reactions/ZaukerProductionReaction.cs
+++ b/Content.Server/ADT/Atmos/Reactions/ZaukerProductionReaction.cs
@@ -10,24 +10,21 @@ public sealed partial class ZaukerProductionReaction : IGasReactionEffect
 {
     public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem, float heatScale)
     {
-        var initialHyperNoblium = mixture.GetMoles(Gas.HyperNoblium);
-        if (initialHyperNoblium >= 5.0f && mixture.Temperature > 20f)
-            return ReactionResult.NoReaction;
 
         var initialHypernoblium = mixture.GetMoles(Gas.HyperNoblium);
         var initialNitrium = mixture.GetMoles(Gas.Nitrium);
 
         var temperature = mixture.Temperature;
-        var heatEfficiency = Math.Min(temperature * Atmospherics.ZaukerFormationTemperatureScale, Math.Min(initialHypernoblium * 0.01f, initialNitrium * 0.5f));
+        var heatEfficiency = Math.Min(temperature * Atmospherics.ZaukerFormationTemperatureScale, Math.Min(initialHypernoblium * 0.1f, initialNitrium * 0.2f));
 
-        if (heatEfficiency <= 0 || initialHypernoblium - heatEfficiency * 0.01f < 0 || initialNitrium - heatEfficiency * 0.5f < 0)
+        if (heatEfficiency <= 0 || initialHypernoblium - heatEfficiency * 0.1f < 0 || initialNitrium - heatEfficiency * 0.2f < 0)
             return ReactionResult.NoReaction;
 
         var oldHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture, true);
 
-        mixture.AdjustMoles(Gas.HyperNoblium, -heatEfficiency * 0.01f);
-        mixture.AdjustMoles(Gas.Nitrium, -heatEfficiency * 0.5f);
-        mixture.AdjustMoles(Gas.Zauker, heatEfficiency * 0.5f);
+        mixture.AdjustMoles(Gas.HyperNoblium, -heatEfficiency * 0.1f);
+        mixture.AdjustMoles(Gas.Nitrium, -heatEfficiency * 5f);
+        mixture.AdjustMoles(Gas.Zauker, heatEfficiency * 6f);
 
         var energyUsed = heatEfficiency * Atmospherics.ZaukerFormationEnergy;
 

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -389,7 +389,7 @@ namespace Content.Shared.Atmos
         public const float H2OxygenFullBurn = 10f;
         public const float FireH2BurnRateDelta = 2f;
         public const float H2MinimumBurnTemperature = T0C + 100f;
-        public const float NitriumFormationTempDivisor = (T0C + 100f) * 8f;
+        public const float NitriumFormationTempDivisor = (T0C + 100f) * 2f;
         public const float NitriumFormationEnergy = 100000f;
         public const float NitriumDecompositionTempDivisor = (T0C + 100f) * 8f;
         public const float NitriumDecompositionEnergy = 30000f;
@@ -400,7 +400,7 @@ namespace Content.Shared.Atmos
         public const float HalonCombustionEnergy = 2500f;
         public const float HealiumFormationEnergy = 9000f;
         public const float ZaukerFormationEnergy = 5000f;
-        public const float ZaukerFormationTemperatureScale = 0.000005f;
+        public const float ZaukerFormationTemperatureScale = 0.00005f;
         public const float ZaukerDecompositionMaxRate = 20f;
         public const float ZaukerDecompositionEnergy = 460f;
         public const float ProtoNitrateTemperatureScale = 0.005f;

--- a/Resources/Prototypes/ADT/Atmospherics/gases.yml
+++ b/Resources/Prototypes/ADT/Atmospherics/gases.yml
@@ -54,21 +54,21 @@
   gasVisbilityFactor: 500
   color: d97e7e
   reagent: Healium
-  pricePerMole: 24
+  pricePerMole: 40
 
 - type: gas
   id: 14
   name: gases-hyper-noblium
-  specificHeat: 2000
+  specificHeat: 1000
   heatCapacityRatio: 1.3
-  molarMass: 150
+  molarMass: 500
   gasOverlaySprite: /Textures/Effects/atmospherics.rsi
   gasOverlayState: frezon
   gasMolesVisible: 0.1
   gasVisbilityFactor: 1000
   color: 33cccc
   reagent: Hyper-Noblium
-  pricePerMole: 15
+  pricePerMole: 100
 
 - type: gas
   id: 15
@@ -96,7 +96,7 @@
   gasVisbilityFactor: 250
   color: 1c1a1a
   reagent: Zauker
-  pricePerMole: 30
+  pricePerMole: 150
 
 - type: gas
   id: 17

--- a/Resources/Prototypes/ADT/Atmospherics/gases.yml
+++ b/Resources/Prototypes/ADT/Atmospherics/gases.yml
@@ -54,7 +54,7 @@
   gasVisbilityFactor: 500
   color: d97e7e
   reagent: Healium
-  pricePerMole: 12
+  pricePerMole: 24
 
 - type: gas
   id: 14

--- a/Resources/Prototypes/ADT/Atmospherics/reactions.yml
+++ b/Resources/Prototypes/ADT/Atmospherics/reactions.yml
@@ -59,7 +59,7 @@
 - type: gasReaction
   id: NitriumProduction
   priority: 5
-  minimumTemperature: 1500
+  minimumTemperature: 300
   minimumRequirements:
   - 0     # oxygen
   - 10    # nitrogen

--- a/Resources/Prototypes/ADT/Atmospherics/reactions.yml
+++ b/Resources/Prototypes/ADT/Atmospherics/reactions.yml
@@ -59,7 +59,7 @@
 - type: gasReaction
   id: NitriumProduction
   priority: 5
-  minimumTemperature: 300
+  minimumTemperature: 1500
   minimumRequirements:
   - 0     # oxygen
   - 10    # nitrogen
@@ -119,13 +119,13 @@
   maximumTemperature: 27.85
   minimumRequirements:
   - 0     # oxygen
-  - 0     # nitrogen
+  - 10     # nitrogen
   - 0     # carbon dioxide
   - 0     # plasma
   - 5     # tritium
   - 0     # vapor
   - 0     # miasma
-  - 10    # n2o
+  - 0    # n2o
   - 0     # frezon
   - 0     # bz
   - 0     # pluoxium
@@ -201,7 +201,7 @@
 - type: gasReaction
   id: ZaukerProduction
   priority: 9
-  minimumTemperature: 50000
+  minimumTemperature: 20000
   maximumTemperature: 100000
   minimumRequirements:
   - 0     # oxygen
@@ -216,9 +216,9 @@
   - 0     # bz
   - 0     # pluoxium
   - 0     # hydrogen
-  - 0.01  # nitrium
+  - 5   # nitrium
   - 0     # healium
-  - 0.01  # hyper-noblium
+  - 0.1   # hyper-noblium
   - 0     # proto-nitrate
   - 0     # zauker
   - 0     # halon
@@ -230,6 +230,7 @@
 - type: gasReaction
   id: ZaukerDecomposition
   priority: 10
+  minimumTemperature: 373.149
   minimumRequirements:
   - 0     # oxygen
   - 0.01  # nitrogen

--- a/Resources/Prototypes/ADT/Reagents/gases.yml
+++ b/Resources/Prototypes/ADT/Reagents/gases.yml
@@ -211,8 +211,8 @@
         ignoreResistances: true
         damage:
           groups:
-            Brute: -0.5
-            Burn: -0.5
+            Brute: -1.0
+            Burn: -1.0
             Toxin: -1.25
 
 - type: reagent

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -137,11 +137,11 @@
         ignoreResistances: true
         damage:
           types:
-            Blunt: -0.015
-            Slash: -0.015
-            Piercing: -0.015
-            Heat: -0.015
-            Poison: -0.012
+            Blunt: -0.25
+            Slash: -0.25
+            Piercing: -0.25
+            Heat: -0.25
+            Poison: -0.25
       - !type:GenericStatusEffect
         conditions:
         - !type:OrganType


### PR DESCRIPTION
## Описание PR
Я ОЧЕНЬ надеюсь, что данные изменения упростят процесс варки Заукера и его составных газов, и позволят карго богатеть от атмоса ХОТЯБЫ на полутора часах смены. Заукер, так как сам по себе является противным по рецепту, теперь же должен вариться больше, и легче (Если есть составные газы). Теперь Гипер-Ноблиум это увесистый бродяга, запрещающий все прочие реакции. Для хорошего количества заукера достаточно 5 моль ноблия в каждой клетке камеры, и 40 моль нитриума. Если этот пр замёржат, я попробую выпустить руководство по заукеру.. или хотя бы какие нибудь советы.. 

![image](https://github.com/user-attachments/assets/abeeea0b-a580-4d82-b970-d49b39949f8c)

А Ещё я хочу вырезать нахер проверку в газовом фильтре у визардов про его выход, что если на ноде выхода у фильтра давление >4.5 кПа то он затыкает ебальник и перестаёт работать ибо это бред ёбаный, но не знаю стоит ли

![image](https://github.com/user-attachments/assets/0b119a93-422d-4c7d-955f-7c86eb53abda)

## Чейнджлог

:cl: WsWiss
- fix: Упрощён процесс варки Заукера и нужных для него газов
- fix: Теперь Заукер не сгорает в станционных 101.3 кПа 22:78 O2/N2
- fix: Хилиум теперь лучше вылечивает организмы
- fix: Плазма теперь существеннее лечит новакидов 
