### PR TITLE
Фикс перекрытия одежды

### DIFF
--- a/Content.Shared/ADT/Inventory/CoveredSlot/CoveredSlotSystem.cs
+++ b/Content.Shared/ADT/Inventory/CoveredSlot/CoveredSlotSystem.cs
@@ -23,6 +23,9 @@ public sealed class CoveredSlotSystem : EntitySystem
         if (args.Cancelled)
             return;
 
+        if (args.EquipTarget != ent.Owner)
+            return;
+
         var blocker = GetBlocker(ent, args.SlotFlags);
 
         // Don't do anything if nothing is blocking the entity from equipping.
@@ -36,6 +39,9 @@ public sealed class CoveredSlotSystem : EntitySystem
     private void OnUnequipAttempt(Entity<InventoryComponent> ent, ref IsUnequippingAttemptEvent args)
     {
         if (args.Cancelled)
+            return;
+
+        if (args.UnEquipTarget != ent.Owner)
             return;
 
         var blocker = GetBlocker(ent, args.SlotFlags);

--- a/Resources/Prototypes/ADT/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/Head/hats.yml
@@ -405,6 +405,8 @@
         Heat: 0.95
   - type: ExplosionResistance
     damageCoefficient: 0.95
+  - type: CoveredSlot
+    slots: [eyes, mask, ears]
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/ADT/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/Head/helmets.yml
@@ -56,6 +56,8 @@
   - type: ExplosionResistance
     damageCoefficient: 0.70
   - type: GroupExamine
+  - type: CoveredSlot
+    slots: [eyes, mask, ears]
 
 - type: entity
   parent: ClothingHeadBase
@@ -74,6 +76,8 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
+  - type: CoveredSlot
+    slots: [eyes]
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/ADT/Entities/Clothing/OuterClothing/modsuits.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/OuterClothing/modsuits.yml
@@ -38,6 +38,8 @@
         type: StorageBoundUserInterface
   - type: FireProtection
     reduction: 0.25
+  - type: CoveredSlot
+    slots: [innerclothing, underwearb, underweart, socks]
 
 - type: entity
   parent: ADTClothingOuterModsuitBodyBase

--- a/Resources/Prototypes/ADT/Entities/Personalization/Clothing/personalization_clothing.yml
+++ b/Resources/Prototypes/ADT/Entities/Personalization/Clothing/personalization_clothing.yml
@@ -40,6 +40,8 @@
   - type: Clothing
     slots: [innerclothing]
     femaleMask: UniformTop
+  - type: CoveredSlot
+    slots: [underweart]
 ##Sponsor Shoes
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -132,8 +132,11 @@
     - Snout
     - HeadTop
     - HeadSide
-  - type: CoveredSlot # Backmen
+  #ADT-Tweak-Start
+  - type: CoveredSlot
     slots: [eyes, mask, ears]
+  #ADT-Tweak-End
+
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -933,6 +933,10 @@
     sprite: Clothing/Head/Hats/gladiator.rsi
   - type: Clothing
     sprite: Clothing/Head/Hats/gladiator.rsi
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes, mask, ears]
+  #ADT-Tweak-End
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -51,6 +51,10 @@
     tags:
     - WhitelistChameleon
     - SecurityHelmet
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes]
+  #ADT-Tweak-End
 
 #Mercenary Helmet
 - type: entity
@@ -86,6 +90,10 @@
         Caustic: 0.95
   - type: ExplosionResistance
     damageCoefficient: 0.75
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes]
+  #ADT-Tweak-End
 
 #Syndicate SWAT Helmet
 - type: entity
@@ -99,6 +107,10 @@
     sprite: Clothing/Head/Helmets/swat_syndicate.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/swat_syndicate.rsi
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes]
+  #ADT-Tweak-End
 
 #Light Riot Helmet
 - type: entity
@@ -118,6 +130,10 @@
         Blunt: 0.8
         Slash: 0.8
         Piercing: 0.95
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes, mask, ears]
+  #ADT-Tweak-End
 
 #Bombsuit Helmet
 - type: entity
@@ -145,6 +161,10 @@
     - Snout
     - HeadTop
     - HeadSide
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes, mask, ears]
+  #ADT-Tweak-End
 
 #Janitorial Bombsuit Helmet
 - type: entity
@@ -178,6 +198,10 @@
         Slash: 0.8
         Piercing: 0.9
         Heat: 0.9
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes, mask, ears]
+  #ADT-Tweak-End
 
 #Space Ninja Helmet
 - type: entity
