### PR TITLE
Локализация шоколадок

### DIFF
--- a/Resources/Locale/ru-RU/ADT/prototypes/Entities/Objects/Consumable/Food/snacks.ftl
+++ b/Resources/Locale/ru-RU/ADT/prototypes/Entities/Objects/Consumable/Food/snacks.ftl
@@ -93,20 +93,20 @@ ent-ADTFoodSnackChocolateBarTwo = двойной батончик
     .desc = Выбирай, на чьей ты стороне?
 
 # Обертки
-ent-ADTFoodSnackChocolateTrashChoco = обертка от шоколадного батончика
-    .desc = Мусор
+ent-ADTFoodPacketChocolateTrashChoco = обертка от шоколадного батончика
+    .desc = Это мусор.
 
-ent-ADTFoodSnackChocolateTrashCoconut = обертка от Кокосового батончика
-    .desc = Мусор
+ent-ADTFoodPacketChocolateTrashCoconut = обертка от кокосового батончика
+    .desc = Это мусор.
 
-ent-ADTFoodSnackChocolateTrashEnergy = обертка от Энергетического батончика
-    .desc = Мусор
+ent-ADTFoodPacketChocolateTrashEnergy = обертка от энергетического батончика
+    .desc = Это мусор.
 
-ent-ADTFoodSnackChocolateTrashNuts = обертка от Шоколадного батончика с орехами
-    .desc = Мусор
+ent-ADTFoodPacketChocolateTrashNuts = обертка от батончика с орехами
+    .desc = Это мусор.
 
-ent-ADTFoodSnackChocolateTrashPink = обертка от Розовый шоколадного батончика
-    .desc = Мусор
+ent-ADTFoodPacketChocolateTrashPink = обертка от розового батончика
+    .desc = Это мусор.
 
-ent-ADTFoodSnackChocolateTrashTwo = обертка от Двойного батончика
-    .desc = Мусор
+ent-ADTFoodPacketChocolateTrashTwo = обертка от двойного батончика
+    .desc = Это мусор.

--- a/Resources/Locale/ru-RU/ADT/prototypes/Entities/Objects/Consumable/Food/snacks.ftl
+++ b/Resources/Locale/ru-RU/ADT/prototypes/Entities/Objects/Consumable/Food/snacks.ftl
@@ -93,20 +93,20 @@ ent-ADTFoodSnackChocolateBarTwo = двойной батончик
     .desc = Выбирай, на чьей ты стороне?
 
 # Обертки
-ent-ADTFoodPacketChocolateTrashChoco = обертка от шоколадного батончика
+ent-ADTFoodPacketChocolateTrashChoco = обёртка от шоколадного батончика
     .desc = Это мусор.
 
-ent-ADTFoodPacketChocolateTrashCoconut = обертка от кокосового батончика
+ent-ADTFoodPacketChocolateTrashCoconut = обёртка от кокосового батончика
     .desc = Это мусор.
 
-ent-ADTFoodPacketChocolateTrashEnergy = обертка от энергетического батончика
+ent-ADTFoodPacketChocolateTrashEnergy = обёртка от энергетического батончика
     .desc = Это мусор.
 
-ent-ADTFoodPacketChocolateTrashNuts = обертка от батончика с орехами
+ent-ADTFoodPacketChocolateTrashNuts = обёртка от батончика с орехами
     .desc = Это мусор.
 
-ent-ADTFoodPacketChocolateTrashPink = обертка от розового батончика
+ent-ADTFoodPacketChocolateTrashPink = обёртка от розового батончика
     .desc = Это мусор.
 
-ent-ADTFoodPacketChocolateTrashTwo = обертка от двойного батончика
+ent-ADTFoodPacketChocolateTrashTwo = обёртка от двойного батончика
     .desc = Это мусор.


### PR DESCRIPTION
Чёртовы шоколадки. Всю жизнь мне испортили.
 А сейчас вот это:

## Описание PR
Починил локализацию шоколадных обёрток.

## Почему / Баланс
Потому что локализация наших шоколадных обёрток сломалась.

## Техническая информация
Изменил FoodSnack на FoodPacket в файле локализации, для красоты поменял описания шоколадок. 
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог

:cl: StasNeStasNe
- fix: Исправлена нерабочая локализация обёрток от шоколадных батончиков.
