### PR TITLE
Сканер масс снова стал маленьким

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
@@ -5,7 +5,7 @@
   description: A hand-held mass scanner.
   components:
   - type: Item
-    size: Normal
+    size: Small #ADT-tweak
     sprite: Objects/Tools/handheld_mass_scanner.rsi
   - type: Sprite
     sprite: Objects/Tools/handheld_mass_scanner.rsi
@@ -50,7 +50,7 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
   - type: Item
-    size: Normal
+    size: Small #ADT-tweak
     sprite: Objects/Tools/handheld_mass_scanner.rsi
   - type: Sprite
     sprite: Objects/Tools/handheld_mass_scanner.rsi


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
Размер ручного сканера масс снова сталь маленьким (2 на 1)
## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс. -->
Ссылка на заказ, предложение или баг-репорт
- [Баг-репорт/Заказ/Предложение](ссылка)--> https://discord.com/channels/901772674865455115/1358507352093102233

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог

:cl: SBatAod
- tweak: Размер ручного сканера масс изменён на маленький (2 на 1)
