### PR TITLE
Добавлена особенность для ботинок охранного МОДа.

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Clothing/Shoes/modsuit_boots.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/Shoes/modsuit_boots.yml
@@ -107,6 +107,8 @@
   - type: Sprite
     sprite: ADT/Clothing/Shoes/Modsuit/mining.rsi
     state: icon
+  - type: ClothingSlowOnDamageModifier
+    modifier: 0.5
   - type: Clothing
     equipDelay: 3
     unequipDelay: 3


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
Добавил сопротивление замедлению от урона для ботинок охранного МОДа
## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс. -->
https://discord.com/channels/901772674865455115/1366044549478092881

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог

:cl: Filo
- tweak: Ботинки охранного МОДа теперь имеют сопротивление замедлению от полученного урона как у стандартных подкованных.

