### PR TITLE
[Admin Tool] Добавлена новая команда "massmsg"

### DIFF
--- a/Content.Server/ADT/Administration/Commands/SubtleMessageMassCommand.cs
+++ b/Content.Server/ADT/Administration/Commands/SubtleMessageMassCommand.cs
@@ -1,0 +1,138 @@
+using System.Linq;
+using Content.Server.Prayer;
+using Content.Shared.Administration;
+using Content.Shared.Players;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+using Robust.Shared.Player;
+using Robust.Shared.Utility;
+
+namespace Content.Server.Administration.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class SubtleMessageMassCommand : LocalizedEntityCommands
+{
+    [Dependency] private readonly IPlayerLocator _locator = default!;
+    [Dependency] private readonly PrayerSystem _prayerSystem = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
+    [Dependency] private readonly EntityManager _entityManager = default!;
+
+    public override string Command => "massmsg";
+    public override string Description => Loc.GetString("massmsg-command-description");
+    public override string Help => Loc.GetString("massmsg-command-help-text", ("command", Command));
+
+    public override async void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length < 3)
+        {
+            shell.WriteLine(Loc.GetString("cmd-ban-invalid-arguments"));
+            shell.WriteLine(Help);
+            return;
+        }
+
+        var player = shell.Player;
+        if (player == null)
+        {
+            shell.WriteLine("You cannot use this command from the server console.");
+            return;
+        }
+
+        // Variables
+        var message = args[0];
+        var popupMessage = args[1];
+        var senderEntity = player.AttachedEntity;
+        string[]? allTargets;
+
+        // Второй аргумент: radius:<число>
+        if (args[2].StartsWith("radius:", StringComparison.OrdinalIgnoreCase))
+        {
+            if (senderEntity == null)
+            {
+                shell.WriteError("You must be attached to an entity to use radius mode.");
+                return;
+            }
+
+            if (!float.TryParse(args[2].Split(':')[1], out var radius))
+            {
+                shell.WriteError("Invalid radius value.");
+                return;
+            }
+
+            if (!_entityManager.TryGetComponent<TransformComponent>(senderEntity.Value, out var xform))
+                return;
+
+            var entitiesInRange = _entityLookup.GetEntitiesInRange(xform.Coordinates, radius)
+                                               .Where(e => _entityManager.HasComponent<ActorComponent>(e))
+                                               .ToList();
+
+            foreach (var ent in entitiesInRange)
+            {
+                if (!_entityManager.TryGetComponent(ent, out ActorComponent? actor))
+                    continue;
+                _prayerSystem.SendSubtleMessage(actor.PlayerSession, player, message, popupMessage);
+                shell.WriteLine($"{_entityManager.ToPrettyString(ent)}");
+            }
+
+            shell.WriteLine($"Sent message to {entitiesInRange.Count} players in radius {radius}.");
+            return;
+        }
+
+        // Второй аргумент: По никам или всех
+        if (args[2] == "all")
+        {
+            allTargets = CompletionHelper.SessionNames()
+                                         .Select(option => option.Value)
+                                         .ToArray();
+        }
+        else
+        {
+            allTargets = args.Skip(2).Where(arg => !string.IsNullOrWhiteSpace(arg)).ToArray();
+        }
+
+        foreach (var target in allTargets)
+        {
+            var trimmedTarget = target.Trim();
+            if (string.IsNullOrWhiteSpace(trimmedTarget))
+                continue;
+
+            var located = await _locator.LookupIdByNameOrIdAsync(trimmedTarget);
+
+            if (located == null)
+            {
+                shell.WriteError(Loc.GetString("massmsg-player-unable"));
+                continue;
+            }
+
+            var targetSession = _playerManager.GetSessionById(located.UserId);
+            _prayerSystem.SendSubtleMessage(targetSession, player, message, popupMessage);
+        }
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length >= 3)
+            return CompletionResult.FromHintOptions(
+                CompletionHelper.SessionNames(),
+                Loc.GetString("massmsg-command-hint")
+            );
+
+        if (args.Length == 2)
+        {
+            var option = new CompletionOption[]
+            {
+                new(Loc.GetString("prayer-popup-subtle-default"), Loc.GetString("default")),
+            };
+
+            return CompletionResult.FromHintOptions(
+                option,
+                Loc.GetString("massmsg-command-hint-second-args")
+            );
+        }
+
+        if (args.Length == 1)
+            return CompletionResult.FromHint(Loc.GetString("massmsg-command-hint-one-args"));
+
+        return CompletionResult.Empty;
+    }
+}

