### PR TITLE
[FIX] Телепорт сумеречников v.2

### DIFF
--- a/Content.Server/ADT/Shadekin/ShadekinSystem.cs
+++ b/Content.Server/ADT/Shadekin/ShadekinSystem.cs
@@ -159,57 +159,10 @@ public sealed partial class ShadekinSystem : EntitySystem
         if (HasComp<MechPilotComponent>(uid))
             return;
 
-        var mapCoords = args.Target.ToMap(EntityManager, _transform);
-        var allEntities = new List<EntityUid>();
-        foreach (var ent in _entityLookup.GetEntitiesInRange(mapCoords, 0.35f))
-            allEntities.Add(ent);
-
-        // Создаем мнимый круглый хитбокс в координатах телепорта
         var targetPosition = args.Target.ToMap(EntityManager, _transform).Position;
-        var virtualPlayerShape = new PhysShapeCircle(0.35f);
-        var virtualPlayerHitbox = virtualPlayerShape.ComputeAABB(new Transform(targetPosition, 0f), 0);
 
-        var filteredEntities = allEntities.Where(ent =>
-            ent != uid &&
-            HasComp<AnchorableComponent>(ent) &&
-            TryComp<PhysicsComponent>(ent, out var physics) && physics != null && physics.CollisionLayer != 0
-        ).ToList();
-
-        // Проверяем коллизию мнимого хитбокса с каждым BB всех энтити
-        var hasCollision = false;
-
-        foreach (var ent in filteredEntities)
-        {
-            if (TryComp<FixturesComponent>(ent, out var fixturesComponent))
-            {
-
-                foreach (var fixture in fixturesComponent.Fixtures.Values)
-                {
-                    // Пропускаем круглые BB
-                    if (fixture.Shape is PhysShapeCircle)
-                        continue;
-
-                    var entTransform = _physics.GetPhysicsTransform(ent);
-                    var fixtureHitbox = fixture.Shape.ComputeAABB(entTransform, 0);
-
-                    if (virtualPlayerHitbox.Intersects(fixtureHitbox))
-                    {
-                        hasCollision = true;
-                        break;
-                    }
-                }
-
-                if (hasCollision)
-                {
-                    break;
-                }
-            }
-        }
-
-        if (hasCollision)
-        {
+        if (HasTeleportCollision(uid, targetPosition))
             return;
-        }
 
         if (!TryUseAbility(uid, 50))
             return;
@@ -271,59 +224,10 @@ public sealed partial class ShadekinSystem : EntitySystem
             if (!_interaction.InRangeUnobstructed(uid, newCoords, -1f))
                 continue;
 
-            var mapCoords = newCoords.ToMap(EntityManager, _transform);
-            var allEntities = new List<EntityUid>();
-            foreach (var ent in _entityLookup.GetEntitiesInRange(mapCoords, 0.35f))
-                allEntities.Add(ent);
-
-            // Создаем мнимый круглый хитбокс в координатах телепорта
             var targetPosition = newCoords.ToMap(EntityManager, _transform).Position;
-            var virtualPlayerShape = new PhysShapeCircle(0.35f);
-            var virtualPlayerHitbox = virtualPlayerShape.ComputeAABB(new Transform(targetPosition, 0f), 0);
 
-            var filteredEntities = allEntities.Where(ent =>
-                ent != uid &&
-                HasComp<AnchorableComponent>(ent) &&
-                TryComp<PhysicsComponent>(ent, out var physics) && physics != null && physics.CollisionLayer != 0 &&
-                _tagSystem.HasTag(ent, "Table") == false
-            ).ToList();
-
-            // Проверяем коллизию мнимого хитбокса с каждым BB всех энтити
-            var hasCollision = false;
-
-            foreach (var ent in filteredEntities)
-            {
-                if (TryComp<FixturesComponent>(ent, out var fixturesComponent))
-                {
-
-                    foreach (var fixture in fixturesComponent.Fixtures.Values)
-                    {
-                        // Пропускаем круглые BB
-                        if (fixture.Shape is PhysShapeCircle)
-                            continue;
-
-                        var entTransform = _physics.GetPhysicsTransform(ent);
-                        var fixtureHitbox = fixture.Shape.ComputeAABB(entTransform, 0);
-
-
-                        if (virtualPlayerHitbox.Intersects(fixtureHitbox))
-                        {
-                            hasCollision = true;
-                            break;
-                        }
-                    }
-
-                    if (hasCollision)
-                    {
-                        break;
-                    }
-                }
-            }
-
-            if (hasCollision)
-            {
+            if (HasTeleportCollision(uid, targetPosition, excludeTables: true))
                 continue;
-            }
 
 
             TryUseAbility(uid, 40, false);
@@ -353,55 +257,9 @@ public sealed partial class ShadekinSystem : EntitySystem
             if (!_interaction.InRangeUnobstructed(uid, newCoords, -1f))
                 continue;
 
-            var mapCoords = newCoords.ToMap(EntityManager, _transform);
-            var allEntities = new List<EntityUid>();
-            foreach (var ent in _entityLookup.GetEntitiesInRange(mapCoords, 0.35f))
-                allEntities.Add(ent);
-
-            // Создаем мнимый круглый хитбокс в координатах телепорта
             var targetPosition = newCoords.ToMap(EntityManager, _transform).Position;
