### PR TITLE
[Feature] Vote map rework

### DIFF
--- a/Content.Server/Maps/GameMapManager.cs
+++ b/Content.Server/Maps/GameMapManager.cs
@@ -32,8 +32,8 @@ public sealed class GameMapManager : IGameMapManager
     [ViewVariables(VVAccess.ReadOnly)]
     private int _mapQueueDepth = 1;
 
-    private readonly Queue<string> _recentlyPlayedMaps = new();
-    private const int RecentMapBanDepth = 3;
+    private readonly Queue<string> _recentlyPlayedMaps = new(); // ADT-Tweak: ReWork Vote Map
+    private const int RecentMapBanDepth = 3;                    // ADT-Tweak: ReWork Vote Map
 
     private ISawmill _log = default!;
 
@@ -100,11 +100,11 @@ public sealed class GameMapManager : IGameMapManager
     {
         var maps = AllVotableMaps()
             .Where(map => IsMapEligible(map) && !_recentlyPlayedMaps.Contains(map.ID))
-            .ToArray();
+            .ToArray(); // ADT-Tweak: ReWork Vote Map
 
         return maps.Length == 0
             ? AllMaps().Where(x => x.Fallback && !_recentlyPlayedMaps.Contains(x.ID))
-            : maps;
+            : maps; // ADT-Tweak: ReWork Vote Map
     }
 
     public IEnumerable<GameMapPrototype> AllVotableMaps()
@@ -141,6 +141,7 @@ public sealed class GameMapManager : IGameMapManager
         return _configSelectedMap ?? _selectedMap;
     }
 
+    // ADT-Tweak-start: Добавлена функция для фильтрации последних карт
     public void RegisterPlayedMap(string mapId)
     {
         _recentlyPlayedMaps.Enqueue(mapId);
@@ -150,7 +151,7 @@ public sealed class GameMapManager : IGameMapManager
             _recentlyPlayedMaps.Dequeue();
         }
     }
-
+    // ADT-Tweak-end
     public void ClearSelectedMap()
     {
         _selectedMap = default!;

--- a/Content.Server/Maps/IGameMapManager.cs
+++ b/Content.Server/Maps/IGameMapManager.cs
@@ -25,6 +25,8 @@ public interface IGameMapManager
     /// <returns>enumerator of map prototypes</returns>
     IEnumerable<GameMapPrototype> AllMaps();
 
+    void RegisterPlayedMap(string mapId);
+
     /// <summary>
     /// Gets the currently selected map
     /// </summary>

--- a/Content.Server/Maps/IGameMapManager.cs
+++ b/Content.Server/Maps/IGameMapManager.cs
@@ -25,6 +25,13 @@ public interface IGameMapManager
     /// <returns>enumerator of map prototypes</returns>
     IEnumerable<GameMapPrototype> AllMaps();
 
+    // ADT-Tweak: ReWork Vote Map
+    /// <summary>
+    /// Registers the specified map as recently played.
+    /// This prevents the map from being selected again in
+    /// the next few rounds (based on ban depth const 'RecentMapBanDepth').
+    /// </summary>
+    /// <param name="mapId">The ID of the map that was played.</param>
     void RegisterPlayedMap(string mapId);
 
     /// <summary>

--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -300,6 +300,7 @@ namespace Content.Server.Voting.Managers
                     picked = (GameMapPrototype) args.Winner;
                     _chatManager.DispatchServerAnnouncement(
                         Loc.GetString("ui-vote-map-win", ("winner", maps[picked])));
+                    _gameMapManager.RegisterPlayedMap(picked.ID); // Добавили регистрацию карты
                 }
 
                 _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Map vote finished: {picked.MapName}");

--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -300,7 +300,7 @@ namespace Content.Server.Voting.Managers
                     picked = (GameMapPrototype) args.Winner;
                     _chatManager.DispatchServerAnnouncement(
                         Loc.GetString("ui-vote-map-win", ("winner", maps[picked])));
-                    _gameMapManager.RegisterPlayedMap(picked.ID); // Добавили регистрацию карты
+                    _gameMapManager.RegisterPlayedMap(picked.ID); // ADT-Tweak: ReWork Vote Map
                 }
 
                 _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Map vote finished: {picked.MapName}");


### PR DESCRIPTION
## 🛠️ Описание PR
**Добавлена система блокировки недавно сыгранных карт при голосовании** 

## 📈 Почему / Баланс
Ранее игроки могли голосовать за одни и те же карты каждый раунд. Это делало ротацию скучной и неразнообразной.
Теперь последние 3 карты (по умолчанию) временно исключаются из голосования, что увеличивает вариативность.

Ссылка на Discord:
[Предложение Иллюми](https://discord.com/channels/901772674865455115/1397174670985531472/1397184171616501900)

## 🧠 Техническая информация
* Новый приватный `Queue<string> _recentlyPlayedMaps` добавлен в `GameMapManager`
* Используется `RecentMapBanDepth = 3`, можно расширить на базе конфигов
* Изменён `CurrentlyEligibleMaps()` для фильтрации `AllVotableMaps()`
* Карта автоматически записывается как недавно сыгранная после победы в голосовании
* Метод `RegisterPlayedMap()` добавлен в интерфейс `IGameMapManager`

## ✅ Чеклист

* [x] Изменения протестированы на локальном сервере и работают корректно
* [x] XML-документация добавлена


## 📜 Чейнджлог
:cl: Шрёдька
- add: Добавлена система исключения недавно сыгранных карт из голосования (ротация карт).
