### PR TITLE
[TWEAK] Cвежие наггетсы из резоми?!

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/ADT/Entities/Mobs/Species/resomi.yml
@@ -37,6 +37,11 @@
       0: Alive
       85: Critical
       140: Dead
+  - type: Butcherable
+    butcheringType: Spike
+    spawned:
+    - id: FoodMeatChicken
+      amount: 5
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: Resomi


### PR DESCRIPTION
## Описание PR
Из резоми при разделке теперь выпадает 5 кусков куриного мяса, также как у воксов.
## Почему / Баланс
Потому что такая фишка уже есть у воксов, а резоми по сути своей пернатой от них не далеко ушли.
Просто смешная фишка/мем.
## Техническая информация
Только несколько строк YAML

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->
<img width="1920" height="1440" alt="изображение" src="https://github.com/user-attachments/assets/fc025cbf-bbd4-4582-87f8-416767c1650e" />

<img width="471" height="577" alt="изображение" src="https://github.com/user-attachments/assets/6cf4aac3-5c57-4e03-b633-98f339917274" />

<img width="391" height="356" alt="изображение" src="https://github.com/user-attachments/assets/094045f8-2b4c-4e02-bead-8426912047ea" />

<img width="365" height="324" alt="изображение" src="https://github.com/user-attachments/assets/0b6d6d82-458e-453b-ad24-3ecfb24aede7" />

## Чейнджлог
:cl: RedSpy
- tweak: Из резоми теперь выпадает куриное мясо.


