### PR TITLE
Небольшие изменения атмоса.

### DIFF
--- a/Content.Server/EntityEffects/Effects/PlantMutateGases.cs
+++ b/Content.Server/EntityEffects/Effects/PlantMutateGases.cs
@@ -18,6 +18,35 @@ public sealed partial class PlantMutateExudeGasses : EntityEffect
     [DataField]
     public float MaxValue = 0.5f;
 
+    private static readonly Dictionary<Gas, float> GasWeights = new()
+    {
+        // Standard chance
+        { Gas.CarbonDioxide, 1.0f },
+        { Gas.WaterVapor,    1.0f },
+        { Gas.Ammonia,       1.0f },
+        { Gas.NitrousOxide,  1.0f },
+        { Gas.Oxygen,        0.8f },
+        { Gas.Nitrogen,      0.8f },
+
+        // Rare chance
+        { Gas.Healium,       0.7f },
+        { Gas.Nitrium,       0.7f },
+        { Gas.BZ,            0.6f },
+        { Gas.Pluoxium,      0.6f },
+        { Gas.Helium,        0.6f },
+        { Gas.Hydrogen,      0.5f },
+        { Gas.Plasma,        0.5f },
+        { Gas.ProtoNitrate,  0.5f },
+        { Gas.Tritium,       0.5f },
+        { Gas.HyperNoblium,  0.4f },
+        { Gas.Halon,         0.4f },
+
+        // Minimum chance
+        { Gas.Zauker,        0.3f },
+        { Gas.Frezon,        0.2f },
+        { Gas.AntiNoblium,   0.1f },
+    };
+
     public override void Effect(EntityEffectBaseArgs args)
     {
         var plantholder = args.EntityManager.GetComponent<PlantHolderComponent>(args.TargetEntity);
@@ -28,9 +57,9 @@ public sealed partial class PlantMutateExudeGasses : EntityEffect
         var random = IoCManager.Resolve<IRobustRandom>();
         var gasses = plantholder.Seed.ExudeGasses;
 
-        // Add a random amount of a random gas to this gas dictionary
         float amount = random.NextFloat(MinValue, MaxValue);
-        Gas gas = random.Pick(Enum.GetValues(typeof(Gas)).Cast<Gas>().ToList());
+        Gas gas = PickWeightedGas(random);
+
         if (gasses.ContainsKey(gas))
         {
             gasses[gas] += amount;
@@ -39,6 +68,22 @@ public sealed partial class PlantMutateExudeGasses : EntityEffect
         {
             gasses.Add(gas, amount);
         }
+    }
+
+    private static Gas PickWeightedGas(IRobustRandom random)
+    {
+        var totalWeight = GasWeights.Values.Sum();
+        var pick = random.NextFloat(0f, totalWeight);
+        float cumulative = 0f;
+
+        foreach (var (gas, weight) in GasWeights)
+        {
+            cumulative += weight;
+            if (pick <= cumulative)
+                return gas;
+        }
+
+        return Gas.Oxygen; // fallback
     }
 
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
@@ -57,6 +102,36 @@ public sealed partial class PlantMutateConsumeGasses : EntityEffect
 
     [DataField]
     public float MaxValue = 0.5f;
+
+    private static readonly Dictionary<Gas, float> GasWeights = new()
+    {
+        // Standard chance
+        { Gas.CarbonDioxide, 1.0f },
+        { Gas.WaterVapor,    1.0f },
+        { Gas.Ammonia,       1.0f },
+        { Gas.NitrousOxide,  1.0f },
+        { Gas.Oxygen,        0.8f },
+        { Gas.Nitrogen,      0.8f },
+
+        // Rare chance
+        { Gas.Healium,       0.7f },
+        { Gas.Nitrium,       0.7f },
+        { Gas.BZ,            0.6f },
+        { Gas.Pluoxium,      0.6f },
+        { Gas.Helium,        0.6f },
+        { Gas.Hydrogen,      0.5f },
+        { Gas.Plasma,        0.5f },
+        { Gas.ProtoNitrate,  0.5f },
+        { Gas.Tritium,       0.5f },
+        { Gas.HyperNoblium,  0.4f },
+        { Gas.Halon,         0.4f },
+
+        // Minimum chance
+        { Gas.Zauker,        0.3f },
+        { Gas.Frezon,        0.2f },
+        { Gas.AntiNoblium,   0.1f },
+    };
+
     public override void Effect(EntityEffectBaseArgs args)
     {
         var plantholder = args.EntityManager.GetComponent<PlantHolderComponent>(args.TargetEntity);
@@ -67,9 +142,9 @@ public sealed partial class PlantMutateConsumeGasses : EntityEffect
         var random = IoCManager.Resolve<IRobustRandom>();
         var gasses = plantholder.Seed.ConsumeGasses;
 
-        // Add a random amount of a random gas to this gas dictionary
         float amount = random.NextFloat(MinValue, MaxValue);
-        Gas gas = random.Pick(Enum.GetValues(typeof(Gas)).Cast<Gas>().ToList());
+        Gas gas = PickWeightedGas(random);
+
         if (gasses.ContainsKey(gas))
         {
             gasses[gas] += amount;
@@ -78,6 +153,22 @@ public sealed partial class PlantMutateConsumeGasses : EntityEffect
         {
             gasses.Add(gas, amount);
         }
+    }
+
+    private static Gas PickWeightedGas(IRobustRandom random)
+    {
+        var totalWeight = GasWeights.Values.Sum();
+        var pick = random.NextFloat(0f, totalWeight);
+        float cumulative = 0f;
+
+        foreach (var (gas, weight) in GasWeights)
+        {
+            cumulative += weight;
+            if (pick <= cumulative)
+                return gas;
+        }
+
+        return Gas.Oxygen; // fallback
     }
 
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)

--- a/Content.Server/EntityEffects/Effects/PlantMutateGases.cs
+++ b/Content.Server/EntityEffects/Effects/PlantMutateGases.cs
@@ -18,6 +18,7 @@ public sealed partial class PlantMutateExudeGasses : EntityEffect
     [DataField]
     public float MaxValue = 0.5f;
 
+    // ADT-Tweak-Start
     private static readonly Dictionary<Gas, float> GasWeights = new()
     {
         // Standard chance
@@ -46,6 +47,7 @@ public sealed partial class PlantMutateExudeGasses : EntityEffect
         { Gas.Frezon,        0.2f },
         { Gas.AntiNoblium,   0.1f },
     };
+    // ADT-Tweak-End
 
     public override void Effect(EntityEffectBaseArgs args)
     {
@@ -70,6 +72,7 @@ public sealed partial class PlantMutateExudeGasses : EntityEffect
         }
     }
 
