### PR TITLE
[Fix] AbsorbDna

### DIFF
--- a/Content.Server/ADT/Objectives/Systems/StealDnaConditionSystem.cs
+++ b/Content.Server/ADT/Objectives/Systems/StealDnaConditionSystem.cs
@@ -60,12 +60,11 @@ public sealed class StealDnaConditionSystem : EntitySystem
         if (!TryComp<ChangelingComponent>(uid, out var ling))
             return 0f;
 
-        // Умер - не выполнил цель.
-        if (!_mind.IsCharacterDeadIc(mind))
+        if (_mind.IsCharacterDeadIc(mind))
             return 0f;
 
         // Подсчёт требуемых и имеющихся ДНК
-        var count = Math.Clamp(ling.DNAStolen, 0, 1);
-        return count;
+        var stolen = Math.Clamp(ling.DNAStolen, 0, comp.AbsorbDnaCount);
+        return (float)stolen / comp.AbsorbDnaCount;
     }
 }

--- a/Resources/Prototypes/ADT/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/ADT/Objectives/objectiveGroups.yml
@@ -35,7 +35,7 @@
     ChangelingObjectiveGroupState: 1
     ChangelingObjectiveGroupSteal: 1
     ChangelingObjectiveGroupPersonalitySteal: 1
-    ChangelingObjectiveGroupAbsorbDna: 1     # почему ты блять не работаешь
+    ChangelingObjectiveGroupAbsorbDna: 1
 
 - type: weightedRandom
   id: ChangelingObjectiveGroupSteal


### PR DESCRIPTION
## Описание PR
https://github.com/CrimeMoot/Ganimed14/pull/245 Port
Исправлена проблема связанная с невозможных сбором DNA у генокрада.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог
:cl: CrimeMoot
- fix: Теперь цели генокрада на кражу/сбор ДНК засчитываются в прогресс цели.
