### PR TITLE
Теперь за ОСЩ и патологоанатома можно открывать кпк наводясь мышкой и нажимая E

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Devices/pda.yml
@@ -24,8 +24,6 @@
   id: ADTBaseMedicalPDA
   abstract: true
   components:
-  # - type: ItemToggle # ADT Tweak (commented)
-  #   onUse: false # ADT Tweak (commented)
   - type: CartridgeLoader
     uiKey: enum.PdaUiKey.Key
     preinstalled:

--- a/Resources/Prototypes/ADT/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Devices/pda.yml
@@ -24,8 +24,8 @@
   id: ADTBaseMedicalPDA
   abstract: true
   components:
-  - type: ItemToggle
-    onUse: false
+  # - type: ItemToggle # ADT Tweak (commented)
+  #   onUse: false # ADT Tweak (commented)
   - type: CartridgeLoader
     uiKey: enum.PdaUiKey.Key
     preinstalled:


### PR DESCRIPTION
## Описание PR
Раньше нельзя было наводится мышкой и открыть взаимодействием меню кпк ОСЩ и патологоанатома, вот теперь можно... вот...

## Почему 
Ну... не очень удобно брать кпк в руки и только потом открывать меню. Теперь вот удобно
- [Баг-репорт] --> https://discord.com/channels/901772674865455115/1406880813639008286

## Техническая информация
Убрал тип, где кпк обязательно нужно было брать в руки, чтобы взаимодействовать с ним (не совсем понимаю зачем его вообще добавили).
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
https://www.youtube.com/watch?v=VpUrG5YU3io

## Чейнджлог
:cl: godot04
- fix: Исправлен баг, при котором нельзя было открывать меню кпк при помощи кнопки взаимодействия (на E) 
