### PR TITLE
Лодаут много не бывает

### DIFF
--- a/Resources/Locale/ru-RU/ADT/Preferences/loadout-groups.ftl
+++ b/Resources/Locale/ru-RU/ADT/Preferences/loadout-groups.ftl
@@ -11,7 +11,9 @@ ent-MagistratJumpsuit = Костюмы
 loadout-group-blueshield-jumpsuit = ОСЩ, комбинезон
 loadout-group-blueshield-head = ОСЩ, голова
 loadout-group-blueshield-neck = ОСЩ, шея
+loadout-blueshield-ears-adt = ОСЩ, ухо
 loadout-group-blueshield-back = ОСЩ, рюкзак
+loadout-group-blueshield-outer-clothing = ОСЩ, верхняя одежда
 
 # Civilian
 loadout-chef-pocket1-adt = Шеф Повар, карман 1
@@ -28,8 +30,10 @@ loadout-barber-other-clothing-adt = Парикмахер, верхняя оде�
 
 # Cargo
 loadout-group-quartermaster-id = Квартирмейстер, ID
+loadout-quartermaster-ears-adt = Квартирмейстер, ухо
 loadout-salvage-specialist-jumpsuit-adt = Утилизатор, комбинезон
 loadout-salvage-specialist-neck-adt = Утилизатор, шея
+loadout-salvage-specialist-ears-adt = Утилизатор, ухо
 loadout-group-salvage-id-adt = Утилизатор, ID
 loadout-group-cargo-id-adt = Грузчик, ID
 
@@ -38,6 +42,7 @@ loadout-chaplain-blessedbook-adt = Священник, священная кни
 loadout-group-chaplain-id-adt = Священник, ID
 
 # Engineering
+loadout-chief-engineer-ears-adt = Старший инженер, ухо
 loadout-group-senior-engineer-head = Бригадир, голова
 loadout-group-senior-engineer-jumpsuit = Бригадир, комбинезон
 loadout-group-atmospheric-technician-neck = Атмосферный техник, плащ
@@ -46,6 +51,7 @@ loadout-group-atmospheric-technician-head = Атмосферный техник,
 loadout-group-atmos-id-adt = Атмосферный техник, ID
 
 # Science
+loadout-research-director-ears-adt = Научный руководитель, ухо
 loadout-group-reserch-director-id-adt = Научный руководитель, ID
 loadout-group-senior-researcher-head = Доцент, голова
 loadout-group-senior-researcher-jumpsuit = Доцент, комбинезон
@@ -82,6 +88,7 @@ loadout-brigmedic-outerwear-adt = Бригмедик, верхняя одежд�
 
 # Medical
 loadout-group-chief-medical-officer-id-adt = Главный врач, ID
+loadout-chief-medical-officer-ears-adt = Главный врач, ухо
 loadout-group-senior-physician-head = Ведущий врач, голова
 loadout-group-senior-physician-jumpsuit = Ведущий врач, комбинезон
 loadout-group-senior-physician-outerclothing = Ведущий врач, верхняя одежда
@@ -102,3 +109,7 @@ loadout-group-psychologist-id-adt = Психолог, ID
 loadout-group-lawyer-id-adt = Адвокат, ID
 loadout-group-lawyer-gloves = Адвокат, перчатки
 loadout-group-lawyer-backpack = Магистрат, рюкзак
+
+# Command
+loadout-captain-ears-adt = Капитан, ухо
+loadout-HoP-ears-adt = Глава персонала, ухо

--- a/Resources/Prototypes/ADT/Loadouts/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Jobs/Cargo/quartermaster.yml
@@ -35,3 +35,14 @@
   id: ADTintendantPDAloadout
   equipment:
     pda: ADTintendantPDA
+
+# Ears
+- type: loadout
+  id: ADTClothingHeadsetQM
+  equipment:
+    ears: ClothingHeadsetQM
+
+- type: loadout
+  id: ADTClothingHeadsetAltCargo
+  equipment:
+    ears: ClothingHeadsetAltCargo

--- a/Resources/Prototypes/ADT/Loadouts/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Jobs/Cargo/salvage_specialist.yml
@@ -146,3 +146,14 @@
    proto: ADTSalvageSpecialistEBomber5hour
   equipment:
     outerClothing: ADTClothingOuterExplorerBomber
