### PR TITLE
пару обновлений

### DIFF
--- a/Content.Server/ADT/Morph/MorphSystem.cs
+++ b/Content.Server/ADT/Morph/MorphSystem.cs
@@ -36,6 +36,9 @@ using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Components;
 using Content.Shared.Standing;
 using Content.Server.Body.Components;
+using Robust.Server.GameObjects;
+using Robust.Shared.Map;
+using System.Numerics;
 
 namespace Content.Server.ADT.Morph;
 
@@ -61,7 +64,7 @@ public sealed class MorphSystem : SharedMorphSystem
     [Dependency] private readonly StunSystem _stun = default!;
     [Dependency] private readonly WeldableSystem _weldable = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
-
+    [Dependency] private readonly TransformSystem _transform = default!;
     public ProtoId<DamageGroupPrototype> BruteDamageGroup = "Brute";
     public ProtoId<DamageGroupPrototype> BurnDamageGroup = "Burn";
     public override void Initialize()
@@ -91,6 +94,11 @@ public sealed class MorphSystem : SharedMorphSystem
 
     private void OnDestroy(EntityUid uid, MorphComponent component, ref BeingGibbedEvent args)
     {
+        foreach (var entity in component.ContainedCreatures)
+        {
+            var transform = Transform(uid);
+            _transform.SetCoordinates(entity, transform.Coordinates);
+        }
         container.EmptyContainer(component.Container);
     }
     private void OnInit(EntityUid uid, MorphComponent component, MapInitEvent args)
@@ -349,7 +357,8 @@ public sealed class MorphSystem : SharedMorphSystem
             health = -component.EatWeaponHungerReq;
             _hunger.ModifyHunger(uid, (float)health.Value, hunger);
             _audioSystem.PlayPvs(component.SoundDevour, uid);
-            container.Insert(args.Target.Value, component.Container);
+            _transform.SetCoordinates(args.Target.Value, new EntityCoordinates(args.Target.Value, MapCoordinates.Nullspace.Position));
+            component.ContainedCreatures.Add(args.Target.Value);
             return;
         }
         if (state.CurrentThresholdState != MobState.Dead)

--- a/Content.Server/ADT/PressureDamageModify/PressureDamageModifyComponent.cs
+++ b/Content.Server/ADT/PressureDamageModify/PressureDamageModifyComponent.cs
@@ -14,10 +14,10 @@ public sealed partial class PressureDamageModifyComponent : Component
     /// <summary>
     /// KPd, below which damage will diminishes.  0 kPa = 1 kPa
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("needsPressure")]
-    public float Pressure = 40f;
-    [ViewVariables(VVAccess.ReadWrite), DataField("needsPressure")]
-    public float MaxPressure = 10f;
+    [ViewVariables(VVAccess.ReadWrite), DataField("maxPressure")]
+    public float MaxPressure = 40f;
+    [ViewVariables(VVAccess.ReadWrite), DataField("minPressure")]
+    public float MinPressure = 10f;
 
     /// <summary>
     /// only for melee, doesn`t work for projectiles

--- a/Content.Server/ADT/PressureDamageModify/PressureDamageModifyComponent.cs
+++ b/Content.Server/ADT/PressureDamageModify/PressureDamageModifyComponent.cs
@@ -16,6 +16,8 @@ public sealed partial class PressureDamageModifyComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("needsPressure")]
     public float Pressure = 40f;
+    [ViewVariables(VVAccess.ReadWrite), DataField("needsPressure")]
+    public float MaxPressure = 10f;
 
     /// <summary>
     /// only for melee, doesn`t work for projectiles

--- a/Content.Server/ADT/PressureDamageModify/PressureDamageModifySystem.cs
+++ b/Content.Server/ADT/PressureDamageModify/PressureDamageModifySystem.cs
@@ -39,7 +39,7 @@ public sealed partial class PressureDamageModifySystem : EntitySystem
         {
             pressure = MathF.Max(mixture.Pressure, 1f);
         }
-        if (pressure >= component.Pressure)
+        if (pressure >= component.MaxPressure && pressure >= component.MinPressure)
         {
             args.Damage *= component.ProjDamage;
         }
@@ -62,7 +62,7 @@ public sealed partial class PressureDamageModifySystem : EntitySystem
             {
                 pressure = MathF.Max(mixture.Pressure, 1f);
             }
-            if (pressure <= component.Pressure)
+            if (pressure <= component.MaxPressure && pressure >= component.MinPressure)
             {
                 _damage.TryChangeDamage(ent, component.AdditionalDamage);
             }

