### PR TITLE
[TWEAK] Настройка и приведение мехов к историческим данным

### DIFF
--- a/Resources/Prototypes/ADT/Catalog/mechuplink.yml
+++ b/Resources/Prototypes/ADT/Catalog/mechuplink.yml
@@ -83,15 +83,15 @@
   categories:
   - ADTUplinkMechWeapon
 
-- type: listing
-  id: UplinkMechGunMHAR21
-  name: uplink-syndimech-weapon-madeuce-name
-  description: uplink-syndimech-weapon-madeuce-desc
-  productEntity: ADTMechGunMHAR21
-  cost:
-    Telecrystal: 12
-  categories:
-  - ADTUplinkMechWeapon
+# - type: listing
+#   id: UplinkMechGunMHAR21
+#   name: uplink-syndimech-weapon-madeuce-name
+#   description: uplink-syndimech-weapon-madeuce-desc
+#   productEntity: ADTMechGunMHAR21
+#   cost:
+#     Telecrystal: 12
+#   categories:
+#   - ADTUplinkMechWeapon
 
 
 - type: listing
@@ -303,15 +303,15 @@
   categories:
   - ADTUplinkERTMechWeapon
 
-- type: listing
-  id: UplinkERTMechGunMHAR21
-  name: uplink-syndimech-weapon-madeuce-name
-  description: uplink-syndimech-weapon-madeuce-desc
-  productEntity: ADTMechGunMHAR21
-  cost:
-    Productunit: 6
-  categories:
-  - ADTUplinkERTMechWeapon
+# - type: listing
+#   id: UplinkERTMechGunMHAR21
+#   name: uplink-syndimech-weapon-madeuce-name
+#   description: uplink-syndimech-weapon-madeuce-desc
+#   productEntity: ADTMechGunMHAR21
+#   cost:
+#     Productunit: 6
+#   categories:
+#   - ADTUplinkERTMechWeapon
 
 - type: listing
   id: UplinkERTMechGunHeavyPulseRifle

--- a/Resources/Prototypes/ADT/Entities/Objects/Specific/Mech/Mech.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Specific/Mech/Mech.yml
@@ -26,7 +26,7 @@
         Heat: 0.5
         Radiation: 0
         Caustic: 0.1
-        Structural: 0.5
+        Structural: 1.0
     maxintegrity: 300
     baseState: gygax
     openState: gygax-open
@@ -41,10 +41,10 @@
       - ADTMechEquipmentSec
   - type: MeleeWeapon
     hidden: true
-    attackRate: 1.2
+    attackRate: 1.0
     damage:
       types:
-        Blunt: 30 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
+        Blunt: 25 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
         Structural: 60
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.25
@@ -98,7 +98,7 @@
         Heat: 0.75
         Radiation: 0
         Caustic: 0.1
-        Structural: 0.75
+        Structural: 1.0
     # ADT end
     maxintegrity: 340
     baseState: clarke
@@ -118,7 +118,7 @@
     damage:
       types:
         Blunt: 15 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
-        Structural: 15
+        Structural: 30
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.0
     baseSprintSpeed: 3.6
@@ -181,7 +181,7 @@
         Heat: 0.25
         Radiation: 0
         Caustic: 0.1
-        Structural: 0.25
+        Structural: 1.0
     maxintegrity: 350
     baseState: durand
     openState: durand-open
@@ -196,11 +196,11 @@
       - ADTMechEquipmentSec
   - type: MeleeWeapon
     hidden: true
-    attackRate: 1.2
+    attackRate: 1.0
     damage:
       types:
-        Blunt: 50 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
-        Structural: 100
+        Blunt: 25 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
+        Structural: 75
   - type: MovementSpeedModifier
     baseWalkSpeed: 1.5
     baseSprintSpeed: 2.7
@@ -266,7 +266,7 @@
         Heat: 0.75
         Radiation: 0
         Caustic: 0.1
-        Structural: 0.75
+        Structural: 1.0
     # ADT end
     maxintegrity: 285
     baseState: odysseus
@@ -343,7 +343,7 @@
         Heat: 0.25
         Radiation: 0
         Caustic: 0.1
-        Structural: 0.25
+        Structural: 1.0
     mechToPilotDamageMultiplier: 0.0  #Боец в тяжелом мехе не должен получать урон пока сам мех - жив
     maxintegrity: 420
     baseState: phazon
@@ -361,7 +361,7 @@
     attackRate: 1.2
     damage:
       types:
-        Blunt: 30 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
+        Blunt: 25 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
         Structural: 60
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.2
@@ -429,7 +429,7 @@
         Heat: 0.75
         Radiation: 0
         Caustic: 0.1
-        Structural: 0.75
+        Structural: 1.0
     # ADT end
     maxintegrity: 315
     baseState: ripleymkii
