### PR TITLE
[FIX] Фикс бага телепортации сумеречника на руках

### DIFF
--- a/Content.Server/ADT/Shadekin/ShadekinSystem.cs
+++ b/Content.Server/ADT/Shadekin/ShadekinSystem.cs
@@ -25,6 +25,7 @@ using Content.Server.Cuffs;
 using Content.Shared.Cuffs.Components;
 using Content.Shared.Mech.Components;
 using Content.Shared.Bed.Cryostorage;
+using Content.Shared.ADT.Components.PickupHumans;
 
 namespace Content.Server.ADT.Shadekin;
 
@@ -75,6 +76,9 @@ public sealed partial class ShadekinSystem : EntitySystem
 
             _alert.ShowAlert(uid, _proto.Index<AlertPrototype>("ShadekinPower"), (short) Math.Clamp(Math.Round(comp.PowerLevel / 50f), 0, 4));
             comp.NextSecond = _timing.CurTime + TimeSpan.FromSeconds(1);
+
+            if (HasComp<TakenHumansComponent>(uid))
+                return;
 
             if (comp.PowerLevel >= comp.PowerLevelMax)
                 comp.MaxedPowerAccumulator += 1f;

--- a/Content.Shared/ADT/PickupHumans/Systems/SharedPickupHumansSystem.cs
+++ b/Content.Shared/ADT/PickupHumans/Systems/SharedPickupHumansSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Interaction;
 using Content.Shared.ActionBlocker;
 // using Content.Shared.Throwing; // TODO: Сделать небольшой бросок
 using Content.Shared.Inventory.VirtualItem;
+using Content.Shared.ADT.Shadekin;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands;
 using Content.Shared.Hands.EntitySystems;
@@ -48,6 +49,7 @@ public abstract class SharedPickupHumansSystem : EntitySystem
         SubscribeLocalEvent<PickupHumansComponent, GetVerbsEvent<AlternativeVerb>>(AddPickupVerb);
         SubscribeLocalEvent<PickupHumansComponent, PickupHumansDoAfterEvent>(OnDoAfter);
         SubscribeLocalEvent<PickupHumansComponent, InteractHandEvent>(OnPickupInteract);
+        SubscribeLocalEvent<PickupHumansComponent, ShadekinTeleportActionEvent>(OnTeleportShadekin);
 
         SubscribeLocalEvent<PickupingHumansComponent, VirtualItemDeletedEvent>(OnVirtualItemDeleted);
         SubscribeLocalEvent<PickupingHumansComponent, MobStateChangedEvent>(OnMobStateChanged);
@@ -315,6 +317,12 @@ public abstract class SharedPickupHumansSystem : EntitySystem
             return;
 
         DropFromHands(pickupHumansComponent.User, pickupHumansComponent.Target);
+    }
+
+
+    private void OnTeleportShadekin(EntityUid uid, PickupHumansComponent comp, ShadekinTeleportActionEvent args)
+    {
+        DropFromHands(comp.User, args.Performer);
     }
 
 


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
Починил баг
## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс. -->
Ссылка на заказ, предложение или баг-репорт
- [Баг-репорт](https://discord.com/channels/901772674865455115/1405632868901715968)

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
В метод `Update()` системы сумеречников добавил проверку на компонент переносимой сущности
В системе взятия на руки добавил метод `OnTeleportShadekin()` на выпадение из рук при активации акшона телепортации сумеречника
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог

:cl: Darkiich
- fix: Исправил баг с телепортацией сумеречника на руках. Теперь при телепортации сумеречник выпадает из рук
