### PR TITLE
Увеличение числа слотов для утилизаторов на карте Packed

### DIFF
--- a/Resources/Prototypes/ADT/Maps/ADTMaps/adt_packed.yml
+++ b/Resources/Prototypes/ADT/Maps/ADTMaps/adt_packed.yml
@@ -59,7 +59,7 @@
             #Lawyer: [ 1, 1 ] # Corvax-IAA
             #supply
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 2, 2 ]
+            SalvageSpecialist: [ 4, 4 ]
             CargoTechnician: [ 2, 2 ]
             #civilian
             Passenger: [ -1, -1 ]


### PR DESCRIPTION
## Описание PR
Увеличил число слотов для утилизаторов с 2 до 4 на карте Packed

## Почему / Баланс
- [Заказ](https://discord.com/channels/901772674865455115/1367834591980687430)-->

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог

:cl: Alternativ_(заказчик: nullik__) 
- tweak: NanoTrasen решило нанимать большее число утилизаторов на станциях типа Packed - вместо двух, целых четверо.
