### PR TITLE
Рубашка СБ и спецовка Атмосов

### DIFF
--- a/Resources/Prototypes/ADT/Loadouts/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Jobs/Engineering/atmospheric_technician.yml
@@ -16,6 +16,11 @@
   - !type:GroupLoadoutEffect
     proto: ADTMasterAtmos
 
+- type: loadout
+  id: ClothingAtmosphericsOveralls
+  equipment:
+    outerClothing: ClothingAtmosphericsOveralls
+
 # Neck
 - type: loadout
   id: ADTCloakAtmosian

--- a/Resources/Prototypes/ADT/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Jobs/Security/security_officer.yml
@@ -47,6 +47,11 @@
 
 # Jumpsuit
 - type: loadout
+  id: ClothingUniformJumpsuitSecBlue
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitSecBlue
+    
+- type: loadout
   id: ADTSecurityOfficerMogesBrown
   equipment:
     jumpsuit: ADTClothingJumpsuitSecOffMogesBrown

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -958,6 +958,7 @@
   # ADT-Loadouts-Start
   - ADTOuterAtmosianBomberJacket
   # ADT-Loadouts-End
+  - ClothingAtmosphericsOveralls # ADT tweak
 
 - type: loadoutGroup
   id: AtmosphericTechnicianBackpack
@@ -1232,6 +1233,7 @@
   - ADTSecurityOfficerMogesBlue
   - ADTSecurityOfficerMogesGray
   # ADT-Loadouts-End
+  - ClothingUniformJumpsuitSecBlue # ADT tweak
 
 - type: loadoutGroup
   id: SecurityBackpack


### PR DESCRIPTION
## Описание PR
Добавил рубашку СБ и спецовку атмосов в Лодаут

## Почему / Баланс
Удобство, они имеются в Автоматах отдела
Так же предложка на добавление в лодаут, 21 лайков
- https://discord.com/channels/901772674865455115/1402586151893864498

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [ ] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [ ] PR закончен и требует просмотра изменений.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог
:cl: SAN
- add: Теперь Атмосферные техники могут получить спецовку заранее, чем искать ее на станции в автомате. Офицеры СБ вспомнили что у них в шкафу весит голубая униформа 