@@ -449,6 +449,7 @@
     damage:
       types:
         Blunt: 25 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
+        Structural: 20 #ADT tweak 0 to 20
   - type: MovementSpeedModifier
     baseWalkSpeed: 1.875
     baseSprintSpeed: 3.375
@@ -514,7 +515,7 @@
         Heat: 0.25
         Radiation: 0
         Caustic: 0.1
-        Structural: 0.25
+        Structural: 1.0
     mechToPilotDamageMultiplier: 0.0  #Боец в тяжелом мехе не должен получать урон пока сам мех - жив
     maxintegrity: 385
     baseState: marauder
@@ -530,11 +531,11 @@
       - ADTMechEquipmentSec
   - type: MeleeWeapon
     hidden: true
-    attackRate: 1.5
+    attackRate: 1.2
     damage:
       types:
-        Blunt: 50 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
-        Structural: 100
+        Blunt: 25 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
+        Structural: 75
   - type: MovementSpeedModifier
     baseWalkSpeed: 2
     baseSprintSpeed: 3.6
@@ -594,7 +595,7 @@
         Heat: 0.15
         Radiation: 0
         Caustic: 0.1
-        Structural: 0.15
+        Structural: 1.0
     mechToPilotDamageMultiplier: 0.0  #Боец в тяжелом мехе не должен получать урон пока сам мех - жив
     maxintegrity: 600
     baseState: seraph
@@ -665,7 +666,7 @@
         Heat: 0.5
         Radiation: 0
         Caustic: 0.1
-        Structural: 0.5
+        Structural: 1.0
     mechToPilotDamageMultiplier: 0.15 #коэффициент для легкобронированных мехов 
     maxintegrity: 350
     baseState: ntgygax
@@ -737,7 +738,7 @@
         Heat: 0.5
         Radiation: 0
         Caustic: 0.1
-        Structural: 0.5
+        Structural: 1.0
     mechToPilotDamageMultiplier: 0.15 #коэффициент для легкобронированных мехов 
     maxintegrity: 350
     baseState: darkgygax
@@ -810,7 +811,7 @@
         Heat: 0.25
         Radiation: 0
         Caustic: 0.1
-        Structural: 0.25
+        Structural: 1.0
     mechToPilotDamageMultiplier: 0.0  #Боец в тяжелом мехе не должен получать урон пока сам мех - жив
     maxintegrity: 385
     baseState: mauler
@@ -826,11 +827,11 @@
     maxEquipmentAmount: 5
   - type: MeleeWeapon
     hidden: true
-    attackRate: 1.5
+    attackRate: 1.2
     damage:
       types:
-        Blunt: 50 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
-        Structural: 100
+        Blunt: 25 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
+        Structural: 75
   - type: MovementSpeedModifier
     baseWalkSpeed: 2
     baseSprintSpeed: 3.6
@@ -897,7 +898,7 @@
         Heat: 0.5
         Radiation: 0
         Caustic: 0.1
-        Structural: 0.5
+        Structural: 1.0
     mechToPilotDamageMultiplier: 0.15 #коэффициент для легкобронированных мехов 
     maxintegrity: 300
     baseState: paddy
@@ -912,11 +913,11 @@
       - ADTMechEquipmentSec
   - type: MeleeWeapon
     hidden: true
-    attackRate: 1.2
+    attackRate: 1.0
     damage:
       types:
-        Blunt: 40 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
-        Structural: 15
+        Blunt: 25 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
+        Structural: 25
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.25
     baseSprintSpeed: 4.1

--- a/Resources/Prototypes/ADT/Entities/Objects/Specific/Mech/mech_gun.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Specific/Mech/mech_gun.yml
@@ -96,7 +96,7 @@
     selectedMode: FullAuto
     availableModes:
     - FullAuto
-    fireRate: 4
+    fireRate: 2.5
   - type: HitscanMechAmmoProvider
     proto: RedLaser
     fireCost: 10
@@ -114,7 +114,7 @@
     selectedMode: FullAuto
     availableModes:
     - FullAuto
-    fireRate: 2.5
+    fireRate: 2
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: HitscanMechAmmoProvider
@@ -201,7 +201,7 @@
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
     state: mecha_scatter
   - type: Gun
-    fireRate: 3
+    fireRate: 2
     selectedMode: FullAuto
     availableModes:
       - FullAuto
@@ -229,7 +229,11 @@
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
     state: mecha_uac2
   - type: Gun
-    fireRate: 9
+    fireRate: 7
+    minAngle: 1
+    maxAngle: 16
+    angleIncrease: 2
+    angleDecay: 24
     selectedMode: FullAuto
     availableModes:
       - FullAuto
