### PR TITLE
Адекватный крафт амбузола

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -223,7 +223,7 @@
     #   amount: 1
     # ZombieBlood:
     #   amount: 1
-    Diphenylmethylamine:
+    Diphenhydramine:
       amount: 1
     ZombieBlood:
       amount: 1


### PR DESCRIPTION
## Описание PR
Сделал более адекватный крафт амбузола

## Почему / Баланс
Заменил Дифенилметиламин на Дифенгидрамин в крафте Амбузола, ибо первый нужно сделать из кофе (почему то), карбона натрия, и Этилоксиэфедрина, который в свою очередь делается из дезоксиэфедрина и стеллибинина, который достается из чертополоха

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог
:cl: SAN
- tweak: Измене рецепт Амбузола, теперь он более адекватный, а именно: Кровь зомби [1], Оппорозидон [1], Фалангимин [1], Дифенгидрамин [1] (до этого вместо него был Дифенилметиламин)