### PR TITLE
Добавление рецептов букетам

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Objects/Specific/Service/bouquets.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Specific/Service/bouquets.yml
@@ -17,6 +17,9 @@
     size: Normal
     sprite: ADT/Objects/Specific/Service/white_bouquet.rsi
   - type: DisarmMalus
+  - type: Construction
+    graph: ADTObjectWhiteBouquet
+    node: done
 
 - type: entity
   parent: BaseItem
@@ -37,6 +40,9 @@
     size: Normal
     sprite: ADT/Objects/Specific/Service/rose_bouquet.rsi
   - type: DisarmMalus
+  - type: Construction
+    graph: ADTObjectRoseBouquet
+    node: done
 
 - type: entity
   parent: BaseItem
@@ -57,6 +63,9 @@
     size: Normal
     sprite: ADT/Objects/Specific/Service/yellow_bouquet.rsi
   - type: DisarmMalus
+  - type: Construction
+    graph: ADTObjectYellowBouquet
+    node: done
 
 - type: entity
   parent: BaseItem
@@ -97,6 +106,9 @@
     size: Normal
     sprite: ADT/Objects/Specific/Service/black_bouquet.rsi
   - type: DisarmMalus
+  - type: Construction
+    graph: ADTObjectBlackBouquet
+    node: done
 
 - type: entity
   parent: BaseItem
@@ -117,3 +129,6 @@
     size: Normal
     sprite: ADT/Objects/Specific/Service/liliac_bouquet.rsi
   - type: DisarmMalus
+  - type: Construction
+    graph: ADTObjectLiliacBouquet
+    node: done

--- a/Resources/Prototypes/ADT/Recipes/Crafting/Graphs/bouquets.yml
+++ b/Resources/Prototypes/ADT/Recipes/Crafting/Graphs/bouquets.yml
@@ -1,0 +1,134 @@
+- type: constructionGraph
+  id: ADTObjectWhiteBouquet
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: done
+          steps:
+            - tag: Flower
+              name: construction-graph-tag-flower
+              icon:
+                sprite: Objects/Specific/Hydroponics/poppy.rsi
+                state: produce
+            - tag: Flower
+              name: construction-graph-tag-flower
+              icon:
+                sprite: Objects/Specific/Hydroponics/poppy.rsi
+                state: produce
+            - tag: Flower
+              name: construction-graph-tag-flower
+              icon:
+                sprite: Objects/Specific/Hydroponics/poppy.rsi
+                state: produce
+              doAfter: 10
+    - node: done
+      entity: ADTObjectWhiteBouquet
+
+- type: constructionGraph
+  id: ADTObjectYellowBouquet
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: done
+          steps:
+            - tag: Flower
+              name: construction-graph-tag-flower
+              icon:
+                sprite: Objects/Specific/Hydroponics/poppy.rsi
+                state: produce
+            - tag: Flower
+              name: construction-graph-tag-flower
+              icon:
+                sprite: Objects/Specific/Hydroponics/poppy.rsi
+                state: produce
+            - tag: Flower
+              name: construction-graph-tag-flower
+              icon:
+                sprite: Objects/Specific/Hydroponics/poppy.rsi
+                state: produce
+              doAfter: 10
+    - node: done
+      entity: ADTObjectYellowBouquet
+
+- type: constructionGraph
+  id: ADTObjectRoseBouquet
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: done
+          steps:
+            - tag: Flower
+              name: construction-graph-tag-flower
+              icon:
+                sprite: Objects/Specific/Hydroponics/poppy.rsi
+                state: produce
+            - tag: Flower
+              name: construction-graph-tag-flower
+              icon:
+                sprite: Objects/Specific/Hydroponics/poppy.rsi
+                state: produce
+            - tag: Flower
+              name: construction-graph-tag-flower
+              icon:
+                sprite: Objects/Specific/Hydroponics/poppy.rsi
+                state: produce
+              doAfter: 10
+    - node: done
+      entity: ADTObjectRoseBouquet
+
+- type: constructionGraph
+  id: ADTObjectLiliacBouquet
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: done
+          steps:
+            - tag: Flower
+              name: construction-graph-tag-flower
+              icon:
+                sprite: Objects/Specific/Hydroponics/poppy.rsi
+                state: produce
+            - tag: Flower
+              name: construction-graph-tag-flower
+              icon:
+                sprite: Objects/Specific/Hydroponics/poppy.rsi
+                state: produce
+            - tag: Flower
+              name: construction-graph-tag-flower
+              icon:
+                sprite: Objects/Specific/Hydroponics/poppy.rsi
+                state: produce
+              doAfter: 10
+    - node: done
+      entity: ADTObjectLiliacBouquet
+
+- type: constructionGraph
+  id: ADTObjectBlackBouquet
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: done
+          steps:
+            - tag: Flower
+              name: construction-graph-tag-flower
+              icon:
+                sprite: Objects/Specific/Hydroponics/poppy.rsi
+                state: produce
+            - tag: Flower
+              name: construction-graph-tag-flower
+              icon:
+                sprite: Objects/Specific/Hydroponics/poppy.rsi
+                state: produce
+            - tag: Flower
+              name: construction-graph-tag-flower
+              icon:
+                sprite: Objects/Specific/Hydroponics/poppy.rsi
+                state: produce
+              doAfter: 10
+    - node: done
+      entity: ADTObjectBlackBouquet

--- a/Resources/Prototypes/ADT/Recipes/Crafting/bouquets.yml
+++ b/Resources/Prototypes/ADT/Recipes/Crafting/bouquets.yml
@@ -1,0 +1,39 @@
+- type: construction
+  id: ADTObjectWhiteBouquet
+  graph: ADTObjectWhiteBouquet
+  startNode: start
+  targetNode: done
+  category: construction-category-misc
+  objectType: Item
+
+- type: construction
+  id: ADTObjectYellowBouquet
+  graph: ADTObjectYellowBouquet
+  startNode: start
+  targetNode: done
+  category: construction-category-misc
+  objectType: Item
+
+- type: construction
+  id: ADTObjectRoseBouquet
+  graph: ADTObjectRoseBouquet
+  startNode: start
+  targetNode: done
+  category: construction-category-misc
+  objectType: Item
+
+- type: construction
+  id: ADTObjectLiliacBouquet
+  graph: ADTObjectLiliacBouquet
+  startNode: start
+  targetNode: done
+  category: construction-category-misc
+  objectType: Item
+
+- type: construction
+  id: ADTObjectBlackBouquet
+  graph: ADTObjectBlackBouquet
+  startNode: start
+  targetNode: done
+  category: construction-category-misc
+  objectType: Item


### PR DESCRIPTION
## Описание PR
Были добавлены рецепты для изготовления букетов, исключая пивной букет в меню крафта.

## Почему / Баланс
По запросу игроков из предложений для сервера
https://discord.com/channels/901772674865455115/1424844492384501800

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<img width="656" height="465" alt="Снимок экрана 2025-10-12 170910" src="https://github.com/user-attachments/assets/4aa564b2-7315-4915-8988-c3eab87f6915" />

## Чейнджлог
:cl: Sipay
- add: Добавлена возможность крафта букетов в меню крафта.

