### PR TITLE
[PORT] meson debuff

### DIFF
--- a/Content.Client/ADT/MesonVision/MesonVisionOverlay.cs
+++ b/Content.Client/ADT/MesonVision/MesonVisionOverlay.cs
@@ -1,16 +1,13 @@
 using System.Numerics;
 using Content.Shared.ADT.MesonVision;
-using Content.Shared.Mobs.Components;
+using Content.Shared.Doors.Components;
+using Content.Shared.Light.Components;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Map;
-using Content.Client.Markers;
-using Robust.Shared.GameObjects;
-using Content.Shared.StepTrigger.Components;
-using Content.Shared.Item;
-using DrawDepthTag = Robust.Shared.GameObjects.DrawDepth;
+
 namespace Content.Client.ADT.MesonVision;
 
 public sealed class MesonVisionOverlay : Overlay
@@ -19,9 +16,6 @@ public sealed class MesonVisionOverlay : Overlay
     [Dependency] private readonly IPlayerManager _player = default!;
     private readonly SharedTransformSystem _xformSystem;
     private readonly ContainerSystem _container;
-    private readonly EntityQuery<ItemComponent> _item;
-    private readonly EntityQuery<MobStateComponent> _mob;
-    private readonly EntityQuery<MarkerComponent> _marker;
     private readonly EntityQuery<SpriteComponent> _spriteQuery;
     private readonly EntityQuery<TransformComponent> _xformQuery;
 
@@ -33,9 +27,6 @@ public sealed class MesonVisionOverlay : Overlay
         IoCManager.InjectDependencies(this);
         _container = _entity.System<ContainerSystem>();
         _xformSystem = _entity.System<SharedTransformSystem>();
-        _item = _entity.GetEntityQuery<ItemComponent>();
-        _mob = _entity.GetEntityQuery<MobStateComponent>();
-        _marker = _entity.GetEntityQuery<MarkerComponent>();
         _spriteQuery = _entity.GetEntityQuery<SpriteComponent>();
         _xformQuery = _entity.GetEntityQuery<TransformComponent>();
     }
@@ -58,15 +49,22 @@ public sealed class MesonVisionOverlay : Overlay
 
         foreach (var entity in _entity.GetEntities())
         {
-            if (_mob.HasComponent(entity) || _marker.HasComponent(entity)) continue;
-            if (!_spriteQuery.TryGetComponent(entity, out var sprite) || sprite.DrawDepth < -2 || sprite.DrawDepth > 7 || sprite.DrawDepth == 0) continue;
-            if (!_xformQuery.TryGetComponent(entity, out var xform)) continue;
-            if (_container.TryGetOuterContainer(entity, xform, out var container)) continue;
-
-            if (xform.MapID != mapId) continue;
+            if (!_spriteQuery.TryGetComponent(entity, out var sprite) ||
+                !_xformQuery.TryGetComponent(entity, out var xform) ||
+                xform.MapID != mapId ||
+                _container.TryGetOuterContainer(entity, xform, out var _))
+            {
+                continue;
+            }
 
             var worldPos = _xformSystem.GetWorldPosition(xform);
             if (!worldBounds.Contains(worldPos)) continue;
+
+            var isWall = _entity.HasComponent<SunShadowCastComponent>(entity) || _entity.HasComponent<IsRoofComponent>(entity);
+            var isDoor = _entity.HasComponent<DoorComponent>(entity);
+
+            if (!isWall && !isDoor)
+                continue;
 
             _entries.Add(new MesonVisionRenderEntry(
                 (entity, sprite, xform),

--- a/Content.Client/ADT/MesonVision/MesonVisionOverlay.cs
+++ b/Content.Client/ADT/MesonVision/MesonVisionOverlay.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using Content.Shared.ADT.MesonVision;
 using Content.Shared.Doors.Components;
 using Content.Shared.Light.Components;
+using Content.Shared.Tag;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
@@ -18,6 +19,7 @@ public sealed class MesonVisionOverlay : Overlay
     private readonly ContainerSystem _container;
     private readonly EntityQuery<SpriteComponent> _spriteQuery;
     private readonly EntityQuery<TransformComponent> _xformQuery;
+    private readonly EntityQuery<TagComponent> _tagQuery;
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
     private readonly List<MesonVisionRenderEntry> _entries = new(64);
@@ -29,41 +31,53 @@ public sealed class MesonVisionOverlay : Overlay
         _xformSystem = _entity.System<SharedTransformSystem>();
         _spriteQuery = _entity.GetEntityQuery<SpriteComponent>();
         _xformQuery = _entity.GetEntityQuery<TransformComponent>();
+        _tagQuery = _entity.GetEntityQuery<TagComponent>();
     }
 
     protected override void Draw(in OverlayDrawArgs args)
     {
         if (!_entity.TryGetComponent(_player.LocalEntity, out MesonVisionComponent? nightVision) ||
             nightVision.State != MesonVisionState.Full)
-        {
             return;
-        }
 
         var eye = args.Viewport.Eye;
-        if (eye == null) return;
+        if (eye == null)
+            return;
 
-        var mapId = eye.Position.MapId;
-        var eyeRot = eye.Rotation;
+        MapId mapId = eye.Position.MapId;
+        Angle eyeRot = eye.Rotation;
         var worldBounds = args.WorldBounds;
         var worldHandle = args.WorldHandle;
 
-        foreach (var entity in _entity.GetEntities())
+        foreach (EntityUid entity in _entity.GetEntities())
         {
             if (!_spriteQuery.TryGetComponent(entity, out var sprite) ||
                 !_xformQuery.TryGetComponent(entity, out var xform) ||
                 xform.MapID != mapId ||
-                _container.TryGetOuterContainer(entity, xform, out var _))
-            {
+                _container.TryGetOuterContainer(entity, xform, out _))
                 continue;
+
+            Vector2 worldPos = _xformSystem.GetWorldPosition(xform);
+            if (!worldBounds.Contains(worldPos))
+                continue;
+
+            bool isWall = _entity.HasComponent<SunShadowCastComponent>(entity) || _entity.HasComponent<IsRoofComponent>(entity);
+            bool isDoor = _entity.HasComponent<DoorComponent>(entity);
+
+            bool hasMesonTag = false;
+            if (_tagQuery.TryGetComponent(entity, out var tagComp))
+            {
+                foreach (var tag in tagComp.Tags)
+                {
+                    if (tag == "MesonVisible")
+                    {
+                        hasMesonTag = true;
+                        break;
+                    }
+                }
             }
 
-            var worldPos = _xformSystem.GetWorldPosition(xform);
-            if (!worldBounds.Contains(worldPos)) continue;
-
-            var isWall = _entity.HasComponent<SunShadowCastComponent>(entity) || _entity.HasComponent<IsRoofComponent>(entity);
-            var isDoor = _entity.HasComponent<DoorComponent>(entity);
-
-            if (!isWall && !isDoor)
+            if (!(isWall || isDoor || hasMesonTag))
                 continue;
 
             _entries.Add(new MesonVisionRenderEntry(
@@ -71,33 +85,33 @@ public sealed class MesonVisionOverlay : Overlay
                 mapId,
                 eyeRot,
                 sprite.DrawDepth,
-                1f
-            ));
+                1f));
         }
 
         foreach (var entry in _entries)
         {
-            RenderFast(entry.Ent, worldHandle, entry.EyeRot, entry.Transparency ?? 1f, nightVision.Color);
+            RenderFastRaw(entry.Ent, worldHandle, entry.EyeRot, entry.Transparency ?? 1f);
         }
 
         _entries.Clear();
     }
 
