### PR TITLE
[FUN] Мимы теперь умеют надувать шарики из воздуха

### DIFF
--- a/Content.Server/ADT/Mime/MImeBaloonComponent.cs
+++ b/Content.Server/ADT/Mime/MImeBaloonComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server.ADT.Mime;
+
+[RegisterComponent]
+public sealed partial class MimeBaloonComponent : Component
+{
+    public List<string> ListPrototypesBaloon = ["BalloonNT", "BalloonCorgi", "BalloonSyn"];
+}

--- a/Content.Server/ADT/Mime/MimeBaloonSystem.cs
+++ b/Content.Server/ADT/Mime/MimeBaloonSystem.cs
@@ -1,0 +1,29 @@
+using Content.Server.ADT.Mime;
+using Content.Shared.ADT.Mime;
+using Content.Server.Popups;
+using Robust.Shared.Random;
+
+public sealed class MimeBaloonSystem : EntitySystem
+{
+
+    [Dependency] private readonly PopupSystem _popupSystem = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MimeBaloonComponent, SpawnBaloonEvent>(OnSpawnBaloonMime);
+    }
+
+    private void OnSpawnBaloonMime(EntityUid uid, MimeBaloonComponent component, SpawnBaloonEvent args)
+    {
+
+        var xform = Transform(args.Performer);
+
+        _popupSystem.PopupEntity(Loc.GetString("mime-baloon-popup", ("entity", uid)), uid);
+
+        var randomPickPrototype = _random.Pick(component.ListPrototypesBaloon);
+
+        Spawn(randomPickPrototype, xform.Coordinates);
+    }
+}

--- a/Content.Shared/ADT/Actions/SpawnBaloonEvent.cs
+++ b/Content.Shared/ADT/Actions/SpawnBaloonEvent.cs
@@ -1,0 +1,7 @@
+using Content.Shared.Actions;
+
+namespace Content.Shared.ADT.Mime;
+
+public sealed partial class SpawnBaloonEvent : InstantActionEvent
+{
+}

--- a/Resources/Locale/ru-RU/ADT/actions/mime.ftl
+++ b/Resources/Locale/ru-RU/ADT/actions/mime.ftl
@@ -1,0 +1,4 @@
+ent-ADTActionBaloonOfMime = Создать воздушный шар
+    .desc = Создайте воздушный шар
+
+mime-baloon-popup = { CAPITALIZE($entity) } надувает воздушный шар!

--- a/Resources/Prototypes/ADT/Actions/baloon.yml
+++ b/Resources/Prototypes/ADT/Actions/baloon.yml
@@ -1,0 +1,13 @@
+- type: entity
+  id: ADTActionBaloonOfMime
+  name: Spawn baloon
+  description: Spawn baloon
+  components:
+  - type: InstantAction
+    useDelay: 10
+    checkCanInteract: false
+    itemIconStyle: BigAction
+    icon:
+      sprite: Objects/Fun/toys.rsi
+      state: ntb
+    event: !type:SpawnBaloonEvent

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -18,6 +18,12 @@
     - type: MimePowers
       preventWriting: true
     - type: FrenchAccent
+    # ADT-Tweak start. Акшон надувания шаров
+    - type: MimeBaloon
+    - type: ActionGrant
+      actions:
+      - ADTActionBaloonOfMime
+    # ADT-Tweak end.
 
 - type: startingGear
   id: MimeGear


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
Добавил возможность мимам надувать все имеющиеся шарики в сборке из воздуха.
Кд в 10 секунд.
## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс. -->
Ссылка на заказ, предложение или баг-репорт
- [Заказ](https://discord.com/channels/901772674865455115/1090864630617886730)

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
Создан компонент `MImeBaloonComponent` имеющий List<string> из которого берутся ID шаров для спавна.
Создана система `MimeBaloonSystem` с подпиской на `SpawnBaloonEvent`, которая спавнит шарик.
Добавлен ивент `SpawnBaloonEvent`, который активируется при нажатии на акшон.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог
🆑 Darkiich
- add: Добавлена возможность для мимо, которая позволяет надувать шарики из воздуха!
