### PR TITLE
Защита пауков от граба

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Mobs/NPCs/spiders.yml
+++ b/Resources/Prototypes/ADT/Entities/Mobs/NPCs/spiders.yml
@@ -118,6 +118,7 @@
     languages:
       Arachnid: Speak
   - type: SupermatterIgnore
+  - type: GrabProtection
 
 - type: entity
   name: hunter


### PR DESCRIPTION
## Описание PR
Добавил паукам защиту от граба.

## Почему / Баланс
Это, друзья мои, баг и абуз! Фиксить надо. Вот такие дела: https://discord.com/channels/901772674865455115/1425530212908798176

## Техническая информация
Вообще код не трогал. Я лишь добавил паренту пауков компонент GrabProtection.
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог

:cl: StasNeStasNe
- fix: Пауков больше нельзя схватить агрессивным захватом. Оставьте бедняжек в покое.

