### PR TITLE
[FIX] Fix movement speed not resetting after death or revival

### DIFF
--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -94,10 +94,10 @@ public partial class MobStateSystem
         // ADT-Tweak-start
         _moveMod.RefreshMovementSpeedModifiers(target);
 
-        if (state == MobState.Alive)
+        if (state is MobState.Critical or MobState.Dead)
         {
             if (HasComp<SlowedDownComponent>(target))
-                RemCompDeferred<SlowedDownComponent>(target);
+                RemComp<SlowedDownComponent>(target);
 
             _moveMod.RefreshMovementSpeedModifiers(target);
         }

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -15,6 +15,7 @@ using Content.Shared.Pointing;
 using Content.Shared.Pulling.Events;
 using Content.Shared.Speech;
 using Content.Shared.Standing;
+using Content.Shared.Stunnable; // ADT-Tweak
 using Content.Shared.Strip.Components;
 using Content.Shared.Throwing;
 using Robust.Shared.Physics.Components;
@@ -89,6 +90,18 @@ public partial class MobStateSystem
             default:
                 throw new NotImplementedException();
         }
+
+        // ADT-Tweak-start
+        _moveMod.RefreshMovementSpeedModifiers(target);
+
+        if (state == MobState.Alive)
+        {
+            if (HasComp<SlowedDownComponent>(target))
+                RemCompDeferred<SlowedDownComponent>(target);
+
+            _moveMod.RefreshMovementSpeedModifiers(target);
+        }
+        // ADT-Tweak-end
     }
 
     private void OnStateEnteredSubscribers(EntityUid target, MobStateComponent component, MobState state)

--- a/Content.Shared/Mobs/Systems/MobStateSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Damage;
 using Content.Shared.Mobs.Components;
+using Content.Shared.Movement.Systems; // ADT-Tweak
 using Content.Shared.Standing;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
@@ -18,6 +19,7 @@ public partial class MobStateSystem : EntitySystem
     [Dependency] private readonly ILogManager _logManager = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly MovementSpeedModifierSystem _moveMod = default!; // ADT-Tweak
     private ISawmill _sawmill = default!;
 
     private EntityQuery<MobStateComponent> _mobStateQuery;


### PR DESCRIPTION
## Описание PR
Исправлена проблема, когда игрок, находясь в состоянии смерти или критического повреждения, навсегда теряли скорость бега, оставаясь на скорости ходьбы. Переключение между ходьбой и бегом не возвращало нормальную скорость. Теперь компонент SlowedDownComponent (искусственно ограничивающий скорость) удаляется. Система MovementSpeedModifierSystem пересчитывает все модификаторы скорости. Игрок может двигаться с нормальной скоростью, при этом все реальные замедляющие эффекты, например стамина, болла и другое - продолжают действовать. Критически раненные игроки, которых оживили, восстанавливают нормальную скорость, но реальные эффекты замедления остаются.
https://discord.com/channels/901772674865455115/1413563185243492464

P.S надеюсь я правильно всё сделал. Как минимум пострелял со станнера и прочих штук. Проблем не заметил.

## Техническая информация
- SlowedDownComponent применяется только в состояниях Dead или Critical для минимизации скорости движения.
- `_moveMod.RefreshMovementSpeedModifiers` вызывается при входе в новое состояние и после удаления SlowedDownComponent
- [x] Локально протестировано, корректно работает для мертвых и критически раненых.

## Чейнджлог
:cl: CrimeMoot
- fix: Исправлен баг, из-за которого после смерти и ревайва, во время смерти можно было переключиться на шаг и персонаж навсегда оставался замедленным.
