### PR TITLE
Фиксы МОДам

### DIFF
--- a/Content.Shared/ADT/Modsuit/Systems/ModSuitSystem.Modules.cs
+++ b/Content.Shared/ADT/Modsuit/Systems/ModSuitSystem.Modules.cs
@@ -119,9 +119,9 @@ public sealed partial class ModSuitSystem
 
         if (TryComp<PowerCellDrawComponent>(suit, out var celldraw))
         {
-            suit.Comp.ModEnergyBaseUsing = (float)Math.Round(suit.Comp.ModEnergyBaseUsing + module.Comp.EnergyUsing, 3);
+            var energy = (float)Math.Round(suit.Comp.ModEnergyBaseUsing + module.Comp.EnergyUsing, 3);
             var attachedCount = GetAttachedToggleCount(suit);
-            celldraw.DrawRate = suit.Comp.ModEnergyBaseUsing * attachedCount;
+            celldraw.DrawRate = energy * attachedCount;
         }
     }
 

--- a/Resources/Prototypes/ADT/Entities/Clothing/OuterClothing/modsuits.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/OuterClothing/modsuits.yml
@@ -195,8 +195,10 @@
     sprintModifier: 0.85
   - type: FireProtection
     reduction: 0.5
-  - type: AshStormImmune
-
+  - type: ClothingGrantComponent
+    component:
+    - type: AshStormImmune
+    
 - type: entity
   parent: ADTClothingOuterModsuitBodyBase
   id: ADTClothingOuterModsuitBodySecurity


### PR DESCRIPTION
## Описание PR
Вроде-бы починил энергопотребления МОДам.
Теперь шахетерский МОД деффает от бури.

## Техническая информация
Заменил использование глобальной переменной из компонента на локальный вариант.

## Чейнджлог
:cl: Эмэндэмс
- fix: Шахтёрский МОД теперь защищает от бури на лаваленде.
- fix: Исправлено энергопотребление МОДов.