+    // ADT-Tweak-Start
     private static Gas PickWeightedGas(IRobustRandom random)
     {
         var totalWeight = GasWeights.Values.Sum();
@@ -85,6 +88,7 @@ public sealed partial class PlantMutateExudeGasses : EntityEffect
 
         return Gas.Oxygen; // fallback
     }
+    // ADT-Tweak-End
 
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
     {
@@ -103,6 +107,7 @@ public sealed partial class PlantMutateConsumeGasses : EntityEffect
     [DataField]
     public float MaxValue = 0.5f;
 
+    // ADT-Tweak-Start
     private static readonly Dictionary<Gas, float> GasWeights = new()
     {
         // Standard chance
@@ -131,6 +136,7 @@ public sealed partial class PlantMutateConsumeGasses : EntityEffect
         { Gas.Frezon,        0.2f },
         { Gas.AntiNoblium,   0.1f },
     };
+    // ADT-Tweak-End
 
     public override void Effect(EntityEffectBaseArgs args)
     {
@@ -155,6 +161,7 @@ public sealed partial class PlantMutateConsumeGasses : EntityEffect
         }
     }
 
+    // ADT-Tweak-Start
     private static Gas PickWeightedGas(IRobustRandom random)
     {
         var totalWeight = GasWeights.Values.Sum();
@@ -170,6 +177,7 @@ public sealed partial class PlantMutateConsumeGasses : EntityEffect
 
         return Gas.Oxygen; // fallback
     }
