### PR TITLE
[TWEAK] БУМ-БУМ!

### DIFF
--- a/Content.Shared/CCVar/CCVars.Atmos.cs
+++ b/Content.Shared/CCVar/CCVars.Atmos.cs
@@ -149,5 +149,5 @@ public sealed partial class CCVars
     ///     Setting this to zero disables the explosion but still allows the tank to burst and leak.
     /// </summary>
     public static readonly CVarDef<float> AtmosTankFragment =
-        CVarDef.Create("atmos.max_explosion_range", 5f, CVar.SERVERONLY); /// ADT-Tweak 26f to 5f - нерф лимиток
+        CVarDef.Create("atmos.max_explosion_range", 26f, CVar.SERVERONLY);
 }


### PR DESCRIPTION
## Описание PR
Возвращён старый радиус взрыва лимитки  
## Почему / Баланс
Старая лимитка была полностью бесполезной. Предложка по возвращению набрала 22 лайка и 0 дизлайков

Ссылка на заказ, предложение или баг-репорт
https://discord.com/channels/901772674865455115/1397281953421721610/1397281953421721610

## Чейнджлог
:cl: LightSurvivor
- tweak: Возвращён старый радиус взрыва лимитки  


