### PR TITLE
[ADD] Некоторые предметы теперь не подбираются в комбот моде

### DIFF
--- a/Content.Shared/ADT/Combat/Components/CombatModePickupWhitelistComponent.cs
+++ b/Content.Shared/ADT/Combat/Components/CombatModePickupWhitelistComponent.cs
@@ -1,0 +1,14 @@
+using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.ADT.Combat;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class CombatModePickupWhitelistComponent : Component
+{
+    [DataField("whitelist"), AutoNetworkedField]
+    public EntityWhitelist? Whitelist;
+
+    [DataField("blacklist"), AutoNetworkedField]
+    public EntityWhitelist? Blacklist;
+}

--- a/Content.Shared/ADT/Combat/Components/CombatModePickupWhitelistComponent.cs
+++ b/Content.Shared/ADT/Combat/Components/CombatModePickupWhitelistComponent.cs
@@ -3,6 +3,15 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared.ADT.Combat;
 
+/// <summary>
+/// Компонент, ограничивающий возможность поднимать предметы, 
+/// когда существо находится в боевом режиме.
+/// 
+/// Работает по системе whitelist/blacklist:
+/// - Если задан <see cref="Whitelist"/>, поднимать можно только предметы из этого списка.
+/// - Если задан <see cref="Blacklist"/>, поднимать нельзя предметы из этого списка.
+/// </summary>
+
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class CombatModePickupWhitelistComponent : Component
 {

--- a/Content.Shared/ADT/Combat/Systems/CombatModePickupWhitelistSystem.cs
+++ b/Content.Shared/ADT/Combat/Systems/CombatModePickupWhitelistSystem.cs
@@ -1,0 +1,32 @@
+using Content.Shared.Whitelist;
+using Content.Shared.Actions.Events;
+using Content.Shared.CombatMode;
+using Content.Shared.Item;
+
+namespace Content.Shared.ADT.Combat;
+
+public sealed class CombatModePickupWhitelistSystem : EntitySystem
+{
+    [Dependency] private readonly SharedCombatModeSystem _combat = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CombatModePickupWhitelistComponent, PickupAttemptEvent>(OnPickup);
+    }
+
+    private void OnCombatToggled(EntityUid uid, CombatModePickupWhitelistComponent comp, ref ToggleCombatActionEvent args)
+    {
+    }
+
+    private void OnPickup(EntityUid uid, CombatModePickupWhitelistComponent comp, ref PickupAttemptEvent args)
+    {
+        if (!_combat.IsInCombatMode(uid))
+            return;
+
+        if (!_whitelist.CheckBoth(args.Item, blacklist: comp.Blacklist, whitelist: comp.Whitelist))
+            args.Cancel();
+    }
+}

--- a/Content.Shared/ADT/Combat/Systems/CombatModePickupWhitelistSystem.cs
+++ b/Content.Shared/ADT/Combat/Systems/CombatModePickupWhitelistSystem.cs
@@ -15,11 +15,7 @@ public sealed class CombatModePickupWhitelistSystem : EntitySystem
 
         SubscribeLocalEvent<CombatModePickupWhitelistComponent, PickupAttemptEvent>(OnPickup);
     }
-
-    private void OnCombatToggled(EntityUid uid, CombatModePickupWhitelistComponent comp, ref ToggleCombatActionEvent args)
-    {
-    }
-
+    
     private void OnPickup(EntityUid uid, CombatModePickupWhitelistComponent comp, ref PickupAttemptEvent args)
     {
         if (!_combat.IsInCombatMode(uid))

--- a/Content.Shared/ADT/Combat/Systems/CombatModePickupWhitelistSystem.cs
+++ b/Content.Shared/ADT/Combat/Systems/CombatModePickupWhitelistSystem.cs
@@ -1,7 +1,6 @@
-using Content.Shared.Whitelist;
-using Content.Shared.Actions.Events;
 using Content.Shared.CombatMode;
 using Content.Shared.Item;
+using Content.Shared.Whitelist;
 
 namespace Content.Shared.ADT.Combat;
 

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -56,6 +56,15 @@
       tags:
         - Cartridge
         - Trash
+        - Pen
+        - Write
+        - Document
+        - Paper
+        - Figurine
+        - Payload
+        - ClothMade
+        - Mouse
+        - Candle
   # ADT tweak end
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -51,6 +51,10 @@
   - type: LanguageSpeaker
     languages:
       GalacticCommon: Speak
+  - type: CombatModePickupWhitelist
+    blacklist:
+      tags:
+        - Cartridge
   # ADT tweak end
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -55,6 +55,7 @@
     blacklist:
       tags:
         - Cartridge
+        - Trash
   # ADT tweak end
 
 - type: entity


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
Добавила систему чтобы во время комбот мода нельзя было взять предмет который находится в блеклисте или можно было бы взять предмет который в вайтлисте.

## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс. -->
Очень часто слышала высказывания по этому поводу и что это очень сильно мешает (в том числе и мне)
На баланс повлияет только тем, что игроки будут меньше мисать так как они не будут подбирать всякую ненужную фигню.

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
Архитектура системы

1. Компонент данных (CombatModePickupWhitelistComponent)

    Хранит конфигурацию фильтров подбора
    Содержит два поля: Whitelist и Blacklist типа EntityWhitelist
    Поддерживает сетевую синхронизацию (NetworkedComponent)

2. Система обработки (CombatModePickupWhitelistSystem)

    Подписывается на событие PickupAttemptEvent
    Проверяет состояние комбат мода через SharedCombatModeSystem
    Использует EntityWhitelistSystem для фильтрации предметов

Логика работы

private void OnPickup(EntityUid uid, CombatModePickupWhitelistComponent comp, ref PickupAttemptEvent args)
{
    if (!_combat.IsInCombatMode(uid))
        return; // Фильтрация работает только в комбат моде

    if (!_whitelist.CheckBoth(args.Item, blacklist: comp.Blacklist, whitelist: comp.Whitelist))
        args.Cancel(); // Блокирует подбор если предмет не прошел фильтрацию
}

Критические изменения

Новые пространства имен:

    Content.Shared.ADT.Combat - содержит компонент и систему

Новые публичные классы:

    CombatModePickupWhitelistComponent - компонент конфигурации
    CombatModePickupWhitelistSystem - система обработки событий

Новые поля компонента:

    EntityWhitelist? Whitelist - список разрешенных предметов
    EntityWhitelist? Blacklist - список запрещенных предметов

Зависимости системы:

    SharedCombatModeSystem - для проверки состояния комбат мода
    EntityWhitelistSystem - для обработки списков фильтрации

Интеграция с существующими системами

Система интегрируется с:

    Системой комбат мода - проверяет активность через IsInCombatMode()
    Системой подбора предметов - перехватывает PickupAttemptEvent
    Системой вайтлистов - использует CheckBoth() для фильтрации

Система работает реактивно - активируется только при попытке подбора предмета в комбат моде и не влияет на производительность в обычном состоянии.
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений. 

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

https://github.com/user-attachments/assets/72b75a1a-e7e4-403f-b231-ca4f5e49eb8d


## Чейнджлог


:cl: Minokaa
- add: Некоторые предметы теперь нельзя подбирать в комбот моде.


