### PR TITLE
[HotFix] Фикс вечного подключения к серверу

### DIFF
--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -465,13 +465,13 @@ namespace Content.Server.Ghost
 
                 if (visible)
                 {
-                    _visibilitySystem.AddLayer((uid, vis), (int)VisibilityFlags.Normal, false);
-                    _visibilitySystem.RemoveLayer((uid, vis), (int)VisibilityFlags.Ghost, false);
+                    _visibilitySystem.AddLayer((uid, vis), (int) VisibilityFlags.Normal, false);
+                    _visibilitySystem.RemoveLayer((uid, vis), (int) VisibilityFlags.Ghost, false);
                 }
                 else
                 {
-                    _visibilitySystem.AddLayer((uid, vis), (int)VisibilityFlags.Ghost, false);
-                    _visibilitySystem.RemoveLayer((uid, vis), (int)VisibilityFlags.Normal, false);
+                    _visibilitySystem.AddLayer((uid, vis), (int) VisibilityFlags.Ghost, false);
+                    _visibilitySystem.RemoveLayer((uid, vis), (int) VisibilityFlags.Normal, false);
                 }
                 _visibilitySystem.RefreshVisibility(uid, visibilityComponent: vis);
             }

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -208,8 +208,8 @@ namespace Content.Server.Ghost
 
             if (_gameTicker.RunLevel != GameRunLevel.PostRound)
             {
-                _visibilitySystem.AddLayer((uid, visibility), (int)VisibilityFlags.Ghost, false);
-                _visibilitySystem.RemoveLayer((uid, visibility), (int)VisibilityFlags.Normal, false);
+                _visibilitySystem.AddLayer((uid, visibility), (int) VisibilityFlags.Ghost, false);
+                _visibilitySystem.RemoveLayer((uid, visibility), (int) VisibilityFlags.Normal, false);
                 _visibilitySystem.RefreshVisibility(uid, visibilityComponent: visibility);
             }
 
@@ -227,8 +227,8 @@ namespace Content.Server.Ghost
             // Entity can't be seen by ghosts anymore.
             if (TryComp(uid, out VisibilityComponent? visibility))
             {
-                _visibilitySystem.RemoveLayer((uid, visibility), (int)VisibilityFlags.Ghost, false);
-                _visibilitySystem.AddLayer((uid, visibility), (int)VisibilityFlags.Normal, false);
+                _visibilitySystem.RemoveLayer((uid, visibility), (int) VisibilityFlags.Ghost, false);
+                _visibilitySystem.AddLayer((uid, visibility), (int) VisibilityFlags.Normal, false);
                 _visibilitySystem.RefreshVisibility(uid, visibilityComponent: visibility);
             }
 