+
+# Ears
+- type: loadout
+  id: ADTClothingHeadsetCargo
+  equipment:
+    ears: ClothingHeadsetCargo
+
+- type: loadout
+  id: ADTClothingHeadsetMining
+  equipment:
+    ears: ClothingHeadsetMining

--- a/Resources/Prototypes/ADT/Loadouts/Jobs/Civilian/botanist.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Jobs/Civilian/botanist.yml
@@ -1,3 +1,21 @@
+# Head
+- type: loadoutEffectGroup
+  id: ClothingHeadHatFlowerWreath10Hour
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobBotanist
+      time: 36000 #10 hrs
+
+- type: loadout
+  id: ADTClothingHeadHatFlowerWreath
+  equipment:
+    head: ClothingHeadHatFlowerWreath
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: ClothingHeadHatFlowerWreath10Hour
+
 # PDA
 - type: loadout
   id: BotanistPDA

--- a/Resources/Prototypes/ADT/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Jobs/Civilian/passenger.yml
@@ -29,3 +29,23 @@
   id: ADTClothingUniformJumpskirtTurtleneckPink
   equipment:
     jumpsuit: ADTClothingUniformJumpskirtTurtleneckPink
+
+- type: loadout
+  id: ADTClothingUniformJumpsuitHawaiRed
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitHawaiRed
+  
+- type: loadout
+  id: ADTClothingUniformJumpsuitHawaiBlue
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitHawaiBlue
+
+- type: loadout
+  id: ADTClothingUniformJumpsuitHawaiYellow
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitHawaiYellow
+
+- type: loadout
+  id: ADTClothingUniformJumpsuitHawaiBlack
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitHawaiBlack

--- a/Resources/Prototypes/ADT/Loadouts/Jobs/Command/blueshield.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Jobs/Command/blueshield.yml
@@ -56,3 +56,25 @@
   id: ADTBlueshieldDuffel
   equipment:
     back: ADTClothingBackpackDuffelBlueshield
+
+# Ears
+- type: loadout
+  id: ADTClothingHeadsetBlueshield
+  equipment:
+    ears: ADTClothingHeadsetBlueshield
+
+- type: loadout
+  id: ADTClothingHeadsetAltBlueshield
+  equipment:
+    ears: ADTClothingHeadsetAltBlueshield
+
+# OuterClothing
+- type: loadout
+  id: ADTClothingOuterWinterBlueshield
+  equipment:
+    outerClothing: ADTClothingOuterWinterBlueshield
+
+- type: loadout
+  id: ADTClothingBlueshieldArmor
+  equipment:
+    outerClothing: ADTClothingBlueshieldArmor

--- a/Resources/Prototypes/ADT/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Jobs/Command/captain.yml
@@ -14,3 +14,14 @@
    proto: ADTClothingCaptainShoulder10hour
   equipment:
     neck: ADTClothingCaptainShoulder
+
+# Ears
+- type: loadout
+  id: ADTClothingHeadsetCommand
+  equipment:
+    ears: ClothingHeadsetCommand
+
+- type: loadout
+  id: ADTClothingHeadsetAltCommand
+  equipment:
+    ears: ClothingHeadsetAltCommand

--- a/Resources/Prototypes/ADT/Loadouts/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Jobs/Command/head_of_personnel.yml
@@ -58,3 +58,14 @@
   effects:
   - !type:GroupLoadoutEffect
     proto: ProfessionalHoP
+
+# Ears
+- type: loadout
+  id: ADTClothingHoPCommand
+  equipment:
+    ears: ClothingHeadsetCommand
+
+- type: loadout
+  id: ADTClothingHoPAltCommand
+  equipment:
+    ears: ClothingHeadsetAltCommand

--- a/Resources/Prototypes/ADT/Loadouts/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Jobs/Engineering/chief_engineer.yml
@@ -2,3 +2,14 @@
   id: ADTChiefEngineerBeret
   equipment:
     head: ADTClothingHeadHatBeretCEngineer
+
+# Ears
+- type: loadout
+  id: ADTClothingHeadsetCE
+  equipment:
+    ears: ClothingHeadsetCE
+
+- type: loadout
+  id: ADTClothingHeadsetAltEngineering
+  equipment:
+    ears: ClothingHeadsetAltEngineering

--- a/Resources/Prototypes/ADT/Loadouts/Jobs/Juridical/magistrat.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Jobs/Juridical/magistrat.yml
@@ -2,8 +2,3 @@
   id: MagistratJumpsuit
   equipment:
     jumpsuit: ADTClothingUniformsJumpsuitWhiteDiplomatSuitL
