### PR TITLE
[Tweak] Limit harvesters

### DIFF
--- a/Content.Server/ADT/BluespaceHarvester/BluespaceHarvesterSystem.cs
+++ b/Content.Server/ADT/BluespaceHarvester/BluespaceHarvesterSystem.cs
@@ -38,6 +38,7 @@ public sealed class BluespaceHarvesterSystem : EntitySystem
 
     private float _updateTimer;
     private const float UpdateTime = 1.0f;
+    private EntityUid? _activeHarvester;
 
     public override void Initialize()
     {
@@ -62,11 +63,21 @@ public sealed class BluespaceHarvesterSystem : EntitySystem
         var query = EntityQueryEnumerator<BluespaceHarvesterComponent, PowerConsumerComponent>();
         while (query.MoveNext(out var uid, out var harvester, out var consumer))
         {
-            var ent = (uid, harvester);
+            if (_activeHarvester == uid && harvester.CurrentLevel == 0)
+            {
+                _activeHarvester = null;
+            }
 
-            // We start only after manual switching on.
-            if (harvester is { Reseted: false, CurrentLevel: 0 })
-                harvester.Reseted = true;
+            if (_activeHarvester != null && _activeHarvester != uid)
+            {
+                UpdateUI(uid, harvester);
+                continue;
+            }
+
+            if (_activeHarvester == null && harvester.CurrentLevel > 0)
+            {
+                _activeHarvester = uid;
+            }
 
             // The HV wires cannot transmit a lot of electricity so quickly,
             // which is why it will not start.
@@ -127,6 +138,9 @@ public sealed class BluespaceHarvesterSystem : EntitySystem
         if (!harvester.Comp.Reseted && harvester.Comp.CurrentLevel != 0)
             return;
 
+        if (_activeHarvester != null && _activeHarvester != harvester.Owner)
+            return;
+
         harvester.Comp.TargetLevel = args.TargetLevel;
         harvester.Comp.Reseted = true; // We start only after manual switching on.
         UpdateUI(harvester.Owner, harvester.Comp);
@@ -135,6 +149,9 @@ public sealed class BluespaceHarvesterSystem : EntitySystem
     private void OnBuy(Entity<BluespaceHarvesterComponent> harvester, ref BluespaceHarvesterBuyMessage args)
     {
         if (!harvester.Comp.Reseted)
+            return;
+
+        if (_activeHarvester != harvester.Owner)
             return;
 
         if (!TryGetCategory(harvester.Owner, args.Category, out var info, harvester.Comp))
@@ -370,6 +387,10 @@ public sealed class BluespaceHarvesterSystem : EntitySystem
         harvester.Danger += harvester.DangerFromReset;
         harvester.Reseted = true;
         harvester.TargetLevel = 0;
+        harvester.CurrentLevel = 0;
+
+        if (_activeHarvester == uid)
+            _activeHarvester = null;
     }
 
     private bool Emagged(EntityUid uid)


### PR DESCRIPTION
## Описание PR
Исправлена логика работы BluespaceHarvester, чтобы одновременно активным мог быть только один харвестер. Теперь, если активный харвестер выключить (CurrentLevel = 0), его можно сменить на другой.

## Почему / Баланс
Это изменение улучшает управление харвестерами и предотвращает спам ими. Игроки больше не смогут одновременно ставить несколько харвесторов.

## Техническая информация
- Добавлена проверка _activeHarvester и сброс при CurrentLevel == 0.
- Логика выбора нового активного харвестера теперь учитывает только отключенные устройства - а именно выставить CurrentLevel на 0.
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.

## Чейнджлог
:cl: CrimeMoot
- tweak: Ограничена одновременная работа несколько харвестеров за раз. Теперь можно включить только один, все последующие перестают работать. Но, они будут работать только после выключения работающего.
