### PR TITLE
[DRAFT] Исправление бага ИИ

### DIFF
--- a/Content.Server/ADT/Systems/AIDownloadSystem.cs
+++ b/Content.Server/ADT/Systems/AIDownloadSystem.cs
@@ -1,0 +1,90 @@
+using Content.Shared.Silicons.StationAi;
+using Content.Shared.DoAfter;
+using Content.Server.Popups;
+using Content.Server.Inventory;
+using Content.Server.Storage.Components;
+using Content.Shared.Mind;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Item;
+using Robust.Shared.Map;
+
+namespace Content.Server.ADT.Systems;
+
+public sealed class AIDownloadSystem : EntitySystem
+{
+    [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly IEntityManager _entMan = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
+
+    private const string ToyPrototype = "ADTToyAI";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<StationAiCoreComponent, IntellicardDoAfterEvent>(OnAiDownloadFinished);
+    }
+
+    private void OnAiDownloadFinished(Entity<StationAiCoreComponent> core, ref IntellicardDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled)
+            return;
+
+        var user = args.Args.User;
+        if (user == null)
+            return;
+
+        if (!TryComp<MindComponent>(user.Value, out var mind))
+            return;
+
+        var toy = TrySpawnToy(core.Owner, user.Value);
+        if (toy == null)
+        {
+            _popup.PopupEntity("Not enough space to download AI!", core.Owner, user.Value);
+            return;
+        }
+
+        // Перенос разума игрока в игрушку
+        _mind.TransferMind(mind, toy.Value);
+    }
+
+    private EntityUid? TrySpawnToy(EntityUid coreUid, EntityUid userUid)
+    {
+        var coords = Transform(coreUid).Coordinates;
+
+        // проверяем 8 тайлов вокруг ядра
+        var offsets = new (int, int)[]
+        {
+            (-1,-1), (0,-1), (1,-1),
+            (-1,0),          (1,0),
+            (-1,1),  (0,1),  (1,1)
+        };
+
+        foreach (var (ox, oy) in offsets)
+        {
+            var target = coords.Offset(new Vector2i(ox, oy));
+            if (AITileHelper.IsTileFree(EntityManager, target))
+            {
+                return _entMan.SpawnEntity(ToyPrototype, target);
+            }
+        }
+
+        // Если тайлов нет – пробуем в руки
+        if (_hands.TryPickupAnyHand(userUid, _entMan.SpawnEntity(ToyPrototype, Transform(userUid).Coordinates)))
+            return _entMan.SpawnEntity(ToyPrototype, Transform(userUid).Coordinates);
+
+        // Если руки заняты – пробуем в рюкзак
+        if (_inventory.TryGetSlotEntity(userUid, "back", out var backpack) &&
+            TryComp<StorageComponent>(backpack, out var storage))
+        {
+            var toy = _entMan.SpawnEntity(ToyPrototype, Transform(userUid).Coordinates);
+            if (storage.Insert(toy, userUid))
+                return toy;
+
+            QueueDel(toy);
+        }
+
+        return null;
+    }
+}

--- a/Content.Server/ADT/Utils/AITileHelper.cs
+++ b/Content.Server/ADT/Utils/AITileHelper.cs
@@ -1,0 +1,31 @@
+// Утилита для проверки тайлов. Ссылается на: ../Content.Server/ADT/Systems/AIDownloadSystem.cs
+using Robust.Shared.Map;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.GameObjects;
+
+namespace Content.Server.ADT.Utils;
+
+public static class AITileHelper
+{
+    public static bool IsTileFree(IEntityManager entMan, EntityCoordinates coords)
+    {
+        var mapSys = entMan.System<MapSystem>();
+        var tileRef = mapSys.GetTileRef(coords);
+
+        if (tileRef == null || tileRef.Value.Tile.IsEmpty)
+            return false;
+
+        // проверяем объекты на тайле
+        foreach (var ent in entMan.GetEntitiesIntersecting(coords))
+        {
+            if (entMan.TryGetComponent(ent, out PhysicsComponent? phys))
+            {
+                if (phys.BodyType == BodyType.Static && phys.Hard)
+                    return false; // есть стена или терминал
+            }
+        }
+
+        return true;
+    }
+}

--- a/Resources/Prototypes/ADT/Entities/Objects/Core_AI/toy_ai.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Core_AI/toy_ai.yml
@@ -1,0 +1,15 @@
+#forks: addet by Prunt
+- type: entity
+  id: ADTToyAI
+  name: Station AI Core (Portable)
+  description: A portable toy version of the station's AI, containing the intelligence of the core.
+  components:
+  - type: Sprite
+    sprite: Objects/Fun/toys.rsi
+    state: AI
+  - type: Item
+    size: Normal
+    sprite: Objects/Fun/toys.rsi
+    heldPrefix: AI
+  - type: MindContainer
+    showExamineInfo: true


### PR DESCRIPTION
## Описание PR
По неустановленной причине на сервере пропала возможность выгрузить Станционный ИИ. По завершению DoAfter выгрузки просто ничего не происходило. Данным PR я попытался вернуть все на место (Это только тестовый вариант. Не окончательный. Скрипт все еще нуждается в тестировании)

## Почему / Баланс
Это банальное восстановление возможности выгрузить ИИ

## Техническая информация
Было создано 3 основных файла. 
1-й _toy_ai.yml_ является прототипом игрушечного ИИ в который по скрипту будет перенесен игрок функцией SetMind. 

2-й _AIDownloadSystem.cs_ содержит в себе основной код переноса игрока в игрушку по окончанию DoAfter получаемый из файла [[../Content.Shared/Silicons/StationAi/Systems/SharedStationAiSystem.cs]](https://github.com/AdventureTimeSS14/space_station_ADT/blob/c7149ba5ff2e60bc1389eab488874db3d18029bb/Content.Shared/Silicons/StationAi/Systems/SharedStationAiSystem.cs). Запускает проверку свободных тайлов куда можно поместить игрушку с игроком, если тайла нету то проверяет лапки игрока, если и лапки заняты то пытается поместить в инвентарь рюкзака. Иначе выдает ошибку что нету места.

3-й _AITileHelper.cs_ служит утилитой которая проверяет 8 тайлов вокруг ядра есть ли на тайле статичный ентити (стена) или прикрученный ентити (консоль).

- [x] Изменения не были протестированы на локальном сервере, не известно работает ли все исправно.
- [x] PR не закончен и нуждается в доработке и консультации по оптимизации кода

## Медиа
<img width="1680" height="1015" alt="image" src="https://github.com/user-attachments/assets/8d9904ff-7273-4595-9b2d-17ace2fdd241" />

## Чейнджлог

🆑 prunt
- add: Файл toy_ai.yml который содержит прототип игрушки уже с разумом.
- add: Файл AIDownloadSystem.cs который содержит всю основную логику выгрузки ИИ.
- add: Файл AITileHelper.cs который работает как утилита в скупе с AIDownloadSystem.cs проверяющий на наличие статических или прикрученных ентити в просматриваемом тайле.