-- type: loadout
-  id: ADTMagistratBackpackSatchel
-  equipment:
-    back: ClothingBackpackSatchelLeather
-

--- a/Resources/Prototypes/ADT/Loadouts/Jobs/Medical/chief-medical-officer.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Jobs/Medical/chief-medical-officer.yml
@@ -28,3 +28,14 @@
   id: ADTCMOPDA
   equipment:
     id: ADTCMOPDA
+
+# Ears
+- type: loadout
+  id: ADTClothingHeadsetCMO
+  equipment:
+    ears: ClothingHeadsetCMO
+
+- type: loadout
+  id: ADTClothingHeadsetAltMedical
+  equipment:
+    ears: ClothingHeadsetAltMedical

--- a/Resources/Prototypes/ADT/Loadouts/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Jobs/Science/research_director.yml
@@ -7,3 +7,14 @@
   id: ADTRDPDA
   equipment:
     id: ADTRDPDA
+
+# Ears
+- type: loadout
+  id: ADTClothingHeadsetRD
+  equipment:
+    ears: ClothingHeadsetRD
+
+- type: loadout
+  id: ADTClothingHeadsetAltScience
+  equipment:
+    ears: ClothingHeadsetAltScience

--- a/Resources/Prototypes/ADT/Loadouts/Miscellaneous/backpack.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Miscellaneous/backpack.yml
@@ -1,0 +1,4 @@
+- type: loadout
+  id: ADTClothingBackpackSatchelLeather
+  equipment:
+    back: ClothingBackpackSatchelLeather

--- a/Resources/Prototypes/ADT/Loadouts/Miscellaneous/gloves.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Miscellaneous/gloves.yml
@@ -1,48 +1,50 @@
 # Gloves
 - type: loadout
   id: ADTLightBrownGloves
-  storage:
-    back:
-    - ClothingHandsGlovesColorLightBrown
+  equipment:
+    gloves: ClothingHandsGlovesColorLightBrown
 
 - type: loadout
   id: ADTRedGloves
-  storage:
-    back:
-    - ClothingHandsGlovesColorRed
+  equipment:
+    gloves: ClothingHandsGlovesColorRed
 
 - type: loadout
   id: ADTTealGloves
-  storage:
-    back:
-    - ClothingHandsGlovesColorTeal
+  equipment:
+    gloves: ClothingHandsGlovesColorTeal
 
 - type: loadout
   id: ADTGreenGloves
-  storage:
-    back:
-    - ClothingHandsGlovesColorGreen
+  equipment:
+    gloves: ClothingHandsGlovesColorGreen
 
 - type: loadout
   id: ADTWhiteGloves
-  storage:
-    back:
-    - ClothingHandsGlovesColorWhite
+  equipment:
+    gloves: ClothingHandsGlovesColorWhite
 
 - type: loadout
   id: ADTBlackGloves
-  storage:
-    back:
-    - ClothingHandsGlovesColorBlack
+  equipment:
+    gloves: ClothingHandsGlovesColorBlack
 
 - type: loadout
   id: ADTGrayGloves
-  storage:
-    back:
-    - ClothingHandsGlovesColorGray
+  equipment:
+    gloves: ClothingHandsGlovesColorGray
 
 - type: loadout
   id: ADTBlueGloves
-  storage:
-    back:
-    - ClothingHandsGlovesColorBlue
+  equipment:
+    gloves: ClothingHandsGlovesColorBlue
+
+- type: loadout
+  id: ADTOrangeGloves
+  equipment:
+    gloves: ClothingHandsGlovesColorOrange
+
+- type: loadout
+  id: ADTPurpleGloves
+  equipment:
+    gloves: ClothingHandsGlovesColorPurple

