### PR TITLE
Фикс бага со слипом на резоми во время спринта

### DIFF
--- a/Resources/Prototypes/ADT/Reagents/biological.yml
+++ b/Resources/Prototypes/ADT/Reagents/biological.yml
@@ -90,8 +90,8 @@
   color: "#c048c2"
   recognizable: true
   physicalDesc: reagent-physical-desc-slimy
-  slipData:
-    requiredSlipSpeed: 3.5
+  # slipData: # ADT-Tweak comment
+  #   requiredSlipSpeed: 3.5 # ADT-Tweak comment
 
 ### КРОВЬ СВЯТОГО МИИШКИИ ФРЕЕЕДЕЕ!!!!
 


### PR DESCRIPTION
## Описание PR
Единственная особенность резоми (в плане быстрого бега, который помогал сбегать в случае опасности) становился не только бесполезным, а еще и вредным так как ты бесконечно поскальзывался на своей крови. Как заядлый игрок на резоми, меня затрахало каждый раз дохнуть из-за того, что после нескольких ударов я не могу просто убежать на спринте. 

## Почему
Чтобы можно было сбегать в случае угрозы даже после того, как в тебя несколько раз попали.

## Техническая информация
Закоментил особенность слипа в крови резоми. 
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
https://www.youtube.com/watch?v=1-wkBAZJeKM

## Чейнджлог
:cl: godot04
- tweak: Изменена особенность крови резоми (теперь она больше не скользкая) 
- fix: Исправлена проблема резоми, при которой при высоком или среднем кровотечении нельзя было нормально использовать спринт из-за вечного поскальзывания на своей собственной крови. 