--- a/Content.Shared/ADT/Morph/MorphComponent.cs
+++ b/Content.Shared/ADT/Morph/MorphComponent.cs
@@ -95,6 +95,7 @@ public sealed partial class MorphComponent : Component
     [DataField("devourTime")]
     public float DevourTime = 3f;
 
+    public List<EntityUid> ContainedCreatures = new();
     /// <summary>
     /// вайтлист на обед
     /// </summary>

--- a/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
@@ -78,11 +78,13 @@ public sealed class GunUpgradeSystem : EntitySystem
         if (_entityWhitelist.IsWhitelistFail(ent.Comp.Whitelist, args.Used))
             return;
 
-        if (GetCurrentUpgradeTags(ent).ToHashSet().IsSupersetOf(upgradeComponent.Tags))
-        {
-            _popup.PopupPredicted(Loc.GetString("upgradeable-gun-popup-already-present"), ent, args.User);
-            return;
-        }
+        //ADT tweak start
+        // if (GetCurrentUpgradeTags(ent).ToHashSet().IsSupersetOf(upgradeComponent.Tags))
+        // {
+        //     _popup.PopupPredicted(Loc.GetString("upgradeable-gun-popup-already-present"), ent, args.User);
+        //     return;
+        // }
+        //ADT tweak end
 
         _audio.PlayPredicted(ent.Comp.InsertSound, ent, args.User);
         _popup.PopupClient(Loc.GetString("gun-upgrade-popup-insert", ("upgrade", args.Used),("gun", ent.Owner)), args.User);

--- a/Resources/Prototypes/ADT/Entities/Mobs/NPCs/spiders.yml
+++ b/Resources/Prototypes/ADT/Entities/Mobs/NPCs/spiders.yml
@@ -2,7 +2,7 @@
 # random sprite state when you spawn it.
 - type: entity
   name: base spider
-  parent: SimpleMobBase
+  parent: SimpleSpaceMobBase
   id: ADTMobBaseSpider
   abstract: true
   description: Widely recognized to be the literal worst thing in existence.

--- a/Resources/Prototypes/ADT/GameRules/roundstart.yml
+++ b/Resources/Prototypes/ADT/GameRules/roundstart.yml
@@ -241,8 +241,8 @@
         cost: 120
       - id: PhantomSpawn
         cost: 110
-      # - id: MorphSpawn #TODO: Раскомментить после фикса
-      #   cost: 130
+      - id: MorphSpawn
+        cost: 130
       - id: NinjaSpawn
         cost: 140
       - id: KingRatMigration
@@ -293,8 +293,8 @@
         cost: 130
       - id: PhantomSpawn
         cost: 120
-      # - id: MorphSpawn #TODO: Раскомментить после фикса
-      #   cost: 140
+      - id: MorphSpawn
+       cost: 140
       - id: NinjaSpawn
         cost: 150
       - id: KingRatMigration
@@ -338,8 +338,8 @@
         cost: 130
       - id: PhantomSpawn
         cost: 120
-      # - id: MorphSpawn #TODO: Раскомментить после фикса
-      #   cost: 140
+      - id: MorphSpawn
+        cost: 140
       - id: NinjaSpawn
         cost: 150
       - id: KingRatMigration

--- a/Resources/Prototypes/ADT/GameRules/roundstart.yml
+++ b/Resources/Prototypes/ADT/GameRules/roundstart.yml
@@ -294,7 +294,7 @@
       - id: PhantomSpawn
         cost: 120
       - id: MorphSpawn
-       cost: 140
+        cost: 140
       - id: NinjaSpawn
         cost: 150
       - id: KingRatMigration

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -68,6 +68,7 @@
   - type: MobPrice
     price: 1000 # Living critters are valuable in space.
   - type: Perishable
+  - type: Fauna #ADT tweak
 
 - type: entity
   parent:

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -42,7 +42,7 @@
     - id: WizardSpawn
     - id: LoneOpsSpawn  # ADT tweak - вернул лон опса в список... АНТАГОВ
     - id: Pirates # ADT tweak pirates
-    # - id: MorphSpawn #ADT tweak morph #TODO: Раскомментить после фикса
+    - id: MorphSpawn #ADT tweak morph
     - id: PhantomSpawn # ADT tweak phantom
     - id: VoxRaidersEvent # ADT tweak vox-raiders
     # - id: ZombieOutbreak


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
фикс морфа
девалидхантизация утилей
подчистика за визденами

## Почему / Баланс

кто-то любит валидхант от утилей?

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог

:cl: Ratyyy

- tweak: В связи с изменением конструкции, ПКА не работают в полной разгерметизации.
- tweak: Инженерам крашеров донесли про невозможность установить метку на большую часть фауны и они это исправили!
- fix: После спячки ульи морфов вновь вернулись к работоспособности и начали появляться на станциях!