--- a/Resources/Prototypes/ADT/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/ADT/Loadouts/loadout_groups.yml
@@ -1,3 +1,76 @@
+# ГАРНИТУРЫ
+- type: loadoutGroup
+  id: ADTQuartermasterEars
+  name: loadout-quartermaster-ears-adt
+  minLimit: 1
+  maxLimit: 1
+  loadouts:
+  - ADTClothingHeadsetQM
+  - ADTClothingHeadsetAltCargo
+
+- type: loadoutGroup
+  id: ADTCaptainEars
+  name: loadout-captain-ears-adt
+  minLimit: 1
+  maxLimit: 1
+  loadouts:
+  - ADTClothingHeadsetCommand
+  - ADTClothingHeadsetAltCommand
+
+- type: loadoutGroup
+  id: ADTHoP
+  name: loadout-HoP-ears-adt
+  minLimit: 1
+  maxLimit: 1
+  loadouts:
+  - ADTClothingHoPCommand
+  - ADTClothingHoPAltCommand
+
+- type: loadoutGroup
+  id: ADTBlueshieldEars
+  name: loadout-blueshield-ears-adt
+  minLimit: 1
+  maxLimit: 1
+  loadouts:
+  - ADTClothingHeadsetBlueshield
+  - ADTClothingHeadsetAltBlueshield
+
+- type: loadoutGroup
+  id: ADTChiefEngineerEars
+  name: loadout-chief-engineer-ears-adt
+  minLimit: 1
+  maxLimit: 1
+  loadouts:
+  - ADTClothingHeadsetCE
+  - ADTClothingHeadsetAltEngineering
+
+- type: loadoutGroup
+  id: ADTResearchDirectorEars
+  name: loadout-research-director-ears-adt
+  minLimit: 1
+  maxLimit: 1
+  loadouts:
+  - ADTClothingHeadsetRD
+  - ADTClothingHeadsetAltScience
+
+- type: loadoutGroup
+  id: ADTChiefMedicalOfficerEars
+  name: loadout-chief-medical-officer-ears-adt
+  minLimit: 1
+  maxLimit: 1
+  loadouts:
+  - ADTClothingHeadsetCMO
+  - ADTClothingHeadsetAltMedical
+
+- type: loadoutGroup
+  id: ADTSalvageSpecialistEars
+  name: loadout-salvage-specialist-ears-adt
+  minLimit: 1
+  maxLimit: 1
+  loadouts:
+  - ADTClothingHeadsetCargo
+  - ADTClothingHeadsetMining
+
 # MAGISTRATE
 
 - type: loadoutGroup
@@ -26,15 +99,15 @@
   maxLimit: 1
   loadouts:
   - ADTLightBrownGloves
-  - OrangeGloves
   - ADTRedGloves
   - ADTTealGloves
   - ADTGreenGloves
   - ADTWhiteGloves
   - ADTBlackGloves
   - ADTGrayGloves
-  - PurpleGloves
   - ADTBlueGloves
+  - ADTOrangeGloves
+  - ADTPurpleGloves
 
 - type: loadoutGroup
   id: LawyerShoes
@@ -71,7 +144,8 @@
   - CommonBackpack
   - CommonSatchel
   - CommonDuffel
-  - ADTMagistratBackpackSatchel
+  - ADTClothingBackpackSatchelLeather
+  
 # PATHOLOGIST
 
 - type: loadoutGroup
@@ -343,6 +417,15 @@
   - ADTBlueshieldBackpack
   - ADTBlueshieldSatchel
   - ADTBlueshieldDuffel
+
+- type: loadoutGroup
+  id: ADTBlueshieldOuterClothing
+  name: loadout-group-blueshield-outer-clothing
+  minLimit: 1
+  maxLimit: 1
+  loadouts:
+  - ADTClothingOuterWinterBlueshield
+  - ADTClothingBlueshieldArmor
 
 # WARDEN
 

--- a/Resources/Prototypes/ADT/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/ADT/Loadouts/role_loadouts.yml
@@ -70,7 +70,9 @@
   - GroupTankHarness
   - ADTBlueshieldHead
   - ADTBlueshieldJumpsuit
+  - ADTBlueshieldOuterClothing # ADT tweak
   - ADTBlueshieldNeck
+  - ADTBlueshieldEars # ADT tweak
   - ADTBlueshieldBack
   - SurvivalSecurity
   - Trinkets

--- a/Resources/Prototypes/ADT/Roles/Jobs/Command/blueshieldofficer.yml
+++ b/Resources/Prototypes/ADT/Roles/Jobs/Command/blueshieldofficer.yml
@@ -190,11 +190,11 @@
   equipment:
     # head: ADTClothingHeadHatBeretBlueshieldBlack
     eyes: ADTClothingEyesGlassesBlueshield
-    ears: ADTClothingHeadsetBlueshield
+    # ears: ADTClothingHeadsetBlueshield 
     # jumpsuit: ADTClothingUniformJumpsuitBlueshield
     # back: ADTClothingBlueshieldBackpack
     shoes: ClothingShoesBootsCombatFilled
