### PR TITLE
минимальный порог

### DIFF
--- a/Resources/Prototypes/ADT/GameRules/roundstart.yml
+++ b/Resources/Prototypes/ADT/GameRules/roundstart.yml
@@ -344,4 +344,6 @@
   id: DynamicRandomGamerule
   parent: BaseGameRule
   components:
+  - type: GameRule
+    minPlayers: 30
   - type: DynamicRandomRule


### PR DESCRIPTION
## Описание PR
Добавляет минимальный порог готовых игроков для случайной динамики.

## Почему / Баланс
- Чтобы не выбирали динамику на 5 человек.
- Нужно, полагаю?

## Медиа
<img width="611" height="139" alt="image" src="https://github.com/user-attachments/assets/9d7cf9aa-9ff0-431a-894b-ffee23480e2e" />

## Чейнджлог

:cl: Kerfus
- add: Добавлен минимальный порог готовых игроков для случайной динамики - не меньше 30.