+    // ADT-Tweak-End
 
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
     {

--- a/Resources/Prototypes/ADT/Atmospherics/reactions.yml
+++ b/Resources/Prototypes/ADT/Atmospherics/reactions.yml
@@ -87,7 +87,7 @@
 - type: gasReaction
   id: NitriumDecomposition
   priority: 6
-  maximumTemperature: 343.15
+  maximumTemperature: 600.324
   minimumRequirements:
   - 0.01  # oxygen
   - 0     # nitrogen

--- a/Resources/Prototypes/ADT/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/ADT/Catalog/Cargo/cargo_atmospherics.yml
@@ -1,0 +1,29 @@
+- type: cargoProduct
+  id: ADTAtmosphericsHydrogen
+  icon:
+    sprite: ADT/Structures/Storage/canister.rsi
+    state: h2
+  product: ADTHydrogenCanister
+  cost: 4000
+  category: cargoproduct-category-name-atmospherics
+  group: market
+
+- type: cargoProduct
+  id: ADTTegCenter
+  icon:
+    sprite: Structures/Power/Generation/teg.rsi
+    state: teg
+  product: TegCenter
+  cost: 30000
+  category: cargoproduct-category-name-atmospherics
+  group: market
+
+- type: cargoProduct
+  id: ADTTegCirculator
+  icon:
+    sprite: Structures/Power/Generation/teg.rsi
+    state: circ-0
+  product: TegCirculator
+  cost: 10000
+  category: cargoproduct-category-name-atmospherics
+  group: market

--- a/Resources/Prototypes/ADT/Reagents/gases.yml
+++ b/Resources/Prototypes/ADT/Reagents/gases.yml
@@ -117,6 +117,16 @@
         ratios:
           CarbonDioxide: 1.0
           Pluoxium: -1.0
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Vox
+        scaleByQuantity: true
+        ignoreResistances: true
+        damage:
+          types:
+            Poison:
+              15
 
 - type: reagent
   id: Hydrogen
@@ -141,40 +151,21 @@
     Gas:
       effects:
       - !type:MovespeedModifier
-        conditions:
-          - !type:ReagentThreshold
-            reagent: Nitrium
-            min: 3
-        statusLifetime: 0.5
-        walkSpeedModifier: 1.5
-        sprintSpeedModifier: 2.5
+        walkSpeedModifier: 1.35
+        sprintSpeedModifier: 1.35
       - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-            min: 10
         key: Stun
-        time: 1
+        time: 3
         type: Remove
       - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-            min: 15
         key: KnockedDown
-        time: 5
-        type: Remove
-      - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-            min: 15
-        key: ForcedSleep
-        component: ForcedSleeping
-        time: 15
+        time: 3
         type: Remove
       - !type:HealthChange
         conditions:
           - !type:ReagentThreshold
             reagent: Nitrium
-            min: 20
+            min: 10
         scaleByQuantity: true
         ignoreResistances: true
         damage:
@@ -294,6 +285,36 @@
   color: "#005959"
   boilingPoint: -253.0
   meltingPoint: -259.2
+  metabolisms:
+    Gas:
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Helium
+          min: 1
+          max: 8
+        scaleByQuantity: true
+        ignoreResistances: true
+        damage:
+          groups:
+            Brute: -1.5
+            Burn: -2
+          types:
+            Asphyxiation: -0.5
+            Poison: -0.5
+      - !type:GenericStatusEffect
+        conditions:
+        - !type:ReagentThreshold
+          reagent: NitrousOxide
+          min: 1
+        - !type:OrganType
+          type: Slime
+          shouldHave: false
+        key: ForcedSleep
+        component: ForcedSleeping
+        time: 5
+        type: Add
 
 - type: reagent
   id: Anti-Noblium

--- a/Resources/Prototypes/ADT/Reagents/gases.yml
+++ b/Resources/Prototypes/ADT/Reagents/gases.yml
@@ -188,10 +188,10 @@
         conditions:
         - !type:ReagentThreshold
           reagent: Healium
-          min: 2
+          min: 1
         key: ForcedSleep
         component: ForcedSleeping
-        time: 3
+        refresh: false
         type: Add
       - !type:HealthChange
         conditions:
@@ -202,9 +202,12 @@
         ignoreResistances: true
         damage:
           groups:
-            Brute: -1.25
-            Burn: -1.25
-            Toxin: -1.5
+            Brute: -1.5
+            Burn: -2
+          types:
+            Asphyxiation: -0.5
+            Poison: -0.5
+
 
 - type: reagent
   id: Hyper-Noblium
@@ -285,36 +288,6 @@
   color: "#005959"
   boilingPoint: -253.0
   meltingPoint: -259.2
-  metabolisms:
-    Gas:
-      effects:
-      - !type:HealthChange
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Helium
-          min: 1
-          max: 8
-        scaleByQuantity: true
-        ignoreResistances: true
-        damage:
-          groups:
-            Brute: -1.5
-            Burn: -2
-          types:
-            Asphyxiation: -0.5
-            Poison: -0.5
-      - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-          reagent: NitrousOxide
-          min: 1
-        - !type:OrganType
-          type: Slime
-          shouldHave: false
-        key: ForcedSleep
-        component: ForcedSleeping
-        time: 5
-        type: Add
 
 - type: reagent
   id: Anti-Noblium


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
  Теперь ТЭГ добавлен в покупку. 30 000 За центральную часть и 10 000 за циркулярный насос.
  Канистра водорода была добавлена в покупку за 4 000
  
  Нитриум теперь более значительно ускоряет.
  Декомпозиционная реакция Нитриума теперь будет происходить при температуре меньше 600 Кельвинов.
  
  Хиллиум теперь не выводит радиацию.
  Хиллиум теперь лечит удушье.
  Хиллиум теперь усыпляет сильние и не дает проснутся самому.
  
  Более глобальное. В список газов, от мутаций растений добавлены шансы на генерацию разных газов. Разделен на 
  обычный/редкий/минимальный. Собственно газы которые находятся в обычной категории, будут появлятся в мутации 
  чаще, чем редкие.

## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс. -->
Ссылка на заказ, предложение или баг-репорт
- [Баг-репорт/Заказ/Предложение](ссылка)-->

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог

:cl: M1and1B
- add: Добавлен ТЭГ и канистра водорода в покупку
- tweak: Изменен рандомайзер газов в мутациях растений.
- tweak: Изменено лечение Хиллиума
- tweak: Изменено ускорение Нитриума