-    outerClothing: ADTClothingBlueshieldArmor
+    # outerClothing: ADTClothingBlueshieldArmor 
     belt: ADTClothingBeltMedicalSecurityFilled
     gloves: ClothingHandsGlovesCombat
     id: ADTBlueshieldOfficerPDA

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
@@ -30,16 +30,6 @@
   equipment:
     gloves: ClothingHandsGlovesJanitor
 
-- type: loadout
-  id: OrangeGloves
-  equipment:
-    gloves: ClothingHandsGlovesColorOrange
-
-- type: loadout
-  id: PurpleGloves
-  equipment:
-    gloves: ClothingHandsGlovesColorPurple
-
 # Outer clothing
 - type: loadout
   id: JanitorWintercoat

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -244,6 +244,10 @@
   - ADTClothingUniformJumpskirtTurtleneckGrey
   - ADTClothingUniformJumpsuitTurtleneckPink
   - ADTClothingUniformJumpskirtTurtleneckPink
+  - ADTClothingUniformJumpsuitHawaiRed
+  - ADTClothingUniformJumpsuitHawaiBlue
+  - ADTClothingUniformJumpsuitHawaiYellow
+  - ADTClothingUniformJumpsuitHawaiBlack
   # ADT tweak end
 
 - type: loadoutGroup
@@ -468,8 +472,10 @@
   minLimit: 0
   loadouts:
   - JanitorRubberGloves
-  - OrangeGloves
-  - PurpleGloves
+  # ADT tweak start
+  - ADTOrangeGloves
+  - ADTPurpleGloves
+  # ADT tweak end
 
 - type: loadoutGroup
   id: JanitorOuterClothing
@@ -492,6 +498,7 @@
   loadouts:
   - BotanistHead
   - BotanistBandana
+  - ADTClothingHeadHatFlowerWreath # ADT tweak
 
 - type: loadoutGroup
   id: BotanistJumpsuit
@@ -767,6 +774,7 @@
   - CargoTechnicianBackpack
   - CargoTechnicianSatchel
   - CargoTechnicianDuffel
+  - ADTClothingBackpackSatchelLeather # ADT tweak
 
 - type: loadoutGroup
   id: CargoTechnicianOuterClothing
@@ -1088,6 +1096,7 @@
   - ScientistBackpack
   - ScientistSatchel
   - ScientistDuffel
+  - ADTClothingBackpackSatchelLeather # ADT tweak
 
 - type: loadoutGroup
   id: ScientistOuterClothing
@@ -1455,6 +1464,7 @@
   - MedicalDoctorBackpack
   - MedicalDoctorSatchel
   - MedicalDoctorDuffel
+  - ADTClothingBackpackSatchelLeather # ADT tweak
 
 - type: loadoutGroup
   id: MedicalShoes

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -5,6 +5,7 @@
   - Inventory # Corvax-Loadouts
   - CaptainHead
   - CaptainNeck
+  - ADTCaptainEars # ADT tweak
   - CaptainJumpsuit
   - CaptainBackpack
   - CaptainOuterClothing
@@ -25,6 +26,7 @@
   - GroupTankHarness
   - HoPHead
   - HoPNeck
+  - ADTHoP # ADT tweak
   - HoPJumpsuit
   - HoPBackpack
   - HoPOuterClothing
@@ -311,6 +313,7 @@
   - Inventory # Corvax-Loadouts
   - GroupTankHarness
   - QuartermasterHead
+  - ADTQuartermasterEars # ADT tweak
   - QuartermasterNeck
   - QuartermasterJumpsuit
   - CargoTechnicianBackpack
@@ -356,6 +359,7 @@
   - ADTSalvageSpecialistJumpsuit #ADT Loadouts
   - SalvageSpecialistBackpack
   - ADTSalvageSpecialistNeck #ADT Loadouts
+  - ADTSalvageSpecialistEars # ADT tweak
   - SalvageSpecialistOuterClothing
   - SalvageSpecialistShoes
   - Glasses
@@ -377,6 +381,7 @@
   - GroupTankHarness
   - ChiefEngineerHead
   - ChiefEngineerJumpsuit
+  - ADTChiefEngineerEars # ADT tweak
   - ChiefEngineerBackpack # Corvax-Loadouts
   - ADTEngineeringBelt # ADT-TWEAK
   - ADTEngineeringGlasses # ADT-TWEAK
@@ -463,6 +468,7 @@
   - GroupTankHarness
   - ResearchDirectorHead
   - ResearchDirectorNeck
