### PR TITLE
Поправил шоколадный батончик

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Consumable/Food/snacks.yml
@@ -279,7 +279,7 @@
   - type: SpawnItemsOnUse
     items:
       - id: ADTFoodPacketChocolateTrashChoco
-      - id: ADTFoodSnackChocolateBarCoconut
+      - id: ADTFoodSnackChocolateBarChoco
 
 - type: entity
   name: chocolate bar


### PR DESCRIPTION
_Вот такие дела. Казалось бы, ну что это - поменял одно слово в коде. Оно же влияет на геймплей, как-никак. Все, даже самые опытные, могут допускать ошибки. Никто в этом не виноват. 
Одну из ошибок мы сейчас поправим._

## Описание PR
Как же трудно иногда бывает собраться с мыслями... В общем, при распаковке **шоколадного батончика** мы получаем **кокосовый шоколадный батончик**. 
Такого быть не должно! Теперь мы будем получать именно шоколадный батончик, а не кокосовый.

## Почему / Баланс
Когда мы открываем Сникерс, мы хотим видеть Сникерс, не Баунти. 

## Техническая информация
Поменял ADTFoodSnackChocolateBarCoconut на ADTFoodSnackChocolateBarChoco в ADTFoodSnackChocolateBarChocoPack. 
Иными словами, поменял шоколадку с кокосовой на обычную в прототипе обычной упаковки с шоколадкой.
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<img width="2560" height="1440" alt="Снимок экрана (31)" src="https://github.com/user-attachments/assets/67d3de01-e81c-4be6-8b58-c6045f6bbbaf" />

## Чейнджлог

:cl: StasNeStasNe
- fix: Теперь упаковка шоколадного батончика содержит не кокосовый, а шоколадный батончик, как и было задумано.

