### PR TITLE
Цели на великую Суперматерию [ FIX ]

### DIFF
--- a/Content.Server/ADT/Objectives/Components/CascadeConditionComponent.cs
+++ b/Content.Server/ADT/Objectives/Components/CascadeConditionComponent.cs
@@ -8,4 +8,6 @@ namespace Content.Server.ADT.Objectives.Components;
 [RegisterComponent, Access(typeof(CascadeConditionSystem))]
 public sealed partial class CascadeConditionComponent : Component
 {
+    [DataField("needSupermatter")]
+    public bool Supermatter = false;
 }

--- a/Content.Server/ADT/Objectives/Systems/CascadeConditionSystem.cs
+++ b/Content.Server/ADT/Objectives/Systems/CascadeConditionSystem.cs
@@ -11,11 +11,23 @@ public sealed class CascadeConditionSystem : EntitySystem
 {
     [Dependency] private readonly AlertLevelSystem _alertLevelSystem = default!;
     [Dependency] private readonly StationSystem _stationSystem = default!;
+    [Dependency] private readonly CheckSupermatterSystem _supermatter = default!;
 
     public override void Initialize()
     {
         base.Initialize();
+
+        SubscribeLocalEvent<CascadeConditionComponent, ObjectiveAssignedEvent>(OnAssigned);
         SubscribeLocalEvent<CascadeConditionComponent, ObjectiveGetProgressEvent>(OnGetProgress);
+    }
+
+    private void OnAssigned(Entity<CascadeConditionComponent> condition, ref ObjectiveAssignedEvent args)
+    {
+        if (condition.Comp.Supermatter && !_supermatter.SupermatterCheck())
+        {
+            args.Cancelled = true;
+            return;
+        }
     }
 
     private void OnGetProgress(EntityUid uid, CascadeConditionComponent comp, ref ObjectiveGetProgressEvent args)

--- a/Content.Server/ADT/Objectives/Systems/CheckSupermatterSystem.cs
+++ b/Content.Server/ADT/Objectives/Systems/CheckSupermatterSystem.cs
@@ -1,0 +1,29 @@
+using Content.Shared.ADT.Supermatter.Components;
+using Content.Server.Station.Systems;
+
+namespace Content.Server.ADT.Objectives.Systems;
+
+public sealed class CheckSupermatterSystem : EntitySystem
+{
+    [Dependency] private readonly StationSystem _stationSystem = default!;
+
+    /// <summary>
+    /// Вынюхиваем кристалл Суперматерии на станции.
+    /// </summary>
+    public bool SupermatterCheck()
+    {
+        var query = AllEntityQuery<SupermatterComponent, TransformComponent>();
+
+        while (query.MoveNext(out var uid, out _, out var xform))
+        {
+            var station = _stationSystem.GetOwningStation(uid);
+
+            if (station == EntityUid.Invalid)
+                continue;
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Content.Server/Objectives/Components/StealConditionComponent.cs
+++ b/Content.Server/Objectives/Components/StealConditionComponent.cs
@@ -68,4 +68,11 @@ public sealed partial class StealConditionComponent : Component
     public LocId DescriptionText;
     [DataField(required: true)]
     public LocId DescriptionMultiplyText;
+
+    // ADT-Tweak
+    ///<summary>
+    /// Проверка на наличие СМа на карте станции.
+    ///</summary>
+    [DataField("needSupermatter")]
+    public bool Supermatter = false;
 }

--- a/Content.Server/Objectives/Systems/StealConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/StealConditionSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Stacks;
+using Content.Server.ADT.Objectives.Systems; // ADT-Tweak
 
 namespace Content.Server.Objectives.Systems;
 
@@ -24,6 +25,7 @@ public sealed class StealConditionSystem : EntitySystem
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
     [Dependency] private readonly SharedObjectivesSystem _objectives = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly CheckSupermatterSystem _supermatter = default!; // ADT-Tweak
 
     private EntityQuery<ContainerManagerComponent> _containerQuery;
 
@@ -44,6 +46,14 @@ public sealed class StealConditionSystem : EntitySystem
     /// start checks of target acceptability, and generation of start values.
     private void OnAssigned(Entity<StealConditionComponent> condition, ref ObjectiveAssignedEvent args)
     {
+        // ADT-Tweak
+        if (condition.Comp.Supermatter && !_supermatter.SupermatterCheck())
+        {
+            args.Cancelled = true;
+            return;
+        }
+        // ADT-Tweak
+
         List<StealTargetComponent?> targetList = new();
 
         var query = AllEntityQuery<StealTargetComponent>();

--- a/Resources/Prototypes/ADT/Objectives/traitor.yml
+++ b/Resources/Prototypes/ADT/Objectives/traitor.yml
@@ -81,6 +81,8 @@
   parent: BaseTraitorStealObjective
   id: ADTStealSupermatterSliverObjective
   components:
+  - type: Objective
+    difficulty: 2.5
   - type: StealCondition
     stealGroup: SupermatterSliver
     objectiveNoOwnerText: objective-condition-steal-smsliver-title

--- a/Resources/Prototypes/ADT/Objectives/traitor.yml
+++ b/Resources/Prototypes/ADT/Objectives/traitor.yml
@@ -78,11 +78,12 @@
       needSupermatter: true
 
 - type: entity
+  categories: [ HideSpawnMenu ]
   parent: BaseTraitorStealObjective
   id: ADTStealSupermatterSliverObjective
   components:
   - type: Objective
-    difficulty: 2.5
+    difficulty: 4
   - type: StealCondition
     stealGroup: SupermatterSliver
     objectiveNoOwnerText: objective-condition-steal-smsliver-title

--- a/Resources/Prototypes/ADT/Objectives/traitor.yml
+++ b/Resources/Prototypes/ADT/Objectives/traitor.yml
@@ -75,15 +75,14 @@
         sprite: ADT/Interface/anti-nob.rsi
         state: antinob
     - type: CascadeCondition
+      needSupermatter: true
 
 - type: entity
-  categories: [ HideSpawnMenu ]
   parent: BaseTraitorStealObjective
   id: ADTStealSupermatterSliverObjective
   components:
-  - type: Objective
-    difficulty: 2.5
   - type: StealCondition
     stealGroup: SupermatterSliver
     objectiveNoOwnerText: objective-condition-steal-smsliver-title
     descriptionText: objective-condition-steal-smsliver-description
+    needSupermatter: true

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -25,7 +25,7 @@
 #    EnergyShotgunStealObjective: 0.5 # ADT objective
     ADTMobileDefibrillatorStealObjective: 1 # ADT Objective
     ADTX01StealObjective: 0.5 # ADT Objective
-    ADTSupermatterSliverObjective: 0.5 # ADT Objective
+    ADTStealSupermatterSliverObjective:: 0.5 # ADT Objective
 
 - type: weightedRandom
   id: TraitorObjectiveGroupKill

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -39,7 +39,7 @@
     EscapeShuttleObjective: 1
     DieObjective: 0.05
     HijackShuttleObjective: 0.02 #Corvax-Hijack
-    ADTDoCascade: 0.05 # ADT Objective
+    ADTDoCascade: 0.02 # ADT Objective
 
 - type: weightedRandom
   id: TraitorObjectiveGroupSocial

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -39,7 +39,7 @@
     EscapeShuttleObjective: 1
     DieObjective: 0.05
     HijackShuttleObjective: 0.02 #Corvax-Hijack
-    ADTDoCascade: 0.01 # ADT Objective
+    ADTDoCascade: 0.05 # ADT Objective
 
 - type: weightedRandom
   id: TraitorObjectiveGroupSocial


### PR DESCRIPTION
## Описание PR
  Теперь цели на СМ могут выпасть ТОЛЬКО если Суперматерия есть на станции.
  Немного повысил шанс на выпадении цели Каскада. Как оказалось, она всё это время работала, просто шанс в 0.01- 
  руина.

## Почему / Баланс
 Думаю, шанс в 0.05 как у славной смерти нормальное решение?


## Техническая информация
  Немного насрал в компоненты визов, ничего критического. Отдельная система для проверки наличия суперматерии на станции.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог
:cl: M1and1B
- tweak: Синдикат увидел, что дедлайны по каскадам горят, поэтому цель стала более приоритетной.
- fix: Теперь цели на СМ выпадают исключительно при наличии Кристалла на станции.
- fix: Теперь цель на Кусок СМа снова может выпасть.
