### PR TITLE
[Fix] Meson

### DIFF
--- a/Content.Client/ADT/MesonVision/MesonVisionOverlay.cs
+++ b/Content.Client/ADT/MesonVision/MesonVisionOverlay.cs
@@ -1,16 +1,13 @@
 using System.Numerics;
 using Content.Shared.ADT.MesonVision;
-using Content.Shared.Mobs.Components;
+using Content.Shared.Doors.Components;
+using Content.Shared.Light.Components;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Map;
-using Content.Client.Markers;
-using Robust.Shared.GameObjects;
-using Content.Shared.StepTrigger.Components;
-using Content.Shared.Item;
-using DrawDepthTag = Robust.Shared.GameObjects.DrawDepth;
+
 namespace Content.Client.ADT.MesonVision;
 
 public sealed class MesonVisionOverlay : Overlay
@@ -19,9 +16,6 @@ public sealed class MesonVisionOverlay : Overlay
     [Dependency] private readonly IPlayerManager _player = default!;
     private readonly SharedTransformSystem _xformSystem;
     private readonly ContainerSystem _container;
-    private readonly EntityQuery<ItemComponent> _item;
-    private readonly EntityQuery<MobStateComponent> _mob;
-    private readonly EntityQuery<MarkerComponent> _marker;
     private readonly EntityQuery<SpriteComponent> _spriteQuery;
     private readonly EntityQuery<TransformComponent> _xformQuery;
 
@@ -33,9 +27,6 @@ public sealed class MesonVisionOverlay : Overlay
         IoCManager.InjectDependencies(this);
         _container = _entity.System<ContainerSystem>();
         _xformSystem = _entity.System<SharedTransformSystem>();
-        _item = _entity.GetEntityQuery<ItemComponent>();
-        _mob = _entity.GetEntityQuery<MobStateComponent>();
-        _marker = _entity.GetEntityQuery<MarkerComponent>();
         _spriteQuery = _entity.GetEntityQuery<SpriteComponent>();
         _xformQuery = _entity.GetEntityQuery<TransformComponent>();
     }
@@ -58,15 +49,22 @@ public sealed class MesonVisionOverlay : Overlay
 
         foreach (var entity in _entity.GetEntities())
         {
-            if (_mob.HasComponent(entity) || _marker.HasComponent(entity)) continue;
-            if (!_spriteQuery.TryGetComponent(entity, out var sprite) || sprite.DrawDepth < -2 || sprite.DrawDepth > 7 || sprite.DrawDepth == 0) continue;
-            if (!_xformQuery.TryGetComponent(entity, out var xform)) continue;
-            if (_container.TryGetOuterContainer(entity, xform, out var container)) continue;
-
-            if (xform.MapID != mapId) continue;
+            if (!_spriteQuery.TryGetComponent(entity, out var sprite) ||
+                !_xformQuery.TryGetComponent(entity, out var xform) ||
+                xform.MapID != mapId ||
+                _container.TryGetOuterContainer(entity, xform, out var _))
+            {
+                continue;
+            }
 
             var worldPos = _xformSystem.GetWorldPosition(xform);
             if (!worldBounds.Contains(worldPos)) continue;
+
+            var isWall = _entity.HasComponent<SunShadowCastComponent>(entity) || _entity.HasComponent<IsRoofComponent>(entity);
+            var isDoor = _entity.HasComponent<DoorComponent>(entity);
+
+            if (!isWall && !isDoor)
+                continue;
 
             _entries.Add(new MesonVisionRenderEntry(
                 (entity, sprite, xform),

--- a/Content.Client/ADT/MesonVision/MesonVisionOverlay.cs
+++ b/Content.Client/ADT/MesonVision/MesonVisionOverlay.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Shared.Traits.Assorted;
 using Content.Shared.ADT.MesonVision;
 using Content.Shared.Doors.Components;
 using Content.Shared.Light.Components;
@@ -34,7 +35,8 @@ public sealed class MesonVisionOverlay : Overlay
     protected override void Draw(in OverlayDrawArgs args)
     {
         if (!_entity.TryGetComponent(_player.LocalEntity, out MesonVisionComponent? nightVision) ||
-            nightVision.State != MesonVisionState.Full)
+            nightVision.State != MesonVisionState.Full ||
+            _entity.HasComponent<PermanentBlindnessComponent>(_player.LocalEntity))
         {
             return;
         }


### PR DESCRIPTION
## Описание PR
Исправлено отображение мезонных очков. Теперь они показывают только стены и шлюзы.
(Не настенные устройства, не ямы, не лаву :D). 
Так же это чинит оверлей. Делая сборку легче - ведь в мезонах теперь обрабатываются значительно меньше объектов, чем раньше.

## Почему / Баланс
Я считаю что очки которые мезонные - не должны показывать все объекты в игре. А должны быть видеть исключительно по назначению, стены,окна и шлюзы. (Пол не знаю как)

## Чейнджлог
:cl: CrimeMoot
- tweak: Мезонные линзы перестали делать из инопланетных сплавов, и теперь они показывают исключительно стены и шлюзы.
- fix: Слепые утеряли возможность видеть в мезонных очках - словно они и не слепые вовсе.
