### PR TITLE
[FIX] Фикс Агостов, взамен теряем фикс для ревенантов

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -27,11 +27,9 @@
   - type: Puller
     needsHands: false
   - type: CombatMode
-  #ADT-tweak-start
-  # - type: Physics
-  #   ignorePaused: true
-  #   bodyType: Kinematic
-  #ADT-tweak-end
+  - type: Physics
+    ignorePaused: true
+    bodyType: Kinematic
   - type: Body
     prototype: Aghost
   - type: Access


### PR DESCRIPTION
## Описание PR
Фикс агостов в маппинге

## Почему / Баланс
Вообщем нужно искать другой способ фикса толкания ревенантов и оставлять физику
А ни вот эта хуйня что придумали в https://github.com/AdventureTimeSS14/space_station_ADT/pull/1897

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: Шрёдька
- add: Агосты снова толкают ревенанта.
- fix: Агосты могут перемещаться по замороженным картам, ave Маппинг!