-            var virtualPlayerShape = new PhysShapeCircle(0.35f);
-            var virtualPlayerHitbox = virtualPlayerShape.ComputeAABB(new Transform(targetPosition, 0f), 0);
 
-            var filteredEntities = allEntities.Where(ent =>
-                ent != uid &&
-                HasComp<AnchorableComponent>(ent) &&
-                TryComp<PhysicsComponent>(ent, out var physics) && physics != null && physics.CollisionLayer != 0 &&
-                _tagSystem.HasTag(ent, "Table") == false
-            ).ToList();
-
-            // Проверяем коллизию мнимого хитбокса с каждым BB всех энтити
-            var hasCollision = false;
-
-            foreach (var ent in filteredEntities)
-            {
-                if (TryComp<FixturesComponent>(ent, out var fixturesComponent))
-                {
-
-                    foreach (var fixture in fixturesComponent.Fixtures.Values)
-                    {
-                        // Пропускаем круглые BB
-                        if (fixture.Shape is PhysShapeCircle)
-                            continue;
-
-                        var entTransform = _physics.GetPhysicsTransform(ent);
-                        var fixtureHitbox = fixture.Shape.ComputeAABB(entTransform, 0);
-
-                        if (virtualPlayerHitbox.Intersects(fixtureHitbox))
-                        {
-                            hasCollision = true;
-                            break;
-                        }
-                    }
-
-                    if (hasCollision)
-                    {
-                        break;
-                    }
-                }
-            }
-
-            if (hasCollision)
+            if (HasTeleportCollision(uid, targetPosition, excludeTables: true))
                 continue;
 
             if (TryComp<PullerComponent>(uid, out var puller) && puller.Pulling != null &&
@@ -452,5 +310,48 @@ public sealed partial class ShadekinSystem : EntitySystem
 
         _alert.ShowAlert(uid, _proto.Index<AlertPrototype>("ShadekinPower"), (short)Math.Clamp(Math.Round(comp.PowerLevel / 50f), 0, 5));
         _action.RemoveAction(comp.ActionEntity);
+    }
+
+    private bool HasTeleportCollision(EntityUid uid, Vector2 targetPosition, bool excludeTables = false)
+    {
+        // Создаем мнимый круглый хитбокс в координатах телепорта
+        var virtualPlayerShape = new PhysShapeCircle(0.35f);
+        var virtualPlayerHitbox = virtualPlayerShape.ComputeAABB(new Transform(targetPosition, 0f), 0);
+
+        var mapCoords = new MapCoordinates(targetPosition, Transform(uid).MapID);
+        var allEntities = new List<EntityUid>();
+        foreach (var ent in _entityLookup.GetEntitiesInRange(mapCoords, 0.35f))
+            allEntities.Add(ent);
+
+        var filteredEntities = allEntities.Where(ent =>
+            ent != uid &&
+            HasComp<AnchorableComponent>(ent) &&
+            TryComp<PhysicsComponent>(ent, out var physics) && physics.CollisionLayer != 0 &&
+            (!excludeTables || !_tagSystem.HasTag(ent, "Table"))
+        ).ToList();
+
+        // Проверяем коллизию мнимого хитбокса с каждым BB всех энтити
+        foreach (var ent in filteredEntities)
+        {
+            if (TryComp<FixturesComponent>(ent, out var fixturesComponent))
+            {
+                foreach (var fixture in fixturesComponent.Fixtures.Values)
+                {
+                    // Пропускаем круглые BB
+                    if (fixture.Shape is PhysShapeCircle)
+                        continue;
+
+                    var entTransform = _physics.GetPhysicsTransform(ent);
+                    var fixtureHitbox = fixture.Shape.ComputeAABB(entTransform, 0);
+
+                    if (virtualPlayerHitbox.Intersects(fixtureHitbox))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->

Более лояльный телепорт для сумеречников

## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс.

В случае, если ваш pull request привязан к запросу из нашего discord сервера, используйте образец, представленный далее.

Ссылка на заказ, предложение или баг-репорт
- [Баг-репорт/Заказ/Предложение](ссылка)-->

Теперь телепорт работает не сколько от компонентов, сколько от коллизии.

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->

Теперь при вызове методов OnTeleport, TeleportRandomly, TeleportRandomlyNoComp создаётся мнимый круглый хитбокс в целевых координатах, размером с хитбокс самого сумеречника. 
Проверяется наличие AnchorableComponent (ведь всё в чём может застрять сумеречник - как минимум имеет этот компонент), через PhysicsComponent.CollisionLayer отфильтровываются все энтити, которые вообще в принципе не могут столкнуться с мнимым хитбоксом.
После через FixturesComponent проверяем все имеющиеся Fixtures. если имеется круглый хитбокс, то мы его не берём в расчёт (круглый хитбокс это стулья, свет, камеры и тому подобное). Для всех остальных мы проверяем, сталкивается ли мнимый хитбокс персонажа со всем остальным содержимым Fixtures. Если хоть одна fixture сталкивается с мнимым хитбоксом, то без телепорта.

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог

no cl, no fun
