### PR TITLE
[OPTIMIZATION] Переписана система BloodCoughSystem, полностью убран Update и заменён на таймер

### DIFF
--- a/Content.Server/ADT/AutoPostingChat/AutoEmotePostingChatSystem.cs
+++ b/Content.Server/ADT/AutoPostingChat/AutoEmotePostingChatSystem.cs
@@ -3,14 +3,12 @@ using Content.Server.Chat.Systems;
 using Content.Shared.Chat;
 using Content.Shared.Mobs;
 using Robust.Shared.Random;
-using Robust.Shared.Timing;
 
 namespace Content.Server.ADT.AutoPostingChat;
 
 public sealed class AutoEmotePostingChatSystem : EntitySystem
 {
     [Dependency] private readonly ChatSystem _chat = default!;
-    [Dependency] private readonly IGameTiming _time = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
 
     public override void Initialize()
@@ -34,7 +32,6 @@ public sealed class AutoEmotePostingChatSystem : EntitySystem
 
     private void OnComponentStartup(EntityUid uid, AutoEmotePostingChatComponent component, ComponentStartup args)
     {
-        // Перезапускаем таймер при старте компонента (например, при десериализации)
         StartEmoteTimer(uid, component);
     }
 

--- a/Content.Server/ADT/AutoPostingChat/AutoSpeakPostingChatSystem.cs
+++ b/Content.Server/ADT/AutoPostingChat/AutoSpeakPostingChatSystem.cs
@@ -3,13 +3,11 @@ using Content.Server.Chat.Systems;
 using Content.Shared.Chat;
 using Content.Shared.Mobs;
 using Robust.Shared.Random;
-using Robust.Shared.Timing;
 
 namespace Content.Server.ADT.AutoPostingChat;
 public sealed class AutoSpeakPostingChatSystem : EntitySystem
 {
     [Dependency] private readonly ChatSystem _chat = default!;
-    [Dependency] private readonly IGameTiming _time = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
 
     public override void Initialize()

--- a/Content.Server/ADT/BloodCough/BloodCoughComponent.cs
+++ b/Content.Server/ADT/BloodCough/BloodCoughComponent.cs
@@ -2,7 +2,7 @@ using System.Threading;
 
 namespace Content.Server.ADT.BloodCough;
 
-[RegisterComponent, AutoGenerateComponentState(true)]
+[RegisterComponent]
 public sealed partial class BloodCoughComponent : Component
 {
     [DataField("coughTimeMin"), ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/ADT/BloodCough/BloodCoughComponent.cs
+++ b/Content.Server/ADT/BloodCough/BloodCoughComponent.cs
@@ -1,22 +1,28 @@
-using Robust.Shared.GameStates;
+using System.Threading;
 
 namespace Content.Server.ADT.BloodCough;
 
-[RegisterComponent]
+[RegisterComponent, AutoGenerateComponentState(true)]
 public sealed partial class BloodCoughComponent : Component
 {
     public TimeSpan NextSecond = TimeSpan.Zero;
 
     [DataField("coughTimeMin"), ViewVariables(VVAccess.ReadWrite)]
-    public int CoughTimeMin = 11;
+    public int CoughTimeMin = 5;
 
     [DataField("coughTimeMax"), ViewVariables(VVAccess.ReadWrite)]
-    public int CoughTimeMax = 17;
+    public int CoughTimeMax = 16;
 
     [DataField("postingSayDamage")]
     public string? PostingSayDamage = default;
 
+    [AutoNetworkedField]
     public bool CheckCoughBlood = false;
+
+    /// <summary>
+    /// Token source for managing the timer cancellation
+    /// </summary>
+    public CancellationTokenSource? TokenSource;
 }
 
 /*

--- a/Content.Server/ADT/BloodCough/BloodCoughComponent.cs
+++ b/Content.Server/ADT/BloodCough/BloodCoughComponent.cs
@@ -5,8 +5,6 @@ namespace Content.Server.ADT.BloodCough;
 [RegisterComponent, AutoGenerateComponentState(true)]
 public sealed partial class BloodCoughComponent : Component
 {
-    public TimeSpan NextSecond = TimeSpan.Zero;
-
     [DataField("coughTimeMin"), ViewVariables(VVAccess.ReadWrite)]
     public int CoughTimeMin = 5;
 

--- a/Content.Server/ADT/BloodCough/BloodCoughComponent.cs
+++ b/Content.Server/ADT/BloodCough/BloodCoughComponent.cs
@@ -14,7 +14,6 @@ public sealed partial class BloodCoughComponent : Component
     [DataField("postingSayDamage")]
     public string? PostingSayDamage = default;
 
-    [AutoNetworkedField]
     public bool CheckCoughBlood = false;
 
     /// <summary>

--- a/Content.Server/ADT/BloodCough/BloodCoughSystem.cs
+++ b/Content.Server/ADT/BloodCough/BloodCoughSystem.cs
@@ -1,5 +1,4 @@
 using Content.Server.Chat.Systems;
-using Robust.Shared.Timing;
 using Robust.Shared.Random;
 using Content.Shared.Damage;
 using Content.Server.Body.Components;
@@ -9,13 +8,13 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.ADT.Silicon.Components;
 using Robust.Shared.Prototypes;
 using Content.Shared.Chat;
+using System.Threading;
 
 namespace Content.Server.ADT.BloodCough;
 
 public sealed class BloodCoughSystem : EntitySystem
 {
     [Dependency] private readonly ChatSystem _chat = default!;
-    [Dependency] private readonly IGameTiming _time = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly PuddleSystem _puddleSystem = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
@@ -25,64 +24,131 @@ public sealed class BloodCoughSystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<BloodCoughComponent, DamageChangedEvent>(OnMobStateDamage);
+        SubscribeLocalEvent<BloodCoughComponent, ComponentStartup>(OnComponentStartup);
+        SubscribeLocalEvent<BloodCoughComponent, ComponentShutdown>(OnComponentShutdown);
+        SubscribeLocalEvent<BloodCoughComponent, AfterAutoHandleStateEvent>(OnAfterAutoHandleState);
+    }
+
+    private void OnComponentStartup(EntityUid uid, BloodCoughComponent component, ComponentStartup args)
+    {
+        // Проверяем текущий урон и запускаем таймер если нужно
+        CheckAndUpdateCoughState(uid, component);
+    }
+
+    private void OnComponentShutdown(EntityUid uid, BloodCoughComponent component, ComponentShutdown args)
+    {
+        // Отменяем таймер при удалении компонента
+        if (component.TokenSource != null)
+        {
+            component.TokenSource.Cancel();
+            component.TokenSource.Dispose();
+            component.TokenSource = null;
+        }
+    }
+
+    private void OnAfterAutoHandleState(EntityUid uid, BloodCoughComponent component, ref AfterAutoHandleStateEvent args)
+    {
+        // Обновляем состояние кашля при изменении компонента
+        CheckAndUpdateCoughState(uid, component);
     }
 
     private void OnMobStateDamage(EntityUid uid, BloodCoughComponent component, DamageChangedEvent args)
     {
-        if (EntityManager.TryGetComponent<DamageableComponent>(uid, out var damageable))
-        {
-            var damagePerGroup = damageable.Damage.GetDamagePerGroup(_prototypeManager);
-            if (damagePerGroup.TryGetValue("Brute", out var bruteDamage))
-            {
-                if (bruteDamage > 70)
-                {
-                    if (TryComp<BloodCoughComponent>(uid, out var posting))
-                    {
-                        posting.CheckCoughBlood = true;
-                    }
-                }
-                if (bruteDamage <= 70)
-                {
-                    if (TryComp<BloodCoughComponent>(uid, out var posting))
-                    {
-                        posting.CheckCoughBlood = false;
-                    }
-                }
-            }
-        }
-        else
+        CheckAndUpdateCoughState(uid, component);
+    }
+
+    private void CheckAndUpdateCoughState(EntityUid uid, BloodCoughComponent component)
+    {
+        if (!EntityManager.TryGetComponent<DamageableComponent>(uid, out var damageable))
         {
             Log.Debug($"Сущность {ToPrettyString(uid)} не имеет компонента DamageableComponent.");
+            return;
+        }
+
+        var damagePerGroup = damageable.Damage.GetDamagePerGroup(_prototypeManager);
+        if (!damagePerGroup.TryGetValue("Brute", out var bruteDamage))
+            return;
+
+        var shouldCough = bruteDamage >= 70 && bruteDamage <= 100;
+
+        if (component.CheckCoughBlood != shouldCough)
+        {
+            component.CheckCoughBlood = shouldCough;
+
+            if (shouldCough)
+            {
+                StartCoughTimer(uid, component);
+            }
+            else
+            {
+                StopCoughTimer(uid, component);
+            }
         }
     }
 
-    public override void Update(float frameTime)
+    private void StartCoughTimer(EntityUid uid, BloodCoughComponent component)
     {
-        base.Update(frameTime);
+        // Отменяем предыдущий таймер если он существует
+        component.TokenSource?.Cancel();
+        component.TokenSource?.Dispose();
+        component.TokenSource = new CancellationTokenSource();
 
-        var query = EntityQueryEnumerator<BloodCoughComponent>();
-        while (query.MoveNext(out var uid, out var comp))
+        var delay = _random.Next(component.CoughTimeMin, component.CoughTimeMax);
+
+        // Запускаем повторяющийся таймер
+        uid.SpawnRepeatingTimer(TimeSpan.FromSeconds(delay), () => OnCoughTimerFired(uid, component), component.TokenSource.Token);
+    }
+
+    private void StopCoughTimer(EntityUid uid, BloodCoughComponent component)
+    {
+        if (component.TokenSource != null)
         {
-            if (_mobState.IsAlive(uid))
+            component.TokenSource.Cancel();
+            component.TokenSource.Dispose();
+            component.TokenSource = null;
+        }
+    }
+
+    private void OnCoughTimerFired(EntityUid uid, BloodCoughComponent component)
+    {
+        // Проверяем, что компонент все еще существует
+        if (!HasComp<BloodCoughComponent>(uid))
+            return;
+
+        // Проверяем, что сущность жива
+        if (!_mobState.IsAlive(uid))
+            return;
+
+        // Проверяем, что урон все еще в нужном диапазоне
+        if (!EntityManager.TryGetComponent<DamageableComponent>(uid, out var damageable))
+            return;
+
+        var damagePerGroup = damageable.Damage.GetDamagePerGroup(_prototypeManager);
+        if (!damagePerGroup.TryGetValue("Brute", out var bruteDamage))
+            return;
+
+        if (bruteDamage < 70 || bruteDamage > 100)
+        {
+            component.CheckCoughBlood = false;
+            StopCoughTimer(uid, component);
+            return;
+        }
+
+        PerformCough(uid, component);
+    }
+
+    private void PerformCough(EntityUid uid, BloodCoughComponent component)
+    {
+        if (component.PostingSayDamage != null)
+        {
+            _chat.TrySendInGameICMessage(uid, Loc.GetString(component.PostingSayDamage), InGameICChatType.Emote, ChatTransmitRange.HideChat);
+
+            if (TryComp<BloodstreamComponent>(uid, out var bloodId) &&
+                !TryComp<SiliconComponent>(uid, out var _))
             {
-                if (_time.CurTime >= comp.NextSecond)
-                {
-                    var delay = _random.Next(comp.CoughTimeMin, comp.CoughTimeMax);
-                    if (comp.PostingSayDamage != null)
-                    {
-                        if (comp.CheckCoughBlood)
-                        {
-                            _chat.TrySendInGameICMessage(uid, Loc.GetString(comp.PostingSayDamage), InGameICChatType.Emote, ChatTransmitRange.HideChat);
-                            if (comp.CheckCoughBlood && TryComp<BloodstreamComponent>(uid, out var bloodId) && !TryComp<SiliconComponent>(uid, out var _)) //лютейший костыль, тут проверка, потому что у кпб в крови ВОДА и при кашле он воду спавнит. поэтому сущности с SiliconComponent игнорим
-                            {
-                                Solution blood = new();
-                                blood.AddReagent(bloodId.BloodReagent, 1);
-                                _puddleSystem.TrySpillAt(uid, blood, out _, sound: false);
-                            }
-                        }
-                    }
-                    comp.NextSecond = _time.CurTime + TimeSpan.FromSeconds(delay);
-                }
+                Solution blood = new();
+                blood.AddReagent(bloodId.BloodReagent, 1);
+                _puddleSystem.TrySpillAt(uid, blood, out _, sound: false);
             }
         }
     }


### PR DESCRIPTION
## Описание PR
В данном PR произведён рефакторинг системы **BloodCoughSystem**:

* Полностью убран метод `Update`, логика переведена на использование таймеров.
* Добавлена корректная обработка запуска и остановки таймера при старте/удалении компонента.
* Реализована проверка состояния урона для активации/деактивации кашля кровью.
* Убран лишний код и оптимизирована работа с `DamageableComponent`.

---

## Почему / Баланс

* Удаление `Update` снижает нагрузку на сервер.
* Логика кашля теперь работает **только при необходимости**, а не в каждом тике.
* Поведение стало более предсказуемым и стабильным.

---

## Техническая информация

* Используется `CancellationTokenSource` для управления таймерами.
* Проверка урона по группе `"Brute"`.
* Если урон в диапазоне **70–100**, запускается таймер кашля.
* При выходе за пределы диапазона таймер корректно останавливается.
* Добавлен `CheckCoughBlood` для синхронизации состояния компонента.

---

### Чейнджлог
no cl, no fun