@@ -215,6 +239,10 @@
     sprite: Clothing/Head/Helmets/templar.rsi
   - type: IngestionBlocker
   - type: IdentityBlocker
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes, mask, ears]
+  #ADT-Tweak-End
 
 #Thunderdome Helmet
 - type: entity
@@ -241,6 +269,10 @@
     sprite: Clothing/Head/Helmets/wizardhelm.rsi
   - type: IngestionBlocker
   - type: IdentityBlocker
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes, mask, ears]
+  #ADT-Tweak-End
 
 #Fire Helmet
 - type: entity
@@ -271,6 +303,10 @@
     - Snout
     - HeadTop
     - HeadSide
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes, mask, ears]
+  #ADT-Tweak-End
 
 #Atmos Fire Helmet
 - type: entity
@@ -305,6 +341,10 @@
     - HeadTop
     - HeadSide
   - type: BreathMask
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes, mask, ears]
+  #ADT-Tweak-End
 
 #Chitinous Helmet
 - type: entity
@@ -324,6 +364,10 @@
         Slash: 0.5
         Piercing: 0.5
         Heat: 0.9
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes, mask, ears]
+  #ADT-Tweak-End
 
 #ERT HELMETS
 #ERT Leader Helmet
@@ -337,6 +381,10 @@
     sprite: Clothing/Head/Helmets/ert_leader.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/ert_leader.rsi
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes]
+  #ADT-Tweak-End
 
 #ERT Security Helmet
 - type: entity
@@ -349,6 +397,10 @@
     sprite: Clothing/Head/Helmets/ert_security.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/ert_security.rsi
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes]
+  #ADT-Tweak-End
 
 #ERT Medic Helmet
 - type: entity
@@ -361,6 +413,10 @@
     sprite: Clothing/Head/Helmets/ert_medic.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/ert_medic.rsi
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes]
+  #ADT-Tweak-End
 
 #ERT Engineer Helmet
 - type: entity
@@ -373,6 +429,10 @@
     sprite: Clothing/Head/Helmets/ert_engineer.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/ert_engineer.rsi
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes]
+  #ADT-Tweak-End
 
 #ERT Janitor Helmet
 - type: entity
@@ -385,6 +445,10 @@
     sprite: Clothing/Head/Helmets/ert_janitor.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/ert_janitor.rsi
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes]
+  #ADT-Tweak-End
 
 - type: entity
   parent: [ BaseSyndicateContraband, ClothingHeadHelmetBase ]
@@ -403,6 +467,10 @@
         Slash: 0.85
         Piercing: 0.85
         Heat: 0.85
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes]
+  #ADT-Tweak-End
 
 #Bone Helmet
 - type: entity
@@ -418,6 +486,10 @@
   - type: Construction
     graph: BoneHelmet
     node: helmet
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes, mask]
+  #ADT-Tweak-End
 
 - type: entity
   parent: [ ClothingHeadHelmetBase, BaseMinorContraband ]
@@ -499,6 +571,10 @@
   - type: Construction
     graph: HelmetJustice
     node: helmet
+  #ADT-Tweak-Start
+  - type: CoveredSlot
+    slots: [eyes]
+  #ADT-Tweak-End
 
 - type: entity
   parent: ClothingHeadHelmetJustice

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -21,8 +21,10 @@
     slots:
     - Snout
     hideOnToggle: true
+  #ADT-Tweak-Start
   - type: CoveredSlot
     slots: [eyes, ears]
+  #ADT-Tweak-End
 
 - type: entity
   parent: [ClothingMaskGas, BaseSecurityContraband]

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -21,6 +21,8 @@
     slots:
     - Snout
     hideOnToggle: true
+  - type: CoveredSlot
+    slots: [eyes, ears]
 
 - type: entity
   parent: [ClothingMaskGas, BaseSecurityContraband]

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -145,7 +145,7 @@
     slots: OUTERCLOTHING
   #ADT-Tweak-Start
   - type: CoveredSlot
-    slots: [innerclothing, feet, underwearb, underweart, socks]
+    slots: [innerclothing, gloves, feet, underwearb, underweart, socks]
   #ADT-Tweak-End
 
 - type: entity


### PR DESCRIPTION
## Описание PR
Добавлены 2 проверки в системе для корректной работы, а также добавление всяким шлемам компонента, ибо умом

## Почему / Баланс
Надо

## Техническая информация


## Медиа

## Чейнджлог
:cl: Cethet

- fix: Исправлена механика перекрытия одежды. Теперь одежда на вас не перестаёт мешать снимать одежду с других.
- fix: Шлемы теперь перекрывают лицо, уши и маску в зависимости от того, что они закрывают по спрайту.

