### PR TITLE
[FIX] Поправлено расположение оружейных модулей

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -87,6 +87,11 @@
         whitelist:
           tags:
             - CartridgeLightRifle
+  - type: AttachableHolderVisuals
+    offsets:
+      rmc-aslot-underbarrel: 0.25, -0.125
+      rmc-aslot-rail: 0, 0
+      rmc-aslot-barrel: 0.96875, 0
 
 - type: entity
   name: TAR-60SF
@@ -105,6 +110,11 @@
     sprite: ADT/Objects/Weapons/Guns/Rifles/tar60sf.rsi
   - type: Gun
     fireRate: 5.5
+  - type: AttachableHolderVisuals
+    offsets:
+      rmc-aslot-underbarrel: 0.34375, -0.125
+      rmc-aslot-rail: 0.03125, -0.09375
+      rmc-aslot-barrel: 0.96875, 0
 
 - type: entity
   name: xC67

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -271,8 +271,8 @@
             - ADTAttachmentT2Miniscope
   - type: AttachableHolderVisuals
     offsets:
-      rmc-aslot-underbarrel: 0.345, -0.125
-      rmc-aslot-rail: -0.1185, -0.0325
+      rmc-aslot-underbarrel: 0.25, -0.14
+      rmc-aslot-rail: -0.03125, -0.09375
 # ADT TWEAK END
 
 - type: entity


### PR DESCRIPTION
## Описание PR
Поправлено расположение оружейных модулей на лазерной винтовке, AR-12 и TAR-60

## Чейнджлог
:cl: Петр
- fix: Исправлено отображение модулей на лазерной винтовке, AR-12 и TAR-60

