### PR TITLE
[PORT] meson debuff

### DIFF
--- a/Content.Client/ADT/MesonVision/MesonVisionOverlay.cs
+++ b/Content.Client/ADT/MesonVision/MesonVisionOverlay.cs
@@ -1,16 +1,13 @@
 using System.Numerics;
 using Content.Shared.ADT.MesonVision;
-using Content.Shared.Mobs.Components;
+using Content.Shared.Doors.Components;
+using Content.Shared.Light.Components;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Map;
-using Content.Client.Markers;
-using Robust.Shared.GameObjects;
-using Content.Shared.StepTrigger.Components;
-using Content.Shared.Item;
-using DrawDepthTag = Robust.Shared.GameObjects.DrawDepth;
+
 namespace Content.Client.ADT.MesonVision;
 
 public sealed class MesonVisionOverlay : Overlay
@@ -19,9 +16,6 @@ public sealed class MesonVisionOverlay : Overlay
     [Dependency] private readonly IPlayerManager _player = default!;
     private readonly SharedTransformSystem _xformSystem;
     private readonly ContainerSystem _container;
-    private readonly EntityQuery<ItemComponent> _item;
-    private readonly EntityQuery<MobStateComponent> _mob;
-    private readonly EntityQuery<MarkerComponent> _marker;
     private readonly EntityQuery<SpriteComponent> _spriteQuery;
     private readonly EntityQuery<TransformComponent> _xformQuery;
 
@@ -33,9 +27,6 @@ public sealed class MesonVisionOverlay : Overlay
         IoCManager.InjectDependencies(this);
         _container = _entity.System<ContainerSystem>();
         _xformSystem = _entity.System<SharedTransformSystem>();
-        _item = _entity.GetEntityQuery<ItemComponent>();
-        _mob = _entity.GetEntityQuery<MobStateComponent>();
-        _marker = _entity.GetEntityQuery<MarkerComponent>();
         _spriteQuery = _entity.GetEntityQuery<SpriteComponent>();
         _xformQuery = _entity.GetEntityQuery<TransformComponent>();
     }
@@ -58,15 +49,22 @@ public sealed class MesonVisionOverlay : Overlay
 
         foreach (var entity in _entity.GetEntities())
         {
-            if (_mob.HasComponent(entity) || _marker.HasComponent(entity)) continue;
-            if (!_spriteQuery.TryGetComponent(entity, out var sprite) || sprite.DrawDepth < -2 || sprite.DrawDepth > 7 || sprite.DrawDepth == 0) continue;
-            if (!_xformQuery.TryGetComponent(entity, out var xform)) continue;
-            if (_container.TryGetOuterContainer(entity, xform, out var container)) continue;
-
-            if (xform.MapID != mapId) continue;
+            if (!_spriteQuery.TryGetComponent(entity, out var sprite) ||
+                !_xformQuery.TryGetComponent(entity, out var xform) ||
+                xform.MapID != mapId ||
+                _container.TryGetOuterContainer(entity, xform, out var _))
+            {
+                continue;
+            }
 
             var worldPos = _xformSystem.GetWorldPosition(xform);
             if (!worldBounds.Contains(worldPos)) continue;
+
+            var isWall = _entity.HasComponent<SunShadowCastComponent>(entity) || _entity.HasComponent<IsRoofComponent>(entity);
+            var isDoor = _entity.HasComponent<DoorComponent>(entity);
+
+            if (!isWall && !isDoor)
+                continue;
 
             _entries.Add(new MesonVisionRenderEntry(
                 (entity, sprite, xform),


### PR DESCRIPTION
## **Описание PR**

Порт: https://github.com/CrimeMoot/Ganimed14/pull/232
Мезонки теперь делают ровно то, что должны: **показывают стены и шлюзы**.
Никаких объектов, разбросанных тапочек, гильз от пуль и прочего цирка через стены вы больше не увидите - только чистый "инженерный сканер".

**Пол**, к сожалению, отрисовать не удалось, потому что… ну, **пол - это не сущность**, и напрямую его нарисовать нельзя.
Если вы знаете как - напишите мне, я тоже хочу это узнать.

## **Почему / Баланс**
Честно говоря, видеть *всё подряд через стены* - это уже перебор.
Мезонки изначально задумывались, чтобы помогать с навигацией инженеров и возможность понимать, как строить а не для шпионских операций в риге.

Теперь они показывают только то, что и должны: **стены, шлюзы, да и в идеале пол… (но пол пока что в отпуске).**

## **Техническая часть**
* Оптимизирован обход сущностей: теперь в рендер попадают **только стены и шлюзы** (`SunShadowCastComponent`, `IsRoofComponent`, `DoorComponent`).
* Все остальные объекты исключены из обработки (окна, мебель, случайные детали).
* Процесс стал быстрее, а картинка - чище.

## **Медиа**


https://github.com/user-attachments/assets/cdf5020a-c721-4454-a643-bc8b71564466

## **Чейнджлог**
:cl: CrimeMoot

- tweak: Мезонные очки теперь показывают **только стены и шлюзы**. Больше никаких "рентгеновских суперспособностей".