### PR TITLE
Разделение предметов на собственное количество

### DIFF
--- a/Content.Server/Stack/StackSystem.cs
+++ b/Content.Server/Stack/StackSystem.cs
@@ -183,11 +183,13 @@ namespace Content.Server.Stack
 
             AlternativeVerb owncount = new()
             {
-                Text = Loc.GetString("comp-stack-split-own-count"),
+                Text = Loc.GetString("comp-stack-split-own-count-verb"),
                 Category = VerbCategory.Split,
                 Act = () =>
                 {
-                    _quickDialog.OpenDialog(player, "Выбрать собственное количество", "Количество:",
+                    _quickDialog.OpenDialog(player,
+                    Loc.GetString("comp-stack-split-choice-label"),
+                    Loc.GetString("comp-stack-split-choice-field"),
                     (string myCount) =>
                     {
                         _ = int.TryParse(myCount, out var count);

--- a/Content.Server/Stack/StackSystem.cs
+++ b/Content.Server/Stack/StackSystem.cs
@@ -4,6 +4,10 @@ using Content.Shared.Verbs;
 using JetBrains.Annotations;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
+// ADT-Tweak start
+using Content.Server.Administration;
+using Robust.Shared.Player;
+// ADT-Tweak end
 
 namespace Content.Server.Stack
 {
@@ -15,6 +19,7 @@ namespace Content.Server.Stack
     public sealed class StackSystem : SharedStackSystem
     {
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        [Dependency] private readonly QuickDialogSystem _quickDialog = default!; // ADT-Tweak for system own split
 
         public static readonly int[] DefaultSplitAmounts = { 1, 5, 10, 20, 30, 50 };
 
@@ -169,6 +174,30 @@ namespace Content.Server.Stack
         {
             if (!args.CanAccess || !args.CanInteract || args.Hands == null || stack.Count == 1)
                 return;
+
+            // ADT-Tweak start
+            if (!EntityManager.TryGetComponent(args.User, out ActorComponent? actor))
+                return;
+
+            var player = actor.PlayerSession;
+
+            AlternativeVerb owncount = new()
+            {
+                Text = Loc.GetString("comp-stack-split-own-count"),
+                Category = VerbCategory.Split,
+                Act = () =>
+                {
+                    _quickDialog.OpenDialog(player, "Выбрать собственное количество", "Количество:",
+                    (string myCount) =>
+                    {
+                        _ = int.TryParse(myCount, out var count);
+                        UserSplit(uid, args.User, count, stack);
+                    });
+                },
+                Priority = 1
+            };
+            args.Verbs.Add(owncount);
+            // ADT-Tweak end
 
             AlternativeVerb halve = new()
             {

--- a/Resources/Locale/ru-RU/stack/stack-component.ftl
+++ b/Resources/Locale/ru-RU/stack/stack-component.ftl
@@ -19,4 +19,5 @@ comp-stack-becomes-full = Стопка теперь заполнена.
 # Text related to splitting a stack
 comp-stack-split = Вы разделили стопку.
 comp-stack-split-halve = Разделить пополам
+comp-stack-split-own-count = Выбрать свое количество
 comp-stack-split-too-small = Стопка слишком мала для разделения.

--- a/Resources/Locale/ru-RU/stack/stack-component.ftl
+++ b/Resources/Locale/ru-RU/stack/stack-component.ftl
@@ -19,5 +19,10 @@ comp-stack-becomes-full = Стопка теперь заполнена.
 # Text related to splitting a stack
 comp-stack-split = Вы разделили стопку.
 comp-stack-split-halve = Разделить пополам
-comp-stack-split-own-count = Выбрать свое количество
 comp-stack-split-too-small = Стопка слишком мала для разделения.
+
+# ADT-Tweak start Разделение предметов
+comp-stack-split-own-count-verb = Выбрать свое количество
+comp-stack-split-choice-label = Выбрать собственное количество
+comp-stack-split-choice-field = Количество:
+# ADT Tweak end


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
Добавлена верб, который позволяет разделить предметы на собственное количество 
## Почему / Баланс
КАМунити хочет
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс. -->
Ссылка на заказ, предложение или баг-репорт
- [Предложение](https://discord.com/channels/901772674865455115/1368636320976601108)

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
В методе `OnStackAlternativeInteract()` класса `StackSystem` был добавлен верб "Выбрать свое количество".
При нажатии которого откроется диалоговое окно для ввода числа. А уже после произойдет разделение купюр.
## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->
![image](https://github.com/user-attachments/assets/6bf22dc4-1c77-4171-8128-21787fbf7016)
![image](https://github.com/user-attachments/assets/7ac0efb0-448b-4867-8759-5a2bd94e179b)
![image](https://github.com/user-attachments/assets/4f2d66a6-769c-4c23-8201-5b0f37fa20f3)

## Чейнджлог
🆑 Darkkiich
- add: Добавлена возможность разделить предметы на собственное количество(купюры тоже)
