### PR TITLE
[TWEAK] Ап травматических патронов

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -26,7 +26,7 @@
       types:
         Blunt: 10
   - type: StaminaDamageOnCollide
-    damage: 40 # 3 hits to stun
+    damage: 55 # ADT-Tweak - 40 to 55. Возврат старого значения урона по стамине, когда заряженной двухстволки хватало для остановки хама
 
 - type: entity
   id: PelletShotgun


### PR DESCRIPTION
## Описание PR
Урон по стамине травматического патрона дробовика увеличен до 55, как было в давние хорошие времена

## Почему / Баланс
Чтобы хамло в баре огребало

## Чейнджлог
:cl: Петр
- tweak: Урон по стамине травматического патрона дробовика увеличен с 40 до 55

