### PR TITLE
Фикс локали

### DIFF
--- a/Content.Server/Silicons/Laws/IonStormSystem.cs
+++ b/Content.Server/Silicons/Laws/IonStormSystem.cs
@@ -275,6 +275,6 @@ public sealed class IonStormSystem : EntitySystem
     private string Pick(string name)
     {
         var dataset = _proto.Index<LocalizedDatasetPrototype>(name); //ADT_Fix - DatasetPrototype to LocalizedDatasetPrototype
-        return _robustRandom.Pick(dataset.Values);
+        return Loc.GetString(_robustRandom.Pick(dataset.Values));
     }
 }

--- a/Resources/Locale/ru-RU/station-events/events/ion-storm.ftl
+++ b/Resources/Locale/ru-RU/station-events/events/ion-storm.ftl
@@ -14,7 +14,7 @@ ion-storm-x-and-y = { $x } И { $y }
 # subjects can generally be threats or jobs or objects
 # thing is specified above it
 ion-storm-law-on-station = ОБНАРУЖЕНЫ { $joined } { $subjects } НА СТАНЦИИ
-ion-storm-law-no-shuttle = ШАТТЛ НЕ МОЖЕТ БЫТЬ ВЫЗВАН ПО ПРИЧИНЕ ПРИСУТСТВИЯ { $joined } { $subjects } НА СТАНЦИИ
+ion-storm-law-call-shuttle = ШАТТЛ ДОЛЖЕН БЫТЬ ВЫЗВАН ПО ПРИЧИНЕ ПРИСУТСТВИЯ {$joined} {$subjects} НА СТАНЦИИ
 ion-storm-law-crew-are = ВСЕ { $who } ТЕПЕРЬ { $joined } { $subjects }
 ion-storm-law-subjects-harmful = { $adjective } { $subjects } ПРИЧИНЯЮТ ВРЕД ЗДОРОВЬЮ ЭКИПАЖА
 ion-storm-law-must-harmful = ВСЕ КТО { $must } ПРИЧИНЯЮТ ВРЕД ЗДОРОВЬЮ ЭКИПАЖА

--- a/Resources/Prototypes/Datasets/Names/military.yml
+++ b/Resources/Prototypes/Datasets/Names/military.yml
@@ -1,17 +1,17 @@
 - type: localizedDataset
-  id: NamesMilitaryFirstLeader
+  id: NamesFirstMilitaryLeader #ADT-Tweak
   values:
     prefix: names-military-leader-first-dataset-
     count: 5 # Corvax-MRP-Edit
 
 - type: localizedDataset
-  id: NamesMilitaryFirst
+  id: NamesFirstMilitary #ADT-Tweak
   values:
     prefix: names-military-first-dataset-
     count: 5 # Corvax-MRP-Edit
 
 - type: localizedDataset
-  id: NamesMilitaryLast
+  id: NamesLastMilitary #ADT-Tweak
   values:
     prefix: names-military-last-dataset-
     count: 43 # Corvax-MRP-Edit

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -76,10 +76,10 @@
   - type: RandomMetadata
     nameSegments:
     # - The # ADT CHANGE
-    - RevenantType
+    - NamesRevenantType
+    - NamesRevenantAdjective
+    - NamesRevenantTheme
     # - of # ADT CHANGE
-    - RevenantAdjective
-    - RevenantTheme
   - type: Speech
     speechVerb: Ghost
   - type: ShowHealthBars


### PR DESCRIPTION
## Описание PR
Пофиксила локаль ревенанту, ERTшников и законов ионного шторма у киборгов.
## Почему / Баланс
Ссылка на заказ, предложение или баг-репорт
- [Баг-репорт](https://discord.com/channels/901772674865455115/1361644356993417436)
- [Баг-репорт](https://discord.com/channels/901772674865455115/1360819887773192402)

## Техническая информация

## Медиа

## Чейнджлог
:cl: Cethet
- fix: Исправлена локализация имён ревенанта, бойцов ОБР и законов киборгов после ионнного шторма
