### PR TITLE
[TWEAK] Маленькие правки режимов игры

### DIFF
--- a/Content.Shared/CCVar/CCVars.Atmos.cs
+++ b/Content.Shared/CCVar/CCVars.Atmos.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Configuration;
+using Robust.Shared.Configuration;
 
 namespace Content.Shared.CCVar;
 
@@ -149,5 +149,5 @@ public sealed partial class CCVars
     ///     Setting this to zero disables the explosion but still allows the tank to burst and leak.
     /// </summary>
     public static readonly CVarDef<float> AtmosTankFragment =
-        CVarDef.Create("atmos.max_explosion_range", 26f, CVar.SERVERONLY);
+        CVarDef.Create("atmos.max_explosion_range", 5f, CVar.SERVERONLY); /// ADT-Tweak 26f to 5f - нерф лимиток
 }

--- a/Resources/Locale/ru-RU/ADT/game-ticking/game-presets/preset-traitor.ftl
+++ b/Resources/Locale/ru-RU/ADT/game-ticking/game-presets/preset-traitor.ftl
@@ -1,0 +1,9 @@
+traitorlight-title = Предатели (облегченный)
+traitorlight-description = Среди нас есть предатели...
+traitorlight-not-enough-ready-players = Недостаточно игроков готовы к игре! Из { $minimumPlayers } необходимых игроков готовы { $readyPlayersCount }. Нельзя запустить пресет Предатели.
+traitorlight-no-one-ready = Нет готовых игроков! Нельзя запустить пресет Предатели.
+
+antagtrio-title = Трио
+antagtrio-description = Кажется, на станции есть предатели, генокрады и еретики..
+antagtrio-not-enough-ready-players = Недостаточно игроков готовы к игре! Из { $minimumPlayers } необходимых игроков готовы { $readyPlayersCount }. Нельзя запустить пресет Трио.
+antagtrio-no-one-ready = Нет готовых игроков! Нельзя запустить пресет Трио.

--- a/Resources/Prototypes/ADT/GameRules/crew_transfer.yml
+++ b/Resources/Prototypes/ADT/GameRules/crew_transfer.yml
@@ -4,7 +4,7 @@
   components:
   - type: GameRule
   - type: BasicStationEventScheduler
-    minimumTimeUntilFirstEvent: 5400 # 90 min
+    minimumTimeUntilFirstEvent: 6300 # 105 min
     minMaxEventTiming:
       min: 1800 # 30 min
       max: 1800 # 30 min

--- a/Resources/Prototypes/ADT/GameRules/roundstart.yml
+++ b/Resources/Prototypes/ADT/GameRules/roundstart.yml
@@ -19,17 +19,17 @@
 
 - type: entity
   parent: BaseHereticRule
-  id: Heretic
+  id: HereticGameRule
   components:
   - type: HereticRule
   - type: GameRule
-    minPlayers: 20
+    minPlayers: 25
   - type: AntagSelection
     agentName: heretic-roundend-name
     definitions:
     - prefRoles: [ Heretic ]
-      max: 3
-      playerRatio: 20
+      max: 4
+      playerRatio: 15
       lateJoinAdditional: true
       mindComponents:
       - type: HereticRole
@@ -62,7 +62,7 @@
   components:
   - type: ChangelingRule
   - type: GameRule
-    minPlayers: 20
+    minPlayers: 25
     delay:
       min: 30
       max: 60
@@ -86,3 +86,98 @@
     sets:
     - groups: ChangelingObjectiveGroups
     maxDifficulty: 5
+
+#Облегченное число агентов
+- type: entity
+  parent: BaseTraitorRule
+  id: TraitorLightGameRule
+  components:
+  - type: GameRule
+    minPlayers: 5
+    delay:
+      min: 240
+      max: 420
+  - type: AntagSelection
+    selectionTime: IntraPlayerSpawn
+    definitions:
+    - prefRoles: [ Traitor ]
+      max: 4          
+      playerRatio: 15 
+      blacklist:
+        components:
+        - AntagImmune
+      lateJoinAdditional: true
+      mindRoles:
+      - MindRoleTraitor
+
+#Пары из антагов
+- type: entity
+  parent: BaseTraitorRule
+  id: TraitorDuoGameRule
+  components:
+  - type: GameRule
+    minPlayers: 20
+    delay:
+      min: 240
+      max: 420
+  - type: AntagSelection
+    selectionTime: IntraPlayerSpawn
+    definitions:
+    - prefRoles: [ Traitor ]
+      max: 2       
+      playerRatio: 10
+      blacklist:
+        components:
+        - AntagImmune
+      lateJoinAdditional: true
+      mindRoles:
+      - MindRoleTraitor
+
+- type: entity
+  parent: BaseGameRule
+  id: ChangelingDuoGameRule
+  components:
+  - type: ChangelingRule
+  - type: GameRule
+    minPlayers: 20
+    delay:
+      min: 30
+      max: 60
+  - type: AntagSelection
+    definitions:
+    - prefRoles: [ Changeling ]
+      max: 2
+      playerRatio: 15
+      blacklist:
+        components:
+        - AntagImmune
+        tags:
+        - ChangelingBlacklist
+      lateJoinAdditional: true
+      mindRoles:
+      - MindRoleChangeling
+      components:
+      - type: Changeling
+    agentName: ling-round-end-name
+  - type: AntagRandomObjectives
+    sets:
+    - groups: ChangelingObjectiveGroups
+    maxDifficulty: 5
+
+- type: entity
+  parent: BaseHereticRule
+  id: HereticDuoGameRule
+  components:
+  - type: HereticRule
+  - type: GameRule
+    minPlayers: 20
+  - type: AntagSelection
+    agentName: heretic-roundend-name
+    definitions:
+    - prefRoles: [ Heretic ]
+      max: 2
+      playerRatio: 15
+      lateJoinAdditional: true
+      mindComponents:
+      - type: HereticRole
+      startingGear: HereticGear # see Roles/Antags/heretic.yml

