### PR TITLE
Фе-ле-ле-лениды

### DIFF
--- a/Resources/Prototypes/ADT/Body/Prototypes/felinid.yml
+++ b/Resources/Prototypes/ADT/Body/Prototypes/felinid.yml
@@ -20,7 +20,7 @@
       organs:
         heart: ADTOrganFelinidHeart
         lungs: OrganHumanLungs
-        stomach: OrganReptilianStomach
+        stomach: OrganHumanStomach
         liver:  OrganAnimalLiver
         kidneys: OrganHumanKidneys
     right arm:


### PR DESCRIPTION
## Описание PR
Желудок феленидов заменен из унатхского на человеческий

## Почему / Баланс
Крысиха попросила

## Чейнджлог

:cl: Эмэндэмс
- tweak: Катаклизм! Фелиниды потеряли унатхские желудки! Учёные в панике, кулинары ликуют. Теперь у них человеческий желудок.