@@ -321,7 +321,7 @@ namespace Content.Server.Ghost
 
         private void OnGhostReturnToBodyRequest(GhostReturnToBodyRequest msg, EntitySessionEventArgs args)
         {
-            if (args.SenderSession.AttachedEntity is not { Valid: true } attached
+            if (args.SenderSession.AttachedEntity is not {Valid: true} attached
                 || !_ghostQuery.TryComp(attached, out var ghost)
                 || !ghost.CanReturnToBody
                 || !TryComp(attached, out ActorComponent? actor))
@@ -337,7 +337,7 @@ namespace Content.Server.Ghost
 
         private void OnGhostWarpsRequest(GhostWarpsRequestEvent msg, EntitySessionEventArgs args)
         {
-            if (args.SenderSession.AttachedEntity is not { Valid: true } entity
+            if (args.SenderSession.AttachedEntity is not {Valid: true} entity
                 || !_ghostQuery.HasComp(entity))
             {
                 Log.Warning($"User {args.SenderSession.Name} sent a {nameof(GhostWarpsRequestEvent)} without being a ghost.");
@@ -350,7 +350,7 @@ namespace Content.Server.Ghost
 
         private void OnGhostWarpToTargetRequest(GhostWarpToTargetRequestEvent msg, EntitySessionEventArgs args)
         {
-            if (args.SenderSession.AttachedEntity is not { Valid: true } attached
+            if (args.SenderSession.AttachedEntity is not {Valid: true} attached
                 || !_ghostQuery.HasComp(attached))
             {
                 Log.Warning($"User {args.SenderSession.Name} tried to warp to {msg.Target} without being a ghost.");
@@ -373,14 +373,14 @@ namespace Content.Server.Ghost
 
         private void OnGhostnadoRequest(GhostnadoRequestEvent msg, EntitySessionEventArgs args)
         {
-            if (args.SenderSession.AttachedEntity is not { } uid
+            if (args.SenderSession.AttachedEntity is not {} uid
                 || !_ghostQuery.HasComp(uid))
             {
                 Log.Warning($"User {args.SenderSession.Name} tried to ghostnado without being a ghost.");
                 return;
             }
 
-            if (_followerSystem.GetMostGhostFollowed() is not { } target)
+            if (_followerSystem.GetMostGhostFollowed() is not {} target)
                 return;
 
             WarpTo(uid, target);
@@ -417,7 +417,7 @@ namespace Content.Server.Ghost
         {
             foreach (var player in _playerManager.Sessions)
             {
-                if (player.AttachedEntity is not { Valid: true } attached)
+                if (player.AttachedEntity is not {Valid: true} attached)
                     continue;
 
                 if (attached == except) continue;

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -43,32 +43,33 @@
     sprite: Mobs/Ghosts/ghost_human.rsi
     color: "#fff8"
     layers: # ADT ghost start
-    - map: [ "enum.HumanoidVisualLayers.Chest" ]
-      shader: unshaded
-    - map: [ "enum.HumanoidVisualLayers.Head" ]
-      shader: unshaded
-    - map: [ "enum.HumanoidVisualLayers.Snout" ]
-      shader: unshaded
-    - map: [ "enum.HumanoidVisualLayers.Eyes" ]
-      shader: unshaded
-    - map: [ "enum.HumanoidVisualLayers.RArm" ]
-      shader: unshaded
-    - map: [ "enum.HumanoidVisualLayers.LArm" ]
-      shader: unshaded
-    - map: [ "enum.HumanoidVisualLayers.RLeg" ]
-      shader: unshaded
-    - map: [ "enum.HumanoidVisualLayers.LLeg" ]
-      shader: unshaded
-    - map: [ "enum.HumanoidVisualLayers.LFoot" ]
-      shader: unshaded
-    - map: [ "enum.HumanoidVisualLayers.RFoot" ]
-      shader: unshaded
-    - map: ["enum.HumanoidVisualLayers.LHand"]
-      shader: unshaded
-    - map: ["enum.HumanoidVisualLayers.RHand"]
-      shader: unshaded
-    - map: ["jumpsuit"]
-      shader: unshaded
+    - state: animated # TODO: был откат, это нужно доделать в Content.Server\Ghost\GhostSystem.cs метод OnPlayerAttached
+    # - map: [ "enum.HumanoidVisualLayers.Chest" ]
+    #   shader: unshaded
+    # - map: [ "enum.HumanoidVisualLayers.Head" ]
+    #   shader: unshaded
+    # - map: [ "enum.HumanoidVisualLayers.Snout" ]
+    #   shader: unshaded
+    # - map: [ "enum.HumanoidVisualLayers.Eyes" ]
+    #   shader: unshaded
+    # - map: [ "enum.HumanoidVisualLayers.RArm" ]
+    #   shader: unshaded
+    # - map: [ "enum.HumanoidVisualLayers.LArm" ]
+    #   shader: unshaded
+    # - map: [ "enum.HumanoidVisualLayers.RLeg" ]
+    #   shader: unshaded
+    # - map: [ "enum.HumanoidVisualLayers.LLeg" ]
+    #   shader: unshaded
+    # - map: [ "enum.HumanoidVisualLayers.LFoot" ]
+    #   shader: unshaded
+    # - map: [ "enum.HumanoidVisualLayers.RFoot" ]
+    #   shader: unshaded
+    # - map: ["enum.HumanoidVisualLayers.LHand"]
+    #   shader: unshaded
+    # - map: ["enum.HumanoidVisualLayers.RHand"]
+    #   shader: unshaded
+    # - map: ["jumpsuit"]
+    #   shader: unshaded
   # ОЧЕНЬ ЧЁРТ ВОЗЬМИ ВАЖНЫЙ TODO: придумать, как сделать аншейдед на госта
   # ADT ghost end
   - type: ContentEye


### PR DESCRIPTION
## Описание PR
Исправление вечного подключения к серверу

Лог ошибки:
```ps
[ERRO] runtime: Caught exception in "Async Queued Callback"

System.InvalidOperationException: Preferences for this player have not loaded yet.

   at Content.Server.Ghost.GhostSystem.OnPlayerAttached(EntityUid uid, GhostComponent component, PlayerAttachedEvent args) in /home/runner/work/space_station_ADT/space_station_ADT/Content.Server/Ghost/GhostSystem.cs:line 278

   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass67_0`1.<EntSubscribe>b__0(EntityUid uid, IComponent comp, Unit& ev) in /home/runner/work/space_station_ADT/space_station_ADT/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 460

   at Robust.Shared.GameObjects.EntityEventBus.EntDispatch(EntityUid euid, Type eventType, Unit& args) in /home/runner/work/space_station_ADT/space_station_ADT/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 633

   at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEvent[TEvent](EntityUid uid, TEvent args, Boolean broadcast) in /home/runner/work/space_station_ADT/space_station_ADT/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 200

   at Robust.Shared.Player.SharedPlayerManager.Attach(ICommonSession session, EntityUid uid, ICommonSession& kicked, Boolean force) in /home/runner/work/space_station_ADT/space_station_ADT/RobustToolbox/Robust.Shared/Player/SharedPlayerManager.Sessions.cs:line 221

   at Robust.Shared.Player.SharedPlayerManager.SetAttachedEntity(ICommonSession session, Nullable`1 uid, ICommonSession& kicked, Boolean force) in /home/runner/work/space_station_ADT/space_station_ADT/RobustToolbox/Robust.Shared/Player/SharedPlayerManager.Sessions.cs:line 167

   at Robust.Shared.Player.ISharedPlayerManager.SetAttachedEntity(ICommonSession session, Nullable`1 entity, Boolean force) in /home/runner/work/space_station_ADT/space_station_ADT/RobustToolbox/Robust.Shared/Player/ISharedPlayerManager.cs:line 149

   at Content.Server.GameTicking.GameTicker.PlayerStatusChanged(Object sender, SessionStatusEventArgs args) in /home/runner/work/space_station_ADT/space_station_ADT/Content.Server/GameTicking/GameTicker.Player.cs:line 181

   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_0(Object state)

   at Robust.Shared.Asynchronous.RobustSynchronizationContext.ProcessPendingTasks() in /home/runner/work/space_station_ADT/space_station_ADT/RobustToolbox/Robust.Shared/Asynchronous/RobustSynchronizationContext.cs:line 54
```

## Почему / Баланс
Пользователи не могут зайти обратно, если выйдут из игры находясь в гостах

## Техническая информация
в `Content.Server\Ghost\GhostSystem.cs` метод `OnPlayerAttached` был закомментирован
Откат функционала этой фичи https://github.com/AdventureTimeSS14/space_station_ADT/pull/1020

## Медиа
<img width="518" height="318" alt="image" src="https://github.com/user-attachments/assets/40ea4d83-e4c3-4bd6-b249-eac75c4d5aba" />

## Чейнджлог

:cl: Шрёдька
- fix: Исправлена бесконечная загрузка при повторном подключении к серверу при нахождении в гостах.
- remove: Скин госта больше не копирует внешний вид вашего персонажа.