-    private void RenderFast(
-        Entity<SpriteComponent, TransformComponent> ent,
+    private void RenderFastRaw(
+        (EntityUid uid, SpriteComponent sprite, TransformComponent xform) ent,
         DrawingHandleWorld handle,
         Angle eyeRot,
-        float alpha,
-        Color color)
+        float alpha)
     {
         var (uid, sprite, xform) = ent;
-        var position = _xformSystem.GetWorldPosition(xform);
-        var rotation = _xformSystem.GetWorldRotation(xform);
+
+        Vector2 position = _xformSystem.GetWorldPosition(xform);
+        Angle rotation = _xformSystem.GetWorldRotation(xform);
 
         handle.SetTransform(position, rotation);
 
         var originalColor = sprite.Color;
-        sprite.Color = color.WithAlpha(alpha);
+
+        sprite.Color = originalColor.WithAlpha(alpha);
         sprite.Render(handle, eyeRot, rotation, position: position);
         sprite.Color = originalColor;
         handle.SetTransform(Vector2.Zero, Angle.Zero);

--- a/Resources/Prototypes/ADT/tags.yml
+++ b/Resources/Prototypes/ADT/tags.yml
@@ -125,6 +125,9 @@
   id: Mask
 
 - type: Tag
+  id: MesonVisible
+
+- type: Tag
   id: Organ
 
 - type: Tag

--- a/Resources/Prototypes/Entities/Structures/Power/apc.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/apc.yml
@@ -149,6 +149,9 @@
     - Power
   - type: BatteryDrinkerSource # ADT - IPC
     maxAmount: 10000
+  - type: Tag # ADT meson
+    tags:
+    - MesonVisible
 
 # APC under construction
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
@@ -51,6 +51,7 @@
   - type: Tag
     tags:
       - AirAlarm
+      - MesonVisible # ADT meson
   - type: AtmosDevice
   - type: StationAiWhitelist #ADT-Tweak
   - type: AirAlarm

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/fire_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/fire_alarm.yml
@@ -39,6 +39,7 @@
   - type: Tag
     tags:
       - FireAlarm
+      - MesonVisible # ADT meson
   - type: Clickable
   - type: InteractionOutline
   - type: FireAlarm


### PR DESCRIPTION
## **Описание PR**
Порт: https://github.com/CrimeMoot/Ganimed14/pull/232
Мезонки теперь делают ровно то, что должны: **показывают стены и шлюзы**.
Никаких объектов, разбросанных тапочек, гильз от пуль и прочего цирка через стены вы больше не увидите - только чистый "инженерный сканер".

**Пол**, к сожалению, отрисовать не удалось, потому что… ну, **пол - это не сущность**, и напрямую его нарисовать нельзя.
Если вы знаете как - напишите мне, я тоже хочу это узнать.

## **Почему / Баланс**
Честно говоря, видеть *всё подряд через стены* - это уже перебор.
Мезонки изначально задумывались, чтобы помогать с навигацией инженеров и возможность понимать, как строить а не для шпионских операций в риге.

Теперь они показывают только то, что и должны: **стены, шлюзы, да и в идеале пол… (но пол пока что в отпуске).**

## **Техническая часть**
* Оптимизирован обход сущностей: теперь в рендер попадают **только стены и шлюзы** (`SunShadowCastComponent`, `IsRoofComponent`, `DoorComponent`).
* Все остальные объекты исключены из обработки (окна, мебель, случайные детали).
* Процесс стал быстрее, а картинка - чище.

## **Медиа**
https://github.com/user-attachments/assets/cdf5020a-c721-4454-a643-bc8b71564466

## **Чейнджлог**
:cl: CrimeMoot
- tweak: Мезонные очки теперь показывают **только стены и шлюзы, и настенные электронные устройства**. Больше никаких "рентгеновских суперспособностей".