### PR TITLE
[FIX] Исправлено требуемое время для игры на тех. ассистенте 

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -6,9 +6,11 @@
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 3600 #1 hr
-    - !type:DepartmentTimeRequirement
-      department: Engineering
-      time: 18000 #5 hrs
+    #  ADT-Tweak
+    # - !type:DepartmentTimeRequirement
+    #   department: Engineering
+    #   time: 18000 #5 hrs
+    # ADT-Tweak
       # inverted: true # stop playing intern if you're good at engineering! # ADT-Tweak
 # ADT-Tweak
     # - !type:DepartmentTimeRequirement


### PR DESCRIPTION
## Описание PR
Исправлено требуемое время для игры на тех. ассистенте 
Требуемое время игры на инженерном отделе: 5 часов -> 0 часов

## Почему / Баланс
~~Почему - Потому.~~

## Чейнджлог
:cl: NameLunar
- fix: Теперь, чтобы начать карьерный рост и попробовать себя в инженерном отделе, не нужно иметь опыта работы в инженерном отделе)