### PR TITLE
[Fix] Harvester target level

### DIFF
--- a/Content.Server/ADT/BluespaceHarvester/BluespaceHarvesterSystem.cs
+++ b/Content.Server/ADT/BluespaceHarvester/BluespaceHarvesterSystem.cs
@@ -134,11 +134,22 @@ public sealed class BluespaceHarvesterSystem : EntitySystem
 
     private void OnTargetLevel(Entity<BluespaceHarvesterComponent> harvester, ref BluespaceHarvesterTargetLevelMessage args)
     {
-        // If we switch off, we don't need to be switched on.
-        if (!harvester.Comp.Reseted && harvester.Comp.CurrentLevel != 0)
-            return;
-
         if (_activeHarvester != null && _activeHarvester != harvester.Owner)
+        {
+            UpdateUI(harvester.Owner, harvester.Comp);
+            return;
+        }
+
+        if (args.TargetLevel == 0)
+        {
+            Reset(harvester.Owner, harvester.Comp);
+            return;
+        }
+
+        if (_activeHarvester == null)
+            _activeHarvester = harvester.Owner;
+
+        if (!harvester.Comp.Reseted && harvester.Comp.CurrentLevel != 0)
             return;
 
         harvester.Comp.TargetLevel = args.TargetLevel;


### PR DESCRIPTION
## Описание PR
Исправил абуз, что будучи открыв два окна с харвестером - можно было выставить значение силы у обоих, игнорируя обход. Баг: https://discord.com/channels/901772674865455115/1415763805241081877

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- fix: Исправлена уязвимость, позволяющая запустить за раз несколько харвестеров.
