### PR TITLE
[Fix] Narcoleps

### DIFF
--- a/Content.Server/Traits/Assorted/NarcolepsySystem.cs
+++ b/Content.Server/Traits/Assorted/NarcolepsySystem.cs
@@ -60,9 +60,10 @@ public sealed class NarcolepsySystem : EntitySystem
             // Make sure the sleep time doesn't cut into the time to next incident.
             narcolepsy.NextIncidentTime += duration;
 
+            _statusEffects.TryAddStatusEffect<ForcedSleepingComponent>(uid, StatusEffectKey,
+                TimeSpan.FromSeconds(duration), false);
+            
             // ADT-Tweak-start
-            _statusEffects.TryAddStatusEffect<ForcedSleepingComponent>(uid, StatusEffectKey, TimeSpan.FromSeconds(duration), false);
-
             if (TryComp<StrapComponent>(uid, out var strap) && strap.BuckledEntities.Count > 0)
             {
                 continue;

--- a/Content.Server/Traits/Assorted/NarcolepsySystem.cs
+++ b/Content.Server/Traits/Assorted/NarcolepsySystem.cs
@@ -1,6 +1,9 @@
+using Content.Shared.ADT.Crawling; // ADT-Tweak
+using Content.Shared.Standing; // ADT-Tweak
 using Content.Shared.Bed.Sleep;
 using Content.Shared.StatusEffect;
 using Robust.Shared.Random;
+using Content.Shared.Buckle.Components; // ADT-Tweak
 
 namespace Content.Server.Traits.Assorted;
 
@@ -14,6 +17,7 @@ public sealed class NarcolepsySystem : EntitySystem
 
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly StandingStateSystem _standing = default!; // ADT-Tweak
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -56,8 +60,16 @@ public sealed class NarcolepsySystem : EntitySystem
             // Make sure the sleep time doesn't cut into the time to next incident.
             narcolepsy.NextIncidentTime += duration;
 
-            _statusEffects.TryAddStatusEffect<ForcedSleepingComponent>(uid, StatusEffectKey,
-                TimeSpan.FromSeconds(duration), false);
+            // ADT-Tweak-start
+            _statusEffects.TryAddStatusEffect<ForcedSleepingComponent>(uid, StatusEffectKey, TimeSpan.FromSeconds(duration), false);
+
+            if (TryComp<StrapComponent>(uid, out var strap) && strap.BuckledEntities.Count > 0)
+            {
+                continue;
+            }
+
+            _standing.Down(uid, dropHeldItems: false);
+            // ADT-Tweak-end
         }
     }
 }


### PR DESCRIPTION
## Описание PR
Исправление нарколепсии. Теперь игрок падает при стадии нарколепсии. А не стоит.

:cl: CrimeMoot
- fix: Члены экипажа перестали слышать дзинь, а персонажи с нарколепсией теперь падают спать во время приступа, а не стоят неподвижно.