@@ -244,6 +248,8 @@
     reloadTime: 5
   - type: UIFragment
     ui: !type:MechGunUi
+  # - type: RunAndGunSpreadModifier
+  #   modifyer: 1
 
 - type: entity
   name: FNX-99 "Hades" Carbine
@@ -255,7 +261,11 @@
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
     state: mecha_carbine
   - type: Gun
-    fireRate: 7
+    fireRate: 5
+    minAngle: 4
+    maxAngle: 20
+    angleIncrease: 4
+    angleDecay: 24
     selectedMode: FullAuto
     availableModes:
       - FullAuto
@@ -282,7 +292,7 @@
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
     state: mecha_carbine
   - type: Gun
-    fireRate: 1.5
+    fireRate: 1
     selectedMode: FullAuto
     availableModes:
       - FullAuto
@@ -297,6 +307,7 @@
     ammoType: sniper
   - type: UIFragment
     ui: !type:MechGunUi
+  - type: RunAndGunBlocker
 
 - type: entity
   name: SGL-6 Grenade Launcher
@@ -308,7 +319,7 @@
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
     state: mecha_grenadelnchr
   - type: Gun
-    fireRate: 1.5
+    fireRate: 1
     selectedMode: FullAuto
     availableModes:
       - FullAuto
@@ -324,6 +335,7 @@
     reloadTime: 5
   - type: UIFragment
     ui: !type:MechGunUi
+  - type: RunAndGunBlocker
 
 - type: entity
   name: SRM-8 Missile Rack
@@ -351,6 +363,7 @@
     reloadTime: 8
   - type: UIFragment
     ui: !type:MechGunUi
+  - type: RunAndGunBlocker
 
 - type: entity
   name: BRM-6 Missile Rack
@@ -378,6 +391,7 @@
     reloadTime: 5
   - type: UIFragment
     ui: !type:MechGunUi
+  - type: RunAndGunBlocker
 
 # #Медиган
 

--- a/Resources/Prototypes/ADT/Recipes/Construction/Graph/mechs/clarke_construction.yml
+++ b/Resources/Prototypes/ADT/Recipes/Construction/Graph/mechs/clarke_construction.yml
@@ -8,7 +8,7 @@
       steps:
 
       - tag: ADTHardsuitSalvage
-        name: salvage hardsuit
+        name: шахтёрский МОД
         icon:
           sprite: "Clothing/OuterClothing/Hardsuits/salvage.rsi"
           state: "icon"

--- a/Resources/Prototypes/ADT/Research/mech_tecnology.yml
+++ b/Resources/Prototypes/ADT/Research/mech_tecnology.yml
@@ -8,6 +8,7 @@
   tier: 2
   cost: 15000
   recipeUnlocks:
+  - ADTWeaponIonRifle #При создании боевых мехов открываются ионные винтовки
   - ADTGygaxHarness
   - ADTGygaxLArm
   - ADTGygaxRArm

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -38,9 +38,9 @@
     requireAnchored: false
     joinSystem: true
   - type: DoAfter
-  - type: Repairable
-    fuelCost: 25
-    doAfterDelay: 10
+  - type: Repairable 
+    fuelCost: 75 # ADT-tweak 25 to 75
+    doAfterDelay: 30 # ADT-tweak 10 to 30
   - type: UserInterface
     interfaces:
       enum.MechUiKey.Key:
@@ -48,6 +48,7 @@
       enum.StorageUiKey.Key: # ADT edit
         type: StorageBoundUserInterface
   - type: MeleeWeapon
+    range: 1.0 # ADT-tweak 1.5 to 1.0
     hidden: true
     attackRate: 0.75
     damage:
@@ -92,7 +93,7 @@
       storagebase: !type:Container #ADT edit
         ents: []
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic #ADT tweak - чтобы мехи получали и структурный урон
     damageModifierSet: ADTMechDamageModifierSet  # ADT tweak mech rebalance
   - type: FootstepModifier
     footstepSoundCollection:
@@ -148,7 +149,7 @@
         Heat: 0.75
         Radiation: 0
         Caustic: 0.1
-        Structural: 0.75
+        Structural: 1.0
     maxintegrity: 285   # ADT-tweak. Правим очки здоровья меха
     equipmentWhitelist:
       tags:
@@ -168,6 +169,7 @@
     damage:
       types:
         Blunt: 14 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
+        Structural: 20 #ADT tweak 0 to 20
   - type: MovementSpeedModifier
     baseWalkSpeed: 1.875
     baseSprintSpeed: 3.375
@@ -215,7 +217,7 @@
         Heat: 0.75
         Radiation: 0
         Caustic: 0.1
-        Structural: 0.75
+        Structural: 1.0
     maxintegrity: 285   # ADT-tweak. Правим очки здоровья меха
     # ADT end
     baseState: honker
