### PR TITLE
Buff+Anouncement for wormhole event

### DIFF
--- a/Resources/Prototypes/ADT/GameRules/events.yml
+++ b/Resources/Prototypes/ADT/GameRules/events.yml
@@ -120,12 +120,14 @@
   components:
   - type: StationEvent
     startAnnouncement: station-event-wormholes-spawn-announcement
+    startAudio:
+      path: /Audio/ADT/Announcements/announce_dig.ogg
     weight: 8
     duration: 10
     minimumPlayers: 15
     earliestStart: 35
-    reoccurrenceDelay: 50
+    reoccurrenceDelay: 60
   - type: RandomSpawnRule
     prototype: ADTEventJaunterPortal
-    minCount: 50
-    maxCount: 150
+    minCount: 100
+    maxCount: 300


### PR DESCRIPTION
## Описание PR
Добавил звук объявления асс холе ивента и изменил количество червоточин с 50-150 до 100-300 увеличил реоккурэнс тайм с 50 до 60 минут


## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс.

В случае, если ваш pull request привязан к запросу из нашего discord сервера, используйте образец, представленный далее.

Ссылка на заказ, предложение или баг-репорт
- [Баг-репорт/Заказ/Предложение](ссылка)-->

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог

:cl: Illumy
- tweak: Шторм червоточин стал только сильнее из-за повышения популярности генераторов червоточин.
- tweak: Шторм червоточин будет появляться слегка реже
