### PR TITLE
Ребаланс монстров лаваленда часть 1

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Clothing/OuterClothing/modsuits.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/OuterClothing/modsuits.yml
@@ -185,7 +185,7 @@
     modifiers:
       coefficients:
         Blunt: 0.7
-        Slash: 0.4
+        Slash: 0.7
         Piercing: 0.85
         Heat: 0.8
         Radiation: 0.8

--- a/Resources/Prototypes/ADT/mining_shop.yml
+++ b/Resources/Prototypes/ADT/mining_shop.yml
@@ -1,11 +1,11 @@
 - type: miningShopSection
   id: Crushers
-  name: Крашеры
+  name: ПКК
   entries:
-  - id: WeaponCrusherDagger
-    price: 550
+#  - id: WeaponCrusherDagger
+#    price: 550
   - id: WeaponCrusher
-    price: 750
+    price: 1050
   - id: WeaponKineticSpear
     price: 1050
   - id: WeaponKineticHammer
@@ -32,7 +32,7 @@
 
 - type: miningShopSection
   id: Motion
-  name: Передвижение
+  name: Выживание
   entries:
   - id: FultonBeacon
     price: 1000
@@ -42,7 +42,13 @@
     price: 900
   - id: WeaponGrapplingGun
     price: 750
-
+  - id: ADTShelterCapsule
+    price: 500
+  - id: ADTShelterCapsuleLuxury
+    price: 3500
+  - id: ADTShelterCapsuleBar
+    price: 10000
+    
 - type: miningShopSection
   id: Medicine
   name: Медицина
@@ -50,13 +56,19 @@
   - id: SpaceMedipen
     price: 300
   - id: EmergencyMedipen
-    price: 150
+    price: 300
+  - id: BruteAutoInjector
+    price: 600
+  - id: BurnAutoInjector
+    price: 600
   - id: MedkitBruteFilled
     price: 900
   - id: MedkitBurnFilled
     price: 800
   - id: MedkitToxinFilled
     price: 1000
+  - id: ADTPatchPackFilled
+    price: 400
 
 - type: miningShopSection
   id: EquipmentWearable
@@ -80,41 +92,38 @@
 #    price: 4000
   - id: ADTClothingJumpBoots
     price: 1500
+  - id: ClothingOuterHardsuitSpatio
+    price: 1000
+  - id: ClothingOuterHardsuitSalvage
+    price: 2500
   - id: ADTClothingModsuitBackMining
     price: 2500
-  - id: ADTModsuitModDrill
-    price: 1000
-  - id: ADTModsuitModStorageLarge
-    price: 500 
-
 
 - type: miningShopSection
   id: EquipmentHand
-  name: Инвентарь
+  name: Раскопки
   entries:
   - id: Flare
     price: 75
   - id: Pickaxe
     price: 125
   - id: MiningDrill
-    price: 425
+    price: 500
   - id: SeismicCharge
     price: 200
   - id: FireExtinguisherMini
     price: 150
   - id: ADTWeaponCutter
     price: 1000
-  - id: ADTShelterCapsule
-    price: 500
   - id: PowerCellHigh
     price: 650
   - id: Binoculars
     price: 450
-  - id: ADTShelterCapsuleLuxury
-    price: 3500
-  - id: ADTShelterCapsuleBar
-    price: 10000
-
+  - id: ADTModsuitModDrill
+    price: 1000
+  - id: ADTModsuitModStorageLarge
+    price: 500 
+    
 - type: miningShopSection
   id: Upgrades
   name: Улучшения
@@ -134,8 +143,8 @@
   entries:
   - id: PlushieLizard
     price: 220 # CURSE
-  - id: SpaceCash5000
-    price: 2000
+  - id: SpaceCash1000
+    price: 2500
   - id: DrinkWhiskeyBottleFull
     price: 100
   - id: DrinkAbsintheBottleFull
@@ -148,3 +157,9 @@
     price: 400
   - id: CheckerBoard
     price: 400
+  - id: SoapNT
+    price: 400
+  - id: Cigar
+    price: 300
+  - id: CigarGoldCase
+    price: 1000

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseMobAsteroid
   parent:
-  - BaseMob
+  - ADTSimpleMobBaselavaland
   - MobDamageable
   - MobAtmosExposed
   - MobCombat
@@ -52,7 +52,7 @@
         Base: goliath_dead
   - type: MovementSpeedModifier
     baseWalkSpeed : 2.00
-    baseSprintSpeed : 2.00
+    baseSprintSpeed : 2.50
   - type: MobThresholds
     thresholds:
       0: Alive
@@ -65,8 +65,8 @@
     animation: WeaponArcPunch
     damage:
       types:
-        Slash: 12   #ADT-Tweak 15>>12
-        Piercing: 5 #ADT-Tweak 10>>5
+        Slash: 15
+        Blunt: 10  #ADT-Tweak Piercing -> Blunt 
   - type: NpcFactionMember
     factions:
     - SimpleHostile
@@ -75,9 +75,9 @@
       task: GoliathCompound
     blackboard:
       VisionRadius: !type:Single
