### PR TITLE
крю трансфер

### DIFF
--- a/Content.Server/ADT/GameTicking/Rules/Components/CrewTransferSchedulerComponent.cs
+++ b/Content.Server/ADT/GameTicking/Rules/Components/CrewTransferSchedulerComponent.cs
@@ -1,0 +1,6 @@
+﻿namespace Content.Server.GameTicking.Rules.Components;
+
+[RegisterComponent]
+public sealed partial class CrewTransferSchedulerComponent : Component
+{
+}

--- a/Content.Server/ADT/GameTicking/Rules/CrewTransferSchedulerSystem.cs
+++ b/Content.Server/ADT/GameTicking/Rules/CrewTransferSchedulerSystem.cs
@@ -1,0 +1,63 @@
+using Content.Server.GameTicking.Rules.Components;
+using Robust.Shared.Map;
+using Content.Shared.GameTicking.Components;
+using Robust.Shared.EntitySerialization.Systems;
+using Content.Server.RoundEnd;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+using Content.Server.Voting;
+using Content.Server.Voting.Managers;
+using Content.Server.Chat.Managers;
+
+namespace Content.Server.GameTicking.Rules;
+
+/// <summary>
+/// Every X minutes starts vote for crew transfer
+/// </summary>
+public sealed class CrewTransferSchedulerSystem : GameRuleSystem<CrewTransferSchedulerComponent>
+{
+    [Dependency] private readonly IChatManager _chatManager = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly RoundEndSystem _roundEndSystem = default!;
+    [Dependency] private readonly IVoteManager _voteManager = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+    }
+
+    protected override void Started(EntityUid uid, CrewTransferSchedulerComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+        var options = new VoteOptions
+        {
+            InitiatorText = Loc.GetString("crew-transfer-sender"),
+            Title = Loc.GetString("ui-vote-crew-transfer-title"),
+            Options =
+            {
+                (Loc.GetString("ui-vote-crew-transfer-yes"), "yes"),
+                (Loc.GetString("ui-vote-crew-transfer-no"), "no")
+            },
+            Duration = TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VoteTimerRestart)),
+            InitiatorTimeout = TimeSpan.FromMinutes(5)
+        };
+        var vote = _voteManager.CreateVote(options);
+        vote.OnFinished += (_, eventArgs) =>
+        {
+            if (eventArgs.Winner == null)
+            {
+                _chatManager.DispatchServerAnnouncement(Loc.GetString("ui-vote-crew-transfer-fail"));
+                return;
+            }
+            if ((string)eventArgs.Winner == Loc.GetString("ui-vote-crew-transfer-no"))
+            {
+                _chatManager.DispatchServerAnnouncement(Loc.GetString("ui-vote-crew-transfer-no"));
+            } else
+            {
+                _roundEndSystem.DoRoundEndBehavior(RoundEndBehavior.ShuttleCall,
+                TimeSpan.FromMinutes(10),
+                "crew-transfer-sender",
+                "crew-transfer-sended");
+            }
+        };
+    }
+}

--- a/Resources/Locale/ru-RU/ADT/vote/crew-transfer.ftl
+++ b/Resources/Locale/ru-RU/ADT/vote/crew-transfer.ftl
@@ -1,0 +1,6 @@
+ui-vote-crew-transfer-title = Смена экипажа
+ui-vote-crew-transfer-yes = Да, начать смену экипажа
+ui-vote-crew-transfer-no = Нет, продолжить смену
+ui-vote-crew-transfer-fail = Ничья. Смена продолжается!
+crew-transfer-sender = Система смены экипажа
+crew-transfer-sended = Процедура смены экипажа начата. Шаттл вызван. Он прибудет через: { $time } { $units }.

--- a/Resources/Prototypes/ADT/GameRules/crew_transfer.yml
+++ b/Resources/Prototypes/ADT/GameRules/crew_transfer.yml
@@ -1,0 +1,25 @@
+- type: entity
+  parent: BaseGameRule
+  id: CrewTransferScheduler
+  components:
+  - type: GameRule
+  - type: BasicStationEventScheduler
+    minimumTimeUntilFirstEvent: 5400 # 90 min
+    minMaxEventTiming:
+      min: 1800 # 30 min
+      max: 1800 # 30 min
+    scheduledGameRules: !type:NestedSelector
+      tableId: CrewTransferEventsTable
+
+- type: entity
+  parent: BaseGameRule
+  id: CrewTransferStart
+  components:
+  - type: GameRule
+  - type: CrewTransferScheduler
+
+- type: entityTable
+  id: CrewTransferEventsTable
+  table: !type:AllSelector
+    children:
+    - id: CrewTransferStart

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -53,6 +53,13 @@
 
 - type: entity
   parent: BaseGameRule
+  id: CrewTransferScheduler
+  components:
+  - type: GameRule
+  - type: CrewTransferScheduler
+
+- type: entity
+  parent: BaseGameRule
   id: MeteorSwarmScheduler
   components:
   - type: GameRule

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -53,13 +53,6 @@
 
 - type: entity
   parent: BaseGameRule
-  id: CrewTransferScheduler
-  components:
-  - type: GameRule
-  - type: CrewTransferScheduler
-
-- type: entity
-  parent: BaseGameRule
   id: MeteorSwarmScheduler
   components:
   - type: GameRule


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
добавляет крю трансфер - систему, что работает примерно так:
на 90 минуте запускается голосование за вызов эвакуации. Это голосование будет запускаться заново каждые следующие 30 минут, если эвак не был вызван

## Почему / Баланс

тестим, может будет лучше, чем текущий вариант

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->
![image](https://github.com/user-attachments/assets/97f65941-e993-4bac-9078-cd41de7a1de5)
![image](https://github.com/user-attachments/assets/9527e29c-42ff-47bd-a7ea-913e1806dca2)

## Чейнджлог


:cl: Ratyyy
- add: Цк устали самостоятельно назначать эвак, потому за это теперь отвечает автоматическая система!

