### PR TITLE
[TWEAK] Пассивное лечение ядов и радиации

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Mobs/Species/Drask.yml
+++ b/Resources/Prototypes/ADT/Entities/Mobs/Species/Drask.yml
@@ -35,6 +35,8 @@
     damage:
       types:
         Heat: -0.04
+        Poison: -0.03
+        Radiation: -0.015
       groups:
         Brute: -0.06
   - type: Body

--- a/Resources/Prototypes/ADT/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/ADT/Entities/Mobs/Species/base.yml
@@ -23,6 +23,8 @@
     damage:
       types:
         Heat: -0.07
+        Poison: -0.035
+        Radiation: -0.0175
       groups:
         Brute: -0.07
   - type: Fingerprint

--- a/Resources/Prototypes/ADT/Entities/Mobs/Species/kobolt.yml
+++ b/Resources/Prototypes/ADT/Entities/Mobs/Species/kobolt.yml
@@ -35,6 +35,8 @@
       types:
         Heat: -0.06
         Cold: -0.04
+        Poison: -0.04
+        Radiation: -0.02
       groups:
         Brute: -0.08
   - type: Bloodstream

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -258,6 +258,8 @@
     damage:
       types:
         Heat: -0.07
+        Poison: -0.035 #ADT-tweak
+        Radiation: -0.0175 #ADT-tweak
       groups:
         Brute: -0.07
   - type: Fingerprint

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -125,6 +125,8 @@
     damage:
       types:
         Cold: -0.06
+        Poison: -0.04 #ADT-tweak
+        Radiation: -0.02 #ADT-tweak
       groups:
         Brute: -0.08
   - type: SlowOnDamage

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -74,6 +74,8 @@
     damage:
       types:
         Heat: -0.14
+        Poison: -0.07 #ADT-tweak
+        Radiation: -0.035 #ADT-tweak
       groups:
         Brute: -0.14
   - type: DamageVisuals

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -48,6 +48,7 @@
       types:
         Heat: -0.07
         Poison: -0.2
+        Radiation: -0.1 #ADT-tweak
       groups:
         Brute: -0.07
   # ADT-Tweak Start


### PR DESCRIPTION
## Описание PR
- Добавляет каждой расе пассивное лечение от ядов, равное половине лечения от механического урона и пассивное лечение от радиации, равное половине лечения от ядов.
**К примеру:**
Механические: 0.07
Яды: 0.035
Радиация: 0.0175

## Почему / Баланс
- Организм способен естественным образом выводить различные токсины со временем.
- Избавит врачей от нужды лечить 1-2 единицы ядов/радиации у несчастных алкоголиков/инженеров.
- [Предложение](https://discord.com/channels/901772674865455115/1395023766039564410/1395023766039564410)

## Чейнджлог

:cl: Kerfus
- tweak: Теперь каждая раса имеет пассивное лечение от ядов и радиации.