--- a/Resources/Prototypes/ADT/game_presets.yml
+++ b/Resources/Prototypes/ADT/game_presets.yml
@@ -7,18 +7,19 @@
   minPlayers: 25
   description: heretic-title
   rules:
-    - Heretic
+    - HereticGameRule
     - BasicRoundstartVariation
     - SubGamemodesRule
     - BasicStationEventScheduler
     - MeteorSwarmScheduler
     - CrewTransferScheduler
+
 - type: gamePreset
   id: Changeling
   alias:
     - changeling
   name: changelings-title
-  minPlayers: 20
+  minPlayers: 25
   showInVote: false
   description: changelings-description
   rules:
@@ -28,3 +29,41 @@
     - BasicStationEventScheduler
     - MeteorSwarmScheduler
     - CrewTransferScheduler
+
+#Облегченная версия предателей
+
+- type: gamePreset
+  id: TraitorLight
+  alias:
+    - traitorlight
+    - tatorlight
+  name: traitorlight-title
+  description: traitorlight-description
+  showInVote: false
+  rules:
+    - TraitorLightGameRule
+    - SubGamemodesRule
+    - BasicStationEventScheduler
+    - MeteorSwarmScheduler
+    - SpaceTrafficControlEventScheduler
+    - BasicRoundstartVariation
+    - CrewTransferScheduler #ADT tweak
+
+#Версия всего понемногу
+- type: gamePreset
+  id: AntagTrio
+  alias:
+    - antagtrio
+  name: antagtrio-title
+  description: antagtrio-description
+  showInVote: false
+  rules:
+    - TraitorDuoGameRule
+    - ChangelingDuoGameRule
+    - HereticDuoGameRule
+    - SubGamemodesRule
+    - BasicStationEventScheduler
+    - MeteorSwarmScheduler
+    - SpaceTrafficControlEventScheduler
+    - BasicRoundstartVariation
+    - CrewTransferScheduler #ADT tweak

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -299,7 +299,7 @@
     duration: 1
     earliestStart: 30
     reoccurrenceDelay: 60
-    minimumPlayers: 10
+    minimumPlayers: 1000  #ADT-Tweak - де факто отключаем визарда 10 > 1000
   - type: AntagSelection
     agentName: wizard-round-end-name
     definitions:

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -196,8 +196,8 @@
     selectionTime: IntraPlayerSpawn
     definitions:
     - prefRoles: [ Traitor ]
-      max: 6          #ADT_Tweak
-      playerRatio: 15 #ADT_Tweak
+      max: 7         #ADT_Tweak 8 > 7
+      playerRatio: 10
       blacklist:
         components:
         - AntagImmune
@@ -276,7 +276,7 @@
   id: Wizard
   components:
   - type: GameRule
-    minPlayers: 10
+    minPlayers: 1000 #ADT-Tweak - де факто отключаем визарда 10 > 1000
   - type: AntagSelection
     agentName: wizard-round-end-name
     selectionTime: PrePlayerSpawn

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -2,7 +2,9 @@
   id: Secret
   weights:
     Nukeops: 0.15
-    Traitor: 0.54
+    Traitor: 0.30
+    TraitorLight: 0.14
+    AntagTrio: 0.10
     Revolutionary: 0.10
     Heretic: 0.10
     Changeling: 0.10


### PR DESCRIPTION
## Описание PR
В режиме секрета, генокрада и еретика незначительно увеличено максимальное количество возможных антагонистов. 

Добавлен в секрет режим с пониженным числом агентов.

Добавлен режим, где в одном раунде появляется по двое агентов, генокрадов и еретиков.

Опрос о завершении смены передвинут с полутора часов до часа-сорока пяти.

Серьезно ограничен (но не убран в ноль) радиус подрыва лимитки.

## Чейнджлог

:cl: Петр
- add: Добавлен в секрет режим с пониженным числом агентов
- add: Добавлен в секрет режим с двумя агентами, двумя генокрадами и двумя еретиками
- tweak: Незначительно увеличено число возможных агентов, еретиков и генокрадов в их основных режимах
- tweak: Время опроса о завершении смены передвинуто с полутора часов до часа сорока пяти
- tweak: Серьезно снижен радиус взрыва лимитки

