### PR TITLE
[FIX] Тупа кволити житухи 7

### DIFF
--- a/Content.Shared/CCVar/CCVars.Interactions.cs
+++ b/Content.Shared/CCVar/CCVars.Interactions.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Configuration;
+using Robust.Shared.Configuration;
 
 namespace Content.Shared.CCVar;
 
@@ -70,7 +70,7 @@ public sealed partial class CCVars
     /// Recommended that you utilise this in conjunction with <see cref="StaticStorageUI"/>
     /// </summary>
     public static readonly CVarDef<int> StorageLimit =
-        CVarDef.Create("control.storage_limit", 1, CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("control.storage_limit", 5, CVar.REPLICATED | CVar.SERVER); /// ADT_Tweak - 1 to 5 - на радость любителям поменеджерить инвентарь
 
     /// <summary>
     /// Whether or not storage can be opened recursively.

--- a/Resources/Prototypes/ADT/Entities/Markers/Spawners/Random/bluespace_harvester.yml
+++ b/Resources/Prototypes/ADT/Entities/Markers/Spawners/Random/bluespace_harvester.yml
@@ -392,7 +392,7 @@
     - ADTMechOdysseusBattery
     - ADTMechGygaxBattery
     - ADTMechpaddyBattery
-    - ADTMechRipleyMk2Battery
+    # - ADTMechRipleyMk2Battery
     chance: 1.0
     offset: 0.0
     rarePrototypes:

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -119,10 +119,7 @@
         - Hands # no use giving a mouse a storage implant, but a monkey is another story...
     - type: Storage
       grid:
-      - 0,0,0,1
-      - 1,0,1,0
-      - 1,2,1,2
-      - 2,1,2,2
+      - 0,0,2,2 #ADT_Tweak - вернул нормальный объем имлпантера, чтобы можно было пихать украденное
     - type: ContainerContainer
       containers:
         storagebase: !type:Container


### PR DESCRIPTION
## Описание PR
Инвентарь субдермального хранилища приведен в адекватное состояние и вмещает штуки как и раньше
Убрал багованный рипли МК2 из лута бс-харвестера
Добавил возможность открывать больше одного окна хранилища разом

## Почему / Баланс
Так надо

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог
:cl: Петр
- remove: Удален Рипли Мк.2 из лута БС-харвестера. Причина - он сломан
- tweak: Возвращен старый (до нерфа оффами) объем у импланта субдермального хранилища
- tweak: Увеличено число открываемых одновременно игроком интерфейсов хранилища до 5
