### PR TITLE
Запрет сумеречникам быть в службе безопасности раундстартом.

### DIFF
--- a/Resources/Prototypes/ADT/Roles/Jobs/Security/guard_officer.yml
+++ b/Resources/Prototypes/ADT/Roles/Jobs/Security/guard_officer.yml
@@ -13,6 +13,7 @@
       species:
       - Resomi
       - Vox
+      - Shadekin
   # ADT RESTRICT End
   startingGear: GuardOfficerGear
   icon: "JobIconADTGuardOfficer"

--- a/Resources/Prototypes/ADT/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/ADT/Roles/Jobs/Security/senior_officer.yml
@@ -22,6 +22,7 @@
       species:
       - Resomi
       - Vox
+      - Shadekin
   # ADT RESTRICT End
   startingGear: SeniorOfficerGear
   icon: "JobIconSeniorOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -13,6 +13,7 @@
     species:
     - Resomi
     - Vox
+    - Shadekin
   # ADT RESTRICT End
   startingGear: DetectiveGear
   icon: "JobIconDetective"

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -21,6 +21,7 @@
       species:
       - Resomi
       - Vox
+      - Shadekin
   # ADT RESTRICT End
   weight: 10
   startingGear: HoSGear

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -16,6 +16,7 @@
       species:
       - Resomi
       - Vox
+      - Shadekin
     # ADT RESTRICT End
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -13,6 +13,7 @@
       species:
       - Resomi
       - Vox
+      - Shadekin
   # ADT RESTRICT End
   startingGear: SecurityOfficerGear
   icon: "JobIconSecurityOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -13,6 +13,7 @@
       species:
       - Resomi
       - Vox
+      - Shadekin
   # ADT RESTRICT End
   startingGear: WardenGear
   icon: "JobIconWarden"


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
Теперь сумеречники не могу зайти за сб раундстартом, но могут быть в роли бригмедика.
## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс. -->
Ссылка на заказ, предложение или баг-репорт
В основном это из-за их слабых тел и отчасти из-за их природы.
## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог

:cl: Filo
- tweak: Весь отдел службы безопасности кроме бригмедика теперь недоступен сумеречникам раундстартом.