--- a/Resources/Locale/ru-RU/ADT/administration/commands.ftl
+++ b/Resources/Locale/ru-RU/ADT/administration/commands.ftl
@@ -51,3 +51,12 @@ cmd-adjstationjob-help = Использование: adjstationjob <station id> 
 cmd-zoom_tweak-command-description = Указанному игроку или uid меняет компонент { $component } устанавливая значения zoom.
 cmd-zoom_tweak-command-help-text = Использование: { $command } <Username/Uid> <int-Zoom>
 cmd-zoom_tweak-command-error-content-eye = У указанной сущности отсутствует { $component }.
+
+# Command: massmsg
+massmsg-command-description = Отправляет скрытое сообщение всем указанным игрокам
+massmsg-command-help-text = Использование: {$command} <сообщение> <всплывающее сообщение> <user1 [user2 [user3]] | all | radius: <float>>
+massmsg-player-unable = Не удалось найти игрока с таким никнеймом.
+massmsg-command-hint = username/all/radius:
+massmsg-command-hint-one-args = message
+massmsg-command-hint-second-args = popupMessage
+

--- a/Resources/Locale/ru-RU/ADT/administration/commands.ftl
+++ b/Resources/Locale/ru-RU/ADT/administration/commands.ftl
@@ -54,9 +54,9 @@ cmd-zoom_tweak-command-error-content-eye = У указанной сущност�
 
 # Command: massmsg
 massmsg-command-description = Отправляет скрытое сообщение всем указанным игрокам
-massmsg-command-help-text = Использование: {$command} <сообщение> <всплывающее сообщение> <user1 [user2 [user3]] | all | radius: <float>>
+massmsg-command-help-text = Использование: {$command} <сообщение> <всплывающее сообщение> <user1 [user2 [user3]] | all | radius:<float>>
 massmsg-player-unable = Не удалось найти игрока с таким никнеймом.
-massmsg-command-hint = username/all/radius:
+massmsg-command-hint = username/all/radius:<int>
 massmsg-command-hint-one-args = message
 massmsg-command-hint-second-args = popupMessage
 

--- a/Resources/Locale/ru-RU/ADT/administration/commands.ftl
+++ b/Resources/Locale/ru-RU/ADT/administration/commands.ftl
@@ -52,7 +52,7 @@ cmd-zoom_tweak-command-description = Указанному игроку или ui
 cmd-zoom_tweak-command-help-text = Использование: { $command } <Username/Uid> <int-Zoom>
 cmd-zoom_tweak-command-error-content-eye = У указанной сущности отсутствует { $component }.
 
-# Command: massmsg
+# Команда: massmsg
 massmsg-command-description = Отправляет скрытое сообщение всем указанным игрокам
 massmsg-command-help-text = Использование: {$command} <сообщение> <всплывающее сообщение> <user1 [user2 [user3]] | all | radius:<float>>
 massmsg-player-unable = Не удалось найти игрока с таким никнеймом.


### PR DESCRIPTION
## Описание PR

Этот PR добавляет новую админ-команду `massmsg`, позволяющую администраторам отправлять скрытые сообщения сразу нескольким игрокам. Команда поддерживает отправку сообщений как конкретным игрокам, так и всем игрокам или вообще по радиусу.

## Зачем / Баланс

Команда предназначена для улучшения административных инструментов. Она никак не влияет на игровой баланс, так как является чисто утилитой для админов.

## Технические детали

* Добавлеа новый класс `SubtleMessageMassCommand` в `Content.Server/ADT/Administration/Commands/SubtleMessageMassCommand.cs`.
* Команда принимает три аргумента: `<message>`, `<popupMessage>` и `<user1 [user2 [user3]] | all | radius: <float>>`.
* Если третьим аргументом указано `all`, сообщение будет отправлено всем подключённым игрокам.
* Если третьим аргументом указано `radius:`, сообщение будет отправлено всем игрокам в указанном радиусе.
* Для автодополнения имён игроков команда использует `CompletionHelper.SessionNames()`.

## Медиа

[https://github.com/user-attachments/assets/259c7cce-d1c6-42f8-b69c-b259bfde1831](https://github.com/user-attachments/assets/259c7cce-d1c6-42f8-b69c-b259bfde1831)

<img width="752" height="151" alt="image" src="https://github.com/user-attachments/assets/a31bc5c2-2fae-46a0-95a3-817de3f99a19" />  


## Критические изменения

В этом PR нет критических изменений.

**Changelog**

:cl: Шрёдька

- add: Добавлена новая админ-команда `massmsg` для отправки скрытых сообщений сразу нескольким игрокам.

