### PR TITLE
[FIX] В вентиляцию нельзя залезть находясь в контейнере

### DIFF
--- a/Content.Server/ADT/VentCrawling/VentCrawlerTubeSystem.cs
+++ b/Content.Server/ADT/VentCrawling/VentCrawlerTubeSystem.cs
@@ -72,6 +72,12 @@ public sealed class VentCrawlerTubeSystem : EntitySystem
         if (!component.AllowInventory && IsHoldingItems(args.Args.Used.Value))
             return;
 
+        if (_containerSystem.IsEntityInContainer(uid))
+        {
+            _popup.PopupEntity(Loc.GetString("attempt-climb-vent-in-container"), uid);
+            return;
+        }
+
         TryInsert(args.Args.Target.Value, args.Args.Used.Value);
 
         args.Handled = true;

--- a/Resources/Locale/ru-RU/ADT/ventcrawling/ventcrawling.ftl
+++ b/Resources/Locale/ru-RU/ADT/ventcrawling/ventcrawling.ftl
@@ -1,3 +1,4 @@
 ventcrawling-enter-pipe-network = Войти в систему труб
 ventcrawling-block-enter-reson-equiptment = ваше снаряжение не позволяет влезть в трубу
 ventcrawling-block-enter-reson-hand = вам нужно освободить свои руки, чтобы влезть в трубу
+attempt-climb-vent-in-container = Вам надо выйти из контейнера, чтобы залезть в вентиляцию


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
Сущности могли залезть в вентиляцию в контейнере. Я исправил
## Почему / Баланс

Ссылка на заказ, предложение или баг-репорт
- [Баг-репорт](https://discord.com/channels/901772674865455115/1415314306261848135)

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
В функцию `OnDoAfterEnterTube()` добавлена проверка на нахождение в контейнере ->
true: Выводит popup, выход из функции
false: залезание пройдет
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог

🆑 Darkiich
- fix: Исправлен баг с возможностью залезть в вентиляцию находясь в контейнере
