### PR TITLE
[Fix] Quark point

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -711,7 +711,7 @@ namespace Content.Shared.Preferences
             _antagPreferences.UnionWith(antags);
 
             _traitPreferences.Clear();
-            _traitPreferences.UnionWith(GetValidTraits(traits, prototypeManager));
+            _traitPreferences.UnionWith(traits); // ADT-Tweak
 
             // Corvax-TTS-Start
             prototypeManager.TryIndex<TTSVoicePrototype>(Voice, out var voice);
@@ -781,14 +781,22 @@ namespace Content.Shared.Preferences
                 if (!protoManager.TryIndex(traitProto.Category, out var category))
                     continue;
 
-                var existing = groups.GetOrNew(category.ID);
-                existing += traitProto.Cost;
+                // ADT-Tweak start
+                if (category.MaxTraitPoints < 0)
+                {
+                    result.Add(trait);
+                    continue;
+                }
 
-                // Too expensive.
-                if (existing > category.MaxTraitPoints)
+                var total = groups.GetOrNew(category.ID);
+                var newTotal = total + traitProto.Cost;
+                // Ganimed edit trait points end
+
+                if (newTotal > category.MaxTraitPoints)
+                // ADT-Tweak end
                     continue;
 
-                groups[category.ID] = existing;
+                groups[category.ID] = newTotal; //  ADT-Tweak trait points
                 result.Add(trait);
             }
 


### PR DESCRIPTION
## Описание PR
Порт моего фикса https://github.com/CrimeMoot/Ganimed14/pull/240. Проблем за всё время не нашёл.
Теперь учитываются и положительные, и отрицательные квирки, суммируя их Cost в рамках категории. Если итоговая сумма не превышает MaxTraitPoints — квирк считается валидным и сохраняется. Раньше сервер удалял такие квирки, потому что считал только положительные очки — что ломало сохранение даже корректных билдов. Даже если ты ушёл по очкам в плюс.

## Чейнджлог
:cl: CrimeMoot
- fix: Теперь положительные особенности (квирки) сохраняются после полного выхода из игры и повторного входа, а не сбрасываются.
