### PR TITLE
Фикс ещё нескольких багов, которые ломают игру

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/OuterClothing/armor.yml
@@ -578,9 +578,9 @@
     modifiers:
       coefficients:
         Blunt: 0.5
-        Slash: 0.45
-        Piercing: 0.35
-        Heat: 0.10
+        Slash: 0.55
+        Piercing: 0.65
+        Heat: 0.9
   - type: GroupExamine
   - type: ClothingSpeedModifier
     walkModifier: 0.75

--- a/Resources/Prototypes/ADT/Entities/Markers/Spawners/Random/casinotables.yml
+++ b/Resources/Prototypes/ADT/Entities/Markers/Spawners/Random/casinotables.yml
@@ -70,15 +70,15 @@
   table: !type:GroupSelector
     children:
     - !type:GroupSelector
-      weight: 10
+      weight: 1
       children:
       - id: ADTChaosCasinoBigBoyJackpot
     - !type:GroupSelector
-      weight: 50
+      weight: 55
       children:
       - id: ADTChaosCasinoBigBoyWin
     - !type:GroupSelector
-      weight: 40
+      weight: 44
       children:
       - id: ADTChaosCasinoBigBoyLoose
 

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -218,6 +218,7 @@
   - type: Tag
     tags:
       - ADTUraniumSheet
+      - Sheet
 ### End ADT Tweak
   - type: Material
   - type: Food


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
Нет. Просто нет. Это кошмарище. Пофикшен уран, шанс на джекпот и броня тамплиера


## Почему / Баланс
[Заказ](https://discordapp.com/channels/901772674865455115/1408381356018499616)


## Чейнджлог
:cl: QWERTY
- fix: Исправлена невозможность вставления урана в различные машины.
- tweak: Бог понял, что сковал слишком сильную броню крестоносца, так что он начал заказывать реплику, сделанную таборами воксов.
- tweak: Боги хаоса, гемблинга и лудомании поняли, что джекпот в секции для больших мальчиков слишком частый. Джекпот теперь будет попадаться реже, но вам определённо стоит дальше лудоманить.