### PR TITLE
Летающие самолёты-оригами

### DIFF
--- a/Content.Server/ADT/PaperOrigami/PaperOrigamiSystem.cs
+++ b/Content.Server/ADT/PaperOrigami/PaperOrigamiSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Tag;
 using Content.Shared.Verbs;
 using Content.Shared.ADT.PaperOrigami;
 using Content.Shared.ADT.PaperOrigami.Components;
+using Content.Shared.Throwing;
 using Robust.Shared.Utility;
 
 namespace Content.Server.ADT.PaperOrigami;
@@ -23,6 +24,16 @@ public sealed class PaperOrigamiSystem : EntitySystem
 
         component.CanMakeState = canMakeState;
         _appearance.SetData(uid, PaperOrigamiState.State, component.CanMakeState, appearance);
+
+        if (canMakeState)
+        {
+            var throwing = EnsureComp<ThrowingAngleComponent>(uid);
+            throwing.Angle = Angle.FromDegrees(90);
+        }
+        else
+        {
+            RemComp<ThrowingAngleComponent>(uid);
+        }
     }
 
     private void OnAddVerbIsPaperOrigami(EntityUid uid, PaperOrigamiComponent component, GetVerbsEvent<Verb> args)


### PR DESCRIPTION
## Описание PR
Позволяет самолетам, сделанным из бумаги, пролетать некоторое расстояние

## Почему / Баланс
Для большей реалистичности
- [Предложение](https://discord.com/channels/901772674865455115/1391433514175434804)

## Техническая информация
1. Система PaperOrigamiSystem инициализируется и подписывается на событие GetVerbsEvent<Verb>, которое позволяет добавлять новые действия (глаголы) к объектам с компонентом PaperOrigamiComponent.

2. Метод UpdateAppearance обновляет визуальное состояние объекта в зависимости от того, может ли он быть преобразован в оригами. Если это возможно, добавляется компонент для управления углом броска.

3. Метод OnAddVerbIsPaperOrigami добавляет два глагола:
   – "Сделать бумажный самолетик"
   – "Сделать обычное оригами"

**Критические изменения**

1. Публичные классы/методы/поля:
   – Класс PaperOrigamiSystem является публичным и наследует от EntitySystem. Он взаимодействует с сущностями.
   – Метод Initialize() переопределен для подписки на события.
   – Метод UpdateAppearance изменяет состояние внешнего вида объекта на основе параметра canMakeState.
   – Метод OnAddVerbIsPaperOrigami добавляет глаголы к объекту, проверяя доступ и взаимодействие перед добавлением.

2. Добавлена логика проверки тегов, чтобы предотвратить добавление глаголов для объектов с тегом "ADTDoNotMakeOrigami".

3. Создание и использование объектов Verb: Создаются экземпляры Verb для выполнения действий, связанных с оригами, с установленными текстом и иконками.

## Чейнджлог
:cl: eddiemercury
- tweak: Самолеты-оригами теперь могут нормально летать