### PR TITLE
Фикс локализации со стульями 

### DIFF
--- a/Resources/Locale/ru-RU/ADT/prototypes/Entities/Structures/Furniture/chairs.ftl
+++ b/Resources/Locale/ru-RU/ADT/prototypes/Entities/Structures/Furniture/chairs.ftl
@@ -2,10 +2,10 @@ ent-ADTChairPizzeria = черный стул для пиццерии
     .desc = Хорошо подойдет для маленького кафе.
 
 ent-ADTChairRed = красный деревянный стул
-    .desc = { ent-ADTChairPizzeria }
+    .desc = Комфортный красный стул с белой спинкой и сидалищем
 
 ent-ADTChairWhite = белый деревянный стул
-    .desc = { ent-ADTChairPizzeria }
+    .desc = Комфортный белый стул с белой спинкой и сидалищем
 
 ent-ADTArmchairWhite = белое кресло
     .desc = Выглядит крайне комфортно.


### PR DESCRIPTION
## Описание PR
Было странное описание про стулья (в описании они были вообще черные). Теперь вот все норм. 

Ссылка на баг-репорт
https://discord.com/channels/901772674865455115/1421159221176569989

## Техническая информация
Просто поменял перевод в ftl и все. 
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: godot04
- fix: Исправлена локализация с некоторыми стульями. 
