### PR TITLE
Шнурованные туфли в Стильномат

### DIFF
--- a/Resources/Prototypes/ADT/Catalog/VendingMachines/Inventories/prazatclothing.yml
+++ b/Resources/Prototypes/ADT/Catalog/VendingMachines/Inventories/prazatclothing.yml
@@ -36,6 +36,7 @@
     ADTClothingOuterWinterRussianCoat: 5
     ADTClothingBeltBlackSuspenders: 5
     ADTClothingBeltBrownSuspenders: 5
+    ClothingShoesBootsLaceup: 5
     ADTClothingFootLightShoes: 5
     ADTClothingFootWhiteSandals: 5
     ADTClothingFootBlackBoots: 5


### PR DESCRIPTION
Вот такие вот дела.

## Описание PR
Добавил в Стильномат шнурованные туфли.

## Почему / Баланс
Звучит прикольно, да ещё и люди одобрили! В общем, хоть туфли и не ADT-шные, но делу это не помешает, верно же?

Ссылка на заказ, предложение или баг-репорт
- [Баг-репорт/Заказ/Предложение](ссылка)--> https://discord.com/channels/901772674865455115/1423714470164824174

## Техническая информация
Не знаю, добавил ClothingShoesBootsLaceup в Стильномат.
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<img width="2560" height="1440" alt="Снимок экрана (46)" src="https://github.com/user-attachments/assets/0f1c6cfb-4a78-4ef1-9faa-053104660899" />



## Чейнджлог

:cl: StasNeStasNe
- add: В ассортименте Стильномата появились шнурованные туфли.