+  - ADTResearchDirectorEars # ADT tweak
   - ResearchDirectorJumpsuit
   - ScientistBackpack
   - ResearchDirectorOuterClothing
@@ -636,6 +642,7 @@
   - ADTMedicalBelt # ADT tweak
   - ChiefMedicalOfficerOuterClothing
   - ChiefMedicalOfficerNeck
+  - ADTChiefMedicalOfficerEars # ADT tweak
   - ChiefMedicalOfficerShoes
   - MedicalEyewear
   - ADTCMOPDA # ADT tweak

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -47,7 +47,7 @@
   id: QuartermasterGear
   equipment:
     id: QuartermasterPDA
-    ears: ClothingHeadsetQM
+    # ears: ClothingHeadsetQM # ADT tweak
     belt: BoxFolderClipboard
     pocket1: AppraisalTool
   storage:

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -29,7 +29,7 @@
   equipment:
 #    jumpsuit: ClothingUniformJumpsuitSalvageSpecialist #ADT tweak
     #id: SalvagePDA # ADT: different PDAs in loadouts
-    ears: ClothingHeadsetCargo
+    # ears: ClothingHeadsetCargo # ADT tweak
     pocket1: AppraisalTool #ADT start
     eyes: ClothingEyesGlassesMeson
     pocket2: OreBag

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -49,7 +49,7 @@
     eyes: ClothingEyesGlassesSunglasses
     gloves: ClothingHandsGlovesCaptain
     id: CaptainPDA
-    ears: ClothingHeadsetAltCommand
+    # ears: ClothingHeadsetAltCommand # ADT tweak
   storage:
     back:
     - Flash

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -70,7 +70,7 @@
     shoes: ClothingShoesColorBrown
     id: HoPPDA
     gloves: ClothingHandsGlovesHop
-    ears: ClothingHeadsetAltCommand
+    # ears: ClothingHeadsetAltCommand # ADT tweak
     belt: BoxFolderClipboard
   storage:
     back:

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -46,7 +46,7 @@
   equipment:
     id: CEPDA
     # eyes: ClothingEyesGlassesMeson #ADT-Tweak - заменено на выбор
-    ears: ClothingHeadsetCE
+    # ears: ClothingHeadsetCE # ADT tweak
 # ADT-Tweak-start по причине того, что ассистент и остальной состав ИО спавнится с двумя поясами, если их выбрать в лоудауте
     # belt: ClothingBeltUtilityEngineering
 # ADT-Tweak-end

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -39,7 +39,7 @@
   id: CMOGear
   equipment:
  #id: CMOPDA  # ADT Tweak
-    ears: ClothingHeadsetCMO
+    # ears: ClothingHeadsetCMO # ADT tweak
 #    belt: ClothingBeltMedicalFilled ADT tweak
   storage:
     back:

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -34,7 +34,7 @@
   id: ResearchDirectorGear
   equipment:
  #id: RnDPDA # ADT Tweak
-    ears: ClothingHeadsetRD
+    # ears: ClothingHeadsetRD # ADT tweak
   storage:
     back:
     - Flash


### PR DESCRIPTION
## Описание PR
Добавил несколько вещей в лодаут

## Почему / Баланс
Теперь у КМД есть выбор между обычной гарнитурой и полноразмерной. Шахтеры под шумок тоже получили выбор обычной гарнитуры и шахтерской. ОСЩ получил выбор между курткой и броником. Подправил немного лодаут магистрата. У сотрудников Меда, Карго и РНД добавилась на выбор Кожаная сумка. Пассажиры получили доступ к 4 гавайским рубашкам. У ботаников появился венок в лодауте за 10 часов

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [ ] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [ ] PR закончен и требует просмотра изменений.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог
:cl: SAN
- add: Командование теперь может заранее выбрать с какой гарнитурой прибывать на станцию: Обычной или полноразмерной. Шахтеры под шумок тоже получили возможность выбора: обычной и шахтерской гарнитуры.
- add: ОСЩ вспомнили что у них в шкафу весит их личная куртка.
- add: У ботаников оказалось слишком много цветов дома, из-за чего они начали прибывать с венками на станцию
- add: Сейчас в моде не обычные сумки, а кожаные. (Для РНД, Меда и Карго)
- add: Пассажиры по скидке выкупили 4 вида гавайских рубашек
- tweak: Изменил выдачу перчаток у Магистрата