### PR TITLE
Фикс коллизии голопада и КПК

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Devices/pda.yml
@@ -31,6 +31,7 @@
     preinstalled:
       - CrewManifestCartridge
       - NotekeeperCartridge
+      - NanoTaskCartridge
       - NewsReaderCartridge
       - MedTekCartridge
       - ADTWalletCartridge # ADT-Economy
@@ -45,6 +46,7 @@
     preinstalled:
     - CrewManifestCartridge
     - NotekeeperCartridge
+    - NanoTaskCartridge
     - NewsReaderCartridge
     - WantedListCartridge
     - ADTWalletCartridge # ADT-Economy

--- a/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
@@ -16,6 +16,7 @@
         - Impassable
         - HighImpassable
         - MidImpassable
+        hard: false #ADT tweak
       fix2:
         shape:
           !type:PhysShapeCircle


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
Пофиксила коллизию голопада, а так же добавила в наши ПДА нанотаск картридж
## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс. -->
Ссылка на предложение и баг-репорт
- [Баг-репорт](https://discord.com/channels/901772674865455115/1366485545038905485)
- [Предложение](https://discord.com/channels/901772674865455115/1367107084855808091)

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
Нету
## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->
Не требуется
## Чейнджлог


:cl: Minokaa
- fix: НТ уменьшили высоту голопадов и теперь через них можно протаскивать вещи.
- fix: В НТ вспомнили про КПК патологоанатома, ОСЩ и надзирателя и добавили в них нанотаск картридж.
