### PR TITLE
Заменяем удаление дракона на гиб.

### DIFF
--- a/Content.Server/Dragon/DragonSystem.cs
+++ b/Content.Server/Dragon/DragonSystem.cs
@@ -99,13 +99,6 @@ public sealed partial class DragonSystem : EntitySystem
             if (!_mobState.IsDead(uid))
                 comp.RiftAccumulator += frameTime;
 
-            // Delete it, naughty dragon!
-            // if (comp.RiftAccumulator >= comp.RiftMaxAccumulator)
-            // {
-            //     Roar(uid, comp);
-            //     QueueDel(uid);
-            // }
-
             // ADT-Tweak start
             // TODO: сделать анимированную смерть, где дракон лопается, после чего трупы разлетяться в разные стороны.
             if (comp.RiftAccumulator >= comp.RiftMaxAccumulator)

--- a/Content.Server/Dragon/DragonSystem.cs
+++ b/Content.Server/Dragon/DragonSystem.cs
@@ -15,6 +15,7 @@ using Content.Shared.Zombies;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
+using Content.Shared.Damage; // ADT-Tweak
 
 namespace Content.Server.Dragon;
 
@@ -30,6 +31,7 @@ public sealed partial class DragonSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly DamageableSystem _damage = default!; // ADT-Tweak
 
     private EntityQuery<CarpRiftsConditionComponent> _objQuery;
 
@@ -98,11 +100,24 @@ public sealed partial class DragonSystem : EntitySystem
                 comp.RiftAccumulator += frameTime;
 
             // Delete it, naughty dragon!
+            // if (comp.RiftAccumulator >= comp.RiftMaxAccumulator)
+            // {
+            //     Roar(uid, comp);
+            //     QueueDel(uid);
+            // }
+
+            // ADT-Tweak start
+            // TODO: сделать анимированную смерть, где дракон лопается, после чего трупы разлетяться в разные стороны.
             if (comp.RiftAccumulator >= comp.RiftMaxAccumulator)
             {
                 Roar(uid, comp);
-                QueueDel(uid);
+
+                var damage = new DamageSpecifier();
+                damage.DamageDict["Blunt"] = 10000;
+
+                _damage.TryChangeDamage(uid, damage, true);
             }
+            // ADT-Tweak end
         }
     }
 


### PR DESCRIPTION
## Описание PR
Теперь дракон будет гибаться, вместо простого удаления, чтобы избежать удаления трупов игроков внутри него.

## Почему / Баланс
- [Баг-репорт/Заказ/Предложение](ссылка)--> https://discord.com/channels/901772674865455115/1387441490061561976

## Техническая информация
Ничо сложного вроде, да. Просто огромное кол-во бланта, чтобы дракона разрывало. В будущем можно будет завести прикольную анимацию для гиба и разлетание трупов по сторонам.

## Чейнджлог
:cl: M1and1B
- tweak: Теперь вместо удаления, дракона гибает, если тот долго не ставил разломы.