@@ -271,7 +273,7 @@
         Heat: 0.75
         Radiation: 0
         Caustic: 0.1
-        Structural: 0.75
+        Structural: 1.0
     maxintegrity: 285   # ADT-tweak. Правим очки здоровья меха
     # ADT end
     baseState: hamtr
@@ -348,7 +350,7 @@
         Heat: 0.75
         Radiation: 0
         Caustic: 0.1
-        Structural: 0.75
+        Structural: 1.0
     maxintegrity: 285   # ADT-tweak. Правим очки здоровья меха
     # ADT end
     baseState: vim

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -58,8 +58,8 @@
   recipeUnlocks:
   - WeaponLaserCarbine
   # Start ADT tweak
-  - ADTWeaponIonRifle
-  - ADTWeaponIonCarbine
+  # - ADTWeaponIonRifle
+  # - ADTWeaponIonCarbine
   - ADTBorgModuleHarm #ADT secborg
   - ADTMechGunImmolatorLaser
   position: 2,-1

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -141,6 +141,7 @@
   tier: 1
   cost: 7500
   recipeUnlocks:
+  - ADTWeaponIonCarbine # ADT Tweak - при создании простейших мехов доступен карабин
   - RipleyHarness
   - RipleyLArm
   - RipleyRArm


### PR DESCRIPTION
## Описание PR
Мехи были понерфлены по тем параметрам, по которым они становились неудобно хорошими

## Почему / Баланс
Чтобы у данного вида техники были свои недостатки

## Чейнджлог

:cl: Петр
- remove: 12.7-мм орудие меха MHAR21 было выведено из аплинков мехов ОБР и ЯО по причине избыточной мощи в условиях станции
- fix: Исправлена ошибка, что мехи не получали структурный тип урона
- tweak: Для всех мехов коэффициент структурного урона стал равен единице - оружие с уроном по структурам теперь второе после ионных винтовок лучшее средство для борьбы с этим типом техники
- tweak: Дальность атаки мехом в рукопашную снижена с 1.5 до 1 тайла
- tweak: Частота атак в рукопашную для "Гайгэксов" снижена с 1.2 до 1.0 в секунду. Ударный урон снижен с 30 до 25 за удар.
- tweak: Структурный урон от атак "Кларка" повышен с 15 до 30
- tweak: Частота атак в рукопашную для "Дюранда" снижена с 1.2 до 1.0 в секунду. Ударный урон снижен с 50 до 25 за удар. Структурный урон снижен с 100 до 75 за атаку.
- tweak: Ударный урон "Фазона" снижен с 30 до 25 за атаку.
- tweak: Для Рипли и Рипли Мк2 добавлен структурный урон (25 единиц) за атаку.
- tweak: Частота атак в рукопашную для "Мародера", "Серафима" и "Маулера" снижена с 1.5 до 1.2 в секунду. Ударный урон снижен с 50 до 25 за удар. Структурный урон снижен с 100 до 75 за атаку.
- tweak: Частота атак в рукопашную для "Падди" снижена с 1.2 до 1.0 в секунду. Ударный урон снижен с 40 до 25 за удар. Структурный урон повышен с 15 до 25 за атаку.
- tweak: Скорострельность лазера "Иммолятор" снижена с 4 до 2.5 выстрелов секунду.
- tweak: Скорострельность лазера "Солярис" снижена с 2.5 до 2 выстрелов секунду.
- tweak: Скорострельность LBX AC 10 "Scattershot" снижена с 3 до 2 выстрелов секунду.
- tweak: Скорострельность Ultra AC-2 снижена с 9 до 7 выстрелов секунду. Добавлен разброс при стрельбе.
- tweak: Скорострельность FNX-99 "Hades" снижена с 7 до 5 выстрелов секунду. Добавлен разброс при стрельбе.
- tweak: Скорострельность всех видов гранатометов для мехов снижена с 1.5 до 1 выстрела секунду. Добавлен компонент, отвечающий за то, что стрельба их них должна вестись только когда скорость меха ниже 1 тайла/сек.
- remove: Удалено открытие рецептов производства ионной винтовки и ионного карабина при исследовании технологии лазерного оружия.
- add: Добавлено открытие рецепта ионного карабина при исследовании "Рипли"
- add: Добавлено открытие рецепта ионной винтовки при исследовании "Гайгэкса"
- fix: Изменен текст в крафте меха "Кларк" - теперь там указано требование шахтерского МОДа (обычный (не легкий) скафандр шахтера также пригоден для крафта, но достать его сложно).
- tweak: Время починки меха сваркой увеличено с 10 до 30 секунд.
- tweak: Расход топлива сварочного аппарата для починки мехов повышено с 25 до 75 единиц.