### PR TITLE
[FIX] Фиксы фиксы..

### DIFF
--- a/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml.cs
+++ b/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml.cs
@@ -101,10 +101,12 @@ public sealed partial class CriminalRecordsConsoleWindow : FancyWindow
             OnKeySelected?.Invoke(cast);
         };
 
+        // ADT-Tweak
         // RecordListing.OnItemDeselected += _ =>
         // {
         //     OnKeySelected?.Invoke(null);
         // };
+        // ADT-Tweak
 
         FilterType.OnItemSelected += eventArgs =>
         {

--- a/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml.cs
+++ b/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml.cs
@@ -101,10 +101,10 @@ public sealed partial class CriminalRecordsConsoleWindow : FancyWindow
             OnKeySelected?.Invoke(cast);
         };
 
-        RecordListing.OnItemDeselected += _ =>
-        {
-            OnKeySelected?.Invoke(null);
-        };
+        // RecordListing.OnItemDeselected += _ =>
+        // {
+        //     OnKeySelected?.Invoke(null);
+        // };
 
         FilterType.OnItemSelected += eventArgs =>
         {

--- a/Content.Shared/ADT/Salvage/Systems/MiningVoucherSystem.cs
+++ b/Content.Shared/ADT/Salvage/Systems/MiningVoucherSystem.cs
@@ -104,7 +104,7 @@ public sealed class MiningVoucherSystem : EntitySystem
             return;
 
         var kit = _proto.Index(ent.Comp.Kits[index]);
-        var xform = Transform(ent);
+        var xform = Transform(user);
 
         switch (ent.Comp.TypeDrop)
         {

--- a/Resources/Prototypes/ADT/Entities/Objects/Weapons/Melee/bats.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Weapons/Melee/bats.yml
@@ -18,12 +18,8 @@
     damageFolded:
       types:
         Blunt: 0
-    staminaDamageFolded: 0
-    staminaDamageOpen: 25
     sizeOpened: Normal
     sizeClosed: Small
-  - type: StaminaDamageOnHit
-    damage: 0
   - type: MeleeWeapon
     damage:
       types:

--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -104,7 +104,7 @@
     sprite: Structures/Machines/silo.rsi
     state: silo
   product: CrateMaterialSilo
-  cost: 6500 #ADTTweak
+  cost: 30000 #ADTTweak
   category: cargoproduct-category-name-materials
   group: market
 

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -7,6 +7,7 @@
     - id: BluespaceLocker
     - id: BreakerFlip
     - id: BureaucraticError
+    - id: CentComRandomEvent # ADT-tweak
     - id: ClericalError
     - id: CockroachMigration
     - id: GasLeak


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
Фикс консоли криминальных записей, того что геймрул с рандомными законами от цк не появлялся сам по себе и то что ваучер получал координаты самого ваучера, а не юзера, от чего он постоянно к нему был прикреплен. Так же внесла правки в баланс биты ГСБ с разрешения балансировщиков и крысы, теперь он не имеет станмина урона. Так же сило теперь стоит 30к
## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс.

В случае, если ваш pull request привязан к запросу из нашего discord сервера, используйте образец, представленный далее.

Ссылка на заказ, предложение или баг-репорт
-->
- [Баг-репорт](https://discord.com/channels/901772674865455115/1416459532124688394/1416459532124688394)

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->
Не требуются.
## Чейнджлог


:cl: Minokaa
- tweak: Теперь у биты ГСБ отсутствует стамина урон
- tweak: Сило теперь стоит 30 тысяч
- fix: Теперь рандомные законы от ЦК будут появлятся в раунде сами
- fix: Дроппод у ваучеров ГСБ/ОСЩ теперь корректно падают в место где были активированы
- fix: Консоль криминальных записей теперь корректно работает

