### PR TITLE
[FIX] Chaos mode

### DIFF
--- a/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
@@ -31,6 +31,14 @@ public sealed partial class RampingStationEventSchedulerComponent : Component
     [DataField]
     public float TimeUntilNextEvent;
 
+    // ADT-tweak start
+    [DataField("lastEventTime")]
+    public double LastEventTime = 0;
+
+    [DataField("eventFloodCounter")]
+    public int EventFloodCounter = 0;
+    // ADT-tweak end
+
     /// <summary>
     /// The gamerules that the scheduler can choose from
     /// </summary>

--- a/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
@@ -44,12 +44,10 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
 
         // Worlds shittiest probability distribution
         // Got a complaint? Send them to
-        // ADT-tweak start
         component.MaxChaos = _random.NextFloat(component.AverageChaos - component.AverageChaos / 4, component.AverageChaos + component.AverageChaos / 4);
         // This is in minutes, so *60 for seconds (for the chaos calc)
         component.EndTime = _random.NextFloat(component.AverageEndTime - component.AverageEndTime / 4, component.AverageEndTime + component.AverageEndTime / 4) * 60f;
 
-        // ADT-tweak end
         component.StartingChaos = component.MaxChaos / 10;
 
         PickNextEventTime(uid, component);

--- a/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.GameTicking.Rules;
 using Content.Server.StationEvents.Components;
 using Content.Shared.GameTicking.Components;
 using Robust.Shared.Random;
+using Robust.Server.Player; // ADT-tweak
 
 namespace Content.Server.StationEvents;
 
@@ -11,6 +12,7 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly EventManagerSystem _event = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!; // ADT-tweak
 
     /// <summary>
     /// Returns the ChaosModifier which increases as round time increases to a point.
@@ -18,10 +20,22 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
     public float GetChaosModifier(EntityUid uid, RampingStationEventSchedulerComponent component)
     {
         var roundTime = (float) _gameTicker.RoundDuration().TotalSeconds;
+
+        if (component.EndTime <= 0)
+            component.EndTime = 3600f;
+
+        if (component.MaxChaos <= 0)
+            component.MaxChaos = 1f;
+
         if (roundTime > component.EndTime)
             return component.MaxChaos;
 
-        return component.MaxChaos / component.EndTime * roundTime + component.StartingChaos;
+        var result = component.MaxChaos / component.EndTime * roundTime + component.StartingChaos;
+
+        if (float.IsNaN(result) || float.IsInfinity(result) || result <= 0)
+            return 1f;
+
+        return result;
     }
 
     protected override void Started(EntityUid uid, RampingStationEventSchedulerComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
@@ -30,9 +44,12 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
 
         // Worlds shittiest probability distribution
         // Got a complaint? Send them to
+        // ADT-tweak start
         component.MaxChaos = _random.NextFloat(component.AverageChaos - component.AverageChaos / 4, component.AverageChaos + component.AverageChaos / 4);
         // This is in minutes, so *60 for seconds (for the chaos calc)
         component.EndTime = _random.NextFloat(component.AverageEndTime - component.AverageEndTime / 4, component.AverageEndTime + component.AverageEndTime / 4) * 60f;
+
+        // ADT-tweak end
         component.StartingChaos = component.MaxChaos / 10;
 
         PickNextEventTime(uid, component);
@@ -49,7 +66,19 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
         while (query.MoveNext(out var uid, out var scheduler, out var gameRule))
         {
             if (!GameTicker.IsGameRuleActive(uid, gameRule))
+            // ADT-tweak start
+            {
+                scheduler.TimeUntilNextEvent = 10f;
                 continue;
+            }
+
+            var playerCount = _playerManager.PlayerCount;
+            if (playerCount < gameRule.MinPlayers)
+            {
+                scheduler.TimeUntilNextEvent = 10f;
+                continue;
+            }
+            // ADT-tweak end
 
             if (scheduler.TimeUntilNextEvent > 0f)
             {
@@ -57,7 +86,28 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
                 continue;
             }
 
+            // ADT-tweak start
+            var roundTime = _gameTicker.RoundDuration().TotalSeconds;
+
+            if (scheduler.LastEventTime > 0 && roundTime - scheduler.LastEventTime < 10)
+            {
+                scheduler.EventFloodCounter++;
+                if (scheduler.EventFloodCounter > 3)
+                {
+                    scheduler.TimeUntilNextEvent = 120f;
+                    scheduler.EventFloodCounter = 0;
+                    continue;
+                }
+            }
+            else
+            {
+                scheduler.EventFloodCounter = 0;
+            }
+            // ADT-tweak end
+
             PickNextEventTime(uid, scheduler);
+            scheduler.LastEventTime = roundTime; // ADT-tweak start
+
             _event.RunRandomEvent(scheduler.ScheduledGameRules);
         }
     }
@@ -69,7 +119,23 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
     {
         var mod = GetChaosModifier(uid, component);
 
-        // 4-12 minutes baseline. Will get faster over time as the chaos mod increases.
-        component.TimeUntilNextEvent = _random.NextFloat(240f / mod, 720f / mod);
+        // ADT-tweak start
+        if (float.IsNaN(mod) || float.IsInfinity(mod) || mod <= 0)
+            mod = 1f;
+
+        var min = 240f / mod;
+        var max = 720f / mod;
+
+        if (min <= 0 || max <= 0 || float.IsNaN(min) || float.IsNaN(max))
+        {
+            component.TimeUntilNextEvent = 300f;
+            return;
+        }
+
+        component.TimeUntilNextEvent = _random.NextFloat(min, max);
+
+        if (component.TimeUntilNextEvent <= 0 || float.IsNaN(component.TimeUntilNextEvent))
+            component.TimeUntilNextEvent = 600f;
     }
+        // ADT-tweak end
 }


### PR DESCRIPTION
## Описание PR
Исправлена работа RampingStationEventScheduler: теперь события учитывают минимальное количество игроков и не флудят, если режим недоступен или игроков недостаточно - раньше из-за этого хаос делился на 0. Добавлен EndTime, защита от флуда.

## Почему / Баланс
Ранее события запускались даже при недостатке игроков, что могло приводить к флуду и запуску неподходящих режимов. Тем самым роля постоянно и переходя в состояние деление на 0.

## Техническая информация
* Проверка `minPlayers`
* Если игроков недостаточно или режим не активен — событие пропускается, пересчёт через 10 секунд.
* [x] Изменения были протестированы на локальном сервере, работают корректно.

## Чейнджлог
:cl: CrimeMoot
- fix: Хаос режим учитывает minPlayers и пропускает события при недостатке игроков, предотвращая флуд и ошибки запуска. Позволяя режиму запуститься.
