### PR TITLE
[Remove] Убран раундстарт за дион

### DIFF
--- a/Resources/Prototypes/Species/diona.yml
+++ b/Resources/Prototypes/Species/diona.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Diona
   name: species-name-diona
-  roundStart: true
+  roundStart: false # ADT-Tweak
   prototype: MobDiona
   sprites: MobDionaSprites
   defaultSkinTone: "#cdb369"


### PR DESCRIPTION
## Описание PR

Убираем возможность захода за расу **Дион** на раундстарте.
Да, я знаю, что это кому-то не понравится. Да, я делаю это намеренно.

Причины просты:
* Я важный, я могу.
* Мне пофиг на чужое мнение — я так хочу.
* Меня не слушают? Буду действовать радикально.
* Дион — живые деревья. Мы тут в космосе, а не в лесопарке.
* Мудрый дуб пошёл нахуй.

## Почему / Баланс

**Моя позиция:**
* Роль слишком редкая и в большинстве случаев используется как способ обойти ограничения других рас.
* Игроки злоупотребляют особенностями Дион (да, я это вижу, даже если вы думаете, что нет).
* Если кого-то не устраивает — обсуждение закрыто. Это моё решение.

## Техническая информация

* В `species.yml` для `Diona` поле `roundStart` изменено с `true` на `false`.
* Это полностью отключает выбор этой расы в лобби на старте раунда.

## Медиа
Скриншоты? А зачем — и так всё понятно.

## Чейнджлог
:cl: Шрёдька
- remove: Убран раундстарт за расу Дион.
