### PR TITLE
Фикс сеньоров

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -890,6 +890,10 @@
     layers:
     - state: default
     - state: idseniorengineer
+#ADT-Tweak-Start
+  - type: PresetIdCard
+    job: ADTSeniorEngineer
+#ADT-Tweak-End
 
 - type: entity
   parent: ResearchIDCard
@@ -900,6 +904,10 @@
     layers:
     - state: default
     - state: idseniorresearcher
+#ADT-Tweak-Start
+  - type: PresetIdCard
+    job: ADTSeniorResearcher
+#ADT-Tweak-End
 
 - type: entity
   parent: MedicalIDCard
@@ -910,6 +918,10 @@
     layers:
     - state: default
     - state: idseniorphysician
+#ADT-Tweak-Start
+  - type: PresetIdCard
+    job: ADTSeniorPhysician
+#ADT-Tweak-End
 
 - type: entity
   parent: SecurityIDCard
@@ -920,6 +932,10 @@
     layers:
     - state: default
     - state: idseniorofficer
+#ADT-Tweak-Start
+  - type: PresetIdCard
+    job: ADTSeniorOfficer
+#ADT-Tweak-End
 
 - type: entity
   parent: IDCardStandard

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -890,10 +890,10 @@
     layers:
     - state: default
     - state: idseniorengineer
-#ADT-Tweak-Start
+# ADT-Tweak-Start
   - type: PresetIdCard
     job: ADTSeniorEngineer
-#ADT-Tweak-End
+# ADT-Tweak-End
 
 - type: entity
   parent: ResearchIDCard
@@ -904,10 +904,10 @@
     layers:
     - state: default
     - state: idseniorresearcher
-#ADT-Tweak-Start
+# ADT-Tweak-Start
   - type: PresetIdCard
     job: ADTSeniorResearcher
-#ADT-Tweak-End
+# ADT-Tweak-End
 
 - type: entity
   parent: MedicalIDCard
@@ -918,10 +918,10 @@
     layers:
     - state: default
     - state: idseniorphysician
-#ADT-Tweak-Start
+# ADT-Tweak-Start
   - type: PresetIdCard
     job: ADTSeniorPhysician
-#ADT-Tweak-End
+# ADT-Tweak-End
 
 - type: entity
   parent: SecurityIDCard
@@ -932,10 +932,10 @@
     layers:
     - state: default
     - state: idseniorofficer
-#ADT-Tweak-Start
+# ADT-Tweak-Start
   - type: PresetIdCard
     job: ADTSeniorOfficer
-#ADT-Tweak-End
+# ADT-Tweak-End
 
 - type: entity
   parent: IDCardStandard


### PR DESCRIPTION
_Я, кажется, опередил в этом младшего разработчика, заранее извинюсь - вашего потраченного времени жаль, зря я в чужой огород полез. :(_

## Описание PR
Роли сеньоров теперь отображаются корректно, пофикшен баг, связанный с их айди-картами.

## Почему / Баланс
Почему я это изменил и как это повлияет на баланс? На баланс - никак, только глазу приятнее будет да люди довольнее станут. Я очень люблю когда в игре всё чётко и без багов, и раз уж меня ещё и попросили, то почему бы и не взяться. :)
(Раньше я этого не умел 💀 )

Ссылка на заказ, предложение или баг-репорт: https://discord.com/channels/901772674865455115/1422908183533322281

## Техническая информация
Я добавил к каждой айди-карте эти строчки:
  - type: PresetIdCard
    job: ADTРаботаСеньора (как пример)

Всё работало отлично, но для уверенности - проверьте, пожалуйста, вдруг оно вызывает какие-нибудь краши, а то вдруг что. Волнуюсь, как-никак.

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<img width="384" height="281" alt="image" src="https://github.com/user-attachments/assets/6a3d4bbe-446c-4065-823f-eb2ce8e4a6e4" />

(Имплант МЩ тоже работает, это фото с проверки снаряжения после фикса)

## Чейнджлог

:cl: StasNeStasNe
- fix: Исправлен баг, из-за которого ID-карты сеньоров отображали некорректные иконки.

