### PR TITLE
Фиксы (ПАДДИ и Набор покера)

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Objects/Fun/poker_chips.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Fun/poker_chips.yml
@@ -337,6 +337,9 @@
     maxItemSize: Small
     grid:
     - 0,0,5,3
+    whitelist:
+      tags:
+        - ADTCardPlay
   - type: ContainerContainer
     containers:
       storagebase: !type:Container

--- a/Resources/Prototypes/ADT/Entities/Objects/Specific/Mech/Mech.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Specific/Mech/Mech.yml
@@ -921,6 +921,10 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.25
     baseSprintSpeed: 4.1
+  - type: Storage
+    grid:
+    - 0,0,6,3
+    clickInsert: false
 
 - type: entity
   id: ADTMechpaddyBattery


### PR DESCRIPTION
## Описание PR
Хранилище для ПАДДИ и ВЛ для Набора покера
## Почему / Баланс
Теперь в ПАДДИ помещаются магазины для оружия мехов. В набор по покеру теперь можно класть только покерные фишки 

Ссылка на баг-репорт
https://discord.com/channels/901772674865455115/1380214196637007932

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [ ] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [ ] PR закончен и требует просмотра изменений.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог
:cl: SAN
- fix: Теперь ПАДДИ АВП имеет хранилище под магазины, как и другие мехи. Набор покера теперь вмещает только покерные фишки