-        6
+        10 #ADT-Tweak 6>>10
       AggroVisionRadius: !type:Single
-        10
+        15 #ADT-Tweak 10>>15
   - type: NPCUseActionOnTarget
     actions: GoliathActions
   - type: Tag
@@ -132,6 +132,21 @@
     sprite: Mobs/Aliens/Asteroid/goliath.rsi
     layers:
     - state: goliath_tentacle_wiggle
+  - type: DamageContacts #ADT-Tweak
+    damage:
+      types:
+        Slash: 15
+        Blunt: 10  
+  - type: Fixtures #ADT-Tweak
+    fixtures:
+      fix1:
+        hard: false
+        density: 7
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.5,-0.5,0.5,0.5"
+        layer:
+          - MidImpassable 
   - type: StunOnContact
     blacklist:
       tags:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
@@ -1,14 +1,13 @@
 ﻿- type: entity
   name: watcher
   id: MobWatcherBase
-  parent: [ SimpleSpaceMobBase, FlyingMobBase ]
+  parent: [ ADTSimpleMobBaselavaland, FlyingMobBase ]
   abstract: true
   description: It's like it's staring right through you.
   components:
   - type: NpcFactionMember
     factions:
     - SimpleHostile
-  - type: HTN
     rootTask:
       task: SimpleRangedHostileCompound
   - type: Sprite
@@ -76,9 +75,17 @@
     interactSuccessSound:
       path: /Audio/Animals/lizard_happy.ogg
   - type: Fauna # ADT-Tweak start
-  - type: AshStormImmune
+  - type: AshStormImmune 
+  - type: HTN
+    rootTask:
+      task: SimpleRangedHostileCompound
+    blackboard:
+      VisionRadius: !type:Single
+        2
+      AggroVisionRadius: !type:Single
+        10
   # ADT-Tweak end
-  
+
 - type: entity
   id: MobWatcherLavaland
   parent: MobWatcherBase
@@ -134,6 +141,31 @@
   - type: ProjectileBatteryAmmoProvider
     proto: WatcherBoltMagmawing
     fireCost: 50
+  
+- type: entity
+  name: magmawing watcher bolt
+  id: WatcherBoltMagmawing
+  parent: BaseBullet
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles_tg.rsi
+    layers:
+    - state: omnilaser_greyscale
+      shader: unshaded
+      color: orangered
+  - type: Projectile
+    #   soundHit:  Waiting on serv3
+    impactEffect: BulletImpactEffectOrangeDisabler
+    damage:
+      types:
+        Heat: 0
+  - type: ChangeTemperatureOnCollide
+    heat: 50000
+  - type: IgniteOnCollide
+    fireStacks: 1
+    count: 10
+
 
 - type: entity
   id: MobWatcherPride
@@ -154,3 +186,48 @@
     energy: 1
   - type: RgbLightController
     layers: [ 1 ]
+
+- type: entity
+  name: SimpleMobBaseLava
+  parent:
+  - MobRespirator
+  - MobAtmosStandard
+  - SimpleSpaceMobBase
+  id: ADTSimpleMobBaselavaland # for lavaland
+  suffix: AI
+  abstract: true
+  components:
+  - type: Hunger
+    thresholds: # only animals and rats are derived from this prototype so let's override it here and in rats' proto
+      Overfed: 100
+      Okay: 50
+      Peckish: 25
+      Starving: 10
+      Dead: 0
+    baseDecayRate: 0.00925925925926 # it is okay for animals to eat and drink less than humans, but more frequently
+  - type: Thirst
+    thresholds:
+      OverHydrated: 200
+      Okay: 150
+      Thirsty: 100
+      Parched: 50
+      Dead: 0
+    baseDecayRate: 0.04
+  - type: StatusEffects
+    allowed:
+    - KnockedDown
+    - SlowedDown
+    - Stutter
+    - Electrocution
+    - ForcedSleep
+    - TemporaryBlindness
+    - Pacified
+    - StaminaModifier
+    - RadiationProtection
+    - Drowsiness
+    - Adrenaline #ADT-Medicine
+  - type: MobPrice
+    price: 150
+  - type: FloatingVisuals
+  - type: Fauna 
+  - type: AshStormImmune 


### PR DESCRIPTION
## Описание PR
Изменил статы брони МОДсьюта шахтёров (забалансил)
Убрал кровь у монстров лавы
Изменил ассортимент ШахтёрМага

## Почему / Баланс
Предложения сервера
https://discord.com/channels/901772674865455115/1355467554696462498
https://discord.com/channels/901772674865455115/1338515816462811147

## Чейнджлог
:cl: Sir Talter, LightSurvivor
- remove: Некрополю не понравился вид кровавого моря в его владениях, и теперь его подчинённые больше не кровоточат. Из-за этого голиафы стали намного агрессивнее, а вотчеры потеряли свои способности снайпера.
- tweak: Ассоциация Вольных Шахтёров добилась изменения в ШахтёрМаге, в него добавлена пара новых предметов, однако это повлияло на цены.
- tweak: Из-за увеличившейся смертности шахтёров их МОДсьюты упали в качестве, это повлияло на их способность защищать.