### PR TITLE
[Tweak] Теперь мим не пропагандист

### DIFF
--- a/Content.Server/ADT/Mime/MImeBaloonComponent.cs
+++ b/Content.Server/ADT/Mime/MImeBaloonComponent.cs
@@ -3,7 +3,7 @@ namespace Content.Server.ADT.Mime;
 [RegisterComponent]
 public sealed partial class MimeBaloonComponent : Component
 {
-    public List<string> ListPrototypesBaloon = ["BalloonNT", "BalloonCorgi", "BalloonSyn"];
+    public List<string> ListPrototypesBaloon = ["BalloonNT", "BalloonCorgi"];
 
     [DataField, AutoNetworkedField]
     public EntityUid? Action;


### PR DESCRIPTION
## Описание PR
Мима могли посадить за шарик синдиката, теперь не могут.

## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс. -->
Ссылка на заказ, предложение или баг-репорт
- [Баг-репорт/Заказ/Предложение](ссылка)-->

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [ ] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [ ] PR закончен и требует просмотра изменений.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог

:cl: Illumy
- remove: Больше мим не может создать шарики синдиката (и сесть за пропаганду)
