### PR TITLE
Аддон лаваленда

### DIFF
--- a/Resources/Locale/ru-RU/ADT/prototypes/Entities/Structures/Storage/crates/necropolis.ftl
+++ b/Resources/Locale/ru-RU/ADT/prototypes/Entities/Structures/Storage/crates/necropolis.ftl
@@ -36,3 +36,15 @@ ent-ADTCrateNecropolisTrapAncientGoliath = { ent-ADTCrateNecropolis }
 ent-ADTCrateNecropolisMjollnir = { ent-ADTCrateNecropolis }
     .desc = { ent-ADTCrateNecropolis.desc }
     .suffix = Мьелльнир, Лаваленд
+
+ent-ADTCrateNecropolisRGBStaff = { ent-ADTCrateNecropolis }
+    .desc = { ent-ADTCrateNecropolis.desc }
+    .suffix = RGB посох, Лаваленд
+
+ent-ADTCrateNecropolisMimicry = { ent-ADTCrateNecropolis }
+    .desc = { ent-ADTCrateNecropolis.desc }
+    .suffix = Мимикрия, Лаваленд
+
+ent-ADTCrateNecropolisStaffHealingWeak = { ent-ADTCrateNecropolis }
+    .desc = { ent-ADTCrateNecropolis.desc }
+    .suffix = Посох исцеления, Лаваленд

--- a/Resources/Prototypes/ADT/Catalog/Fills/Crates/necropolis.yml
+++ b/Resources/Prototypes/ADT/Catalog/Fills/Crates/necropolis.yml
@@ -79,3 +79,33 @@
   - type: StorageFill
     contents:
       - id: Mjollnir
+
+- type: entity
+  id: ADTCrateNecropolisRGBStaff
+  parent: ADTCrateNecropolis
+  suffix: RGBStaff
+  components:
+  - type: StorageFill
+    contents:
+      - id: RGBStaff
+
+- type: entity
+  id: ADTCrateNecropolisMimicry
+  parent: ADTCrateNecropolis
+  suffix: Mimicry
+  components:
+  - type: StorageFill
+    contents:
+      - id: ADTWeaponSworldMimicry
+      - id: ADTClothingFootMimicry
+      - id: ADTClothingEyesGlassesMimicry
+      - id: ADTClothingUniformMimicry
+
+- type: entity
+  id: ADTCrateNecropolisStaffHealingWeak
+  parent: ADTCrateNecropolis
+  suffix: HealingStaff
+  - type: StorageFill
+    contents:
+      - id: ADTWeaponStaffHealingWeak
+

--- a/Resources/Prototypes/ADT/Entities/Markers/Spawners/Random/crates.yml
+++ b/Resources/Prototypes/ADT/Entities/Markers/Spawners/Random/crates.yml
@@ -17,10 +17,13 @@
       - ADTCrateNecropolisCultRobe
       - ADTCrateNecropolisCultArmor
       - ADTCrateNecropolisVehicleLavabike
+      - ADTCrateNecropolisRGBStaff
     rarePrototypes:
       - ADTCrateNecropolisVavilon
       - ADTCrateNecropolisCursedKatana #krisa, why there was shard but not crate with shard???
       - ADTCrateNecropolisVampirismCrystal
       - ADTCrateNecropolisTrapAncientGoliath
       - ADTCrateNecropolisMjollnir
+      - ADTCrateNecropolisStaffHealingWeak
+      - ADTCrateNecropolisMimicry
     chance: 1

--- a/Resources/Prototypes/ADT/mining_shop.yml
+++ b/Resources/Prototypes/ADT/mining_shop.yml
@@ -22,13 +22,13 @@
   - id: WeaponProtoKineticAccelerator
     price: 550
   - id: ADTWeaponProtoKineticPistol
-    price: 1250
+    price: 1750
   - id: ADTWeaponProtoKineticShotgun
-    price: 1850
+    price: 2350
   - id: ADTWeaponProtoKineticRepeater
-    price: 1650
+    price: 2150
   - id: ADTWeaponProtoKineticRailgun
-    price: 1700
+    price: 2100
 
 - type: miningShopSection
   id: Motion
@@ -74,18 +74,18 @@
 #    price: 3000
   - id: ADTClothingOuterArmorMiner
     price: 1000
-  - id: ADTClothingModsuitBackMining
-    price: 1800
-  - id: ADTModsuitModDrill
-    price: 1000
-  - id: ADTModsuitModStorageLarge
-    price: 500 
 #  - id: ADTClothingOuterArmorMinerHeavy
 #    price: 3600
 #  - id: ADTClothingOuterArmorMinerLight
 #    price: 4000
   - id: ADTClothingJumpBoots
+    price: 1500
+  - id: ADTClothingModsuitBackMining
     price: 2500
+  - id: ADTModsuitModDrill
+    price: 1000
+  - id: ADTModsuitModStorageLarge
+    price: 500 
 
 
 - type: miningShopSection
@@ -95,13 +95,13 @@
   - id: Flare
     price: 75
   - id: Pickaxe
-    price: 150
+    price: 125
   - id: MiningDrill
-    price: 400
+    price: 425
   - id: SeismicCharge
-    price: 250
+    price: 200
   - id: FireExtinguisherMini
-    price: 250
+    price: 150
   - id: ADTWeaponCutter
     price: 1000
   - id: ADTShelterCapsule


### PR DESCRIPTION
Расширение дропа с тендрилов
Ребаланс цен в торгомате (очередной)

## Описание PR
- Расширение дропа с шипов некрополя
- Ребаланс шахтвенда
- Добавление новых штук для шахтёров и впиндюривание их в сундуки

## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс. -->
Ссылка на заказ, предложение или баг-репорт
- [Баг-репорт/Заказ/Предложение](ссылка)-->

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог

# ❗❗ УДАЛЯЙТЕ КОММЕНТЫ НИЖЕ И ПИШИТЕ no cl, no fun ЕСЛИ НИ ХОТИТЕ ЭТОГО В ЧЕЙНЖЛОГИ  ❗❗
# ❗❗ НЕ МЕРДЖИТЬ ПОКА НЕ УДАЛИТЕ  ❗❗
# ❗❗ ↓↓↓ ВОТ ЭТИ ↓↓↓ ❗❗

:cl: Illumy
- add: Добавлено пипи
- remove: Удалено пупу
- tweak: Многие позиции снаряжения в торгомате шахтёров стали дороже из-за дефицита на складах NanoTrasen.
- tweak: Некоторые позиции стали дешевле из-за избытка.
- tweak: Шипы некрополя пробудили новые секреты и стали дарить авантюристам новые ценности, которые сложно достать в других местах.
