### PR TITLE
Новый параллакс в загрузочном меню

### DIFF
--- a/Resources/Prototypes/Parallaxes/default.yml
+++ b/Resources/Prototypes/Parallaxes/default.yml
@@ -6,29 +6,30 @@
   layers:
     - texture:
         !type:ImageParallaxTextureSource
-        path: "/Textures/Parallaxes/layer1.png"
-      slowness: 0.998046875
+        path: "/Textures/ADT/Parallaxes/NES/GreenParallax2.png"
+      slowness: 0.999
       scale: "1, 1"
     - texture:
         !type:GeneratedParallaxTextureSource
         id: "hq_wizard_stars"
         configPath: "/Prototypes/Parallaxes/parallax_config_stars.toml"
-      slowness: 0.996625
+      slowness: 0.999
     - texture:
         !type:GeneratedParallaxTextureSource
-        id: "hq_wizard_stars_dim"
-        configPath: "/Prototypes/Parallaxes/parallax_config_stars_dim.toml"
-      slowness: 0.989375
+        id: "hq_wizard_stars"
+        configPath: "/Prototypes/Parallaxes/parallax_config_stars.toml"
+      slowness: 0.998
     - texture:
         !type:GeneratedParallaxTextureSource
         id: "hq_wizard_stars_faster"
         configPath: "/Prototypes/Parallaxes/parallax_config_stars-2.toml"
-      slowness: 0.987265625
+      slowness: 0.9998
     - texture:
-        !type:GeneratedParallaxTextureSource
-        id: "hq_wizard_stars_dim_faster"
-        configPath: "/Prototypes/Parallaxes/parallax_config_stars_dim-2.toml"
-      slowness: 0.984352
+        !type:ImageParallaxTextureSource
+        path: "/Textures/ADT/Parallaxes/NES/GreenPlanet.png"
+      slowness: 0.99
+      scale: "0.3, 0.3"
+      tiled: false
   layersLQ:
     - texture:
         !type:GeneratedParallaxTextureSource
@@ -36,7 +37,39 @@
         configPath: "/Prototypes/Parallaxes/parallax_config.toml"
       slowness: 0.875
   layersLQUseHQ: false
-
+#  layers:
+#    - texture:
+#        !type:ImageParallaxTextureSource
+#        path: "/Textures/Parallaxes/layer1.png"
+#      slowness: 0.998046875
+#      scale: "1, 1"
+#    - texture:
+#        !type:GeneratedParallaxTextureSource
+#        id: "hq_wizard_stars"
+#        configPath: "/Prototypes/Parallaxes/parallax_config_stars.toml"
+#      slowness: 0.996625
+#    - texture:
+#        !type:GeneratedParallaxTextureSource
+#        id: "hq_wizard_stars_dim"
+#        configPath: "/Prototypes/Parallaxes/parallax_config_stars_dim.toml"
+#      slowness: 0.989375
+#    - texture:
+#        !type:GeneratedParallaxTextureSource
+#        id: "hq_wizard_stars_faster"
+#        configPath: "/Prototypes/Parallaxes/parallax_config_stars-2.toml"
+#      slowness: 0.987265625
+#    - texture:
+#        !type:GeneratedParallaxTextureSource
+#        id: "hq_wizard_stars_dim_faster"
+#        configPath: "/Prototypes/Parallaxes/parallax_config_stars_dim-2.toml"
+#      slowness: 0.984352
+#  layersLQ:
+#    - texture:
+#        !type:GeneratedParallaxTextureSource
+#        id: ""
+#        configPath: "/Prototypes/Parallaxes/parallax_config.toml"
+#      slowness: 0.875
+#  layersLQUseHQ: false
 # Because hyperspace and the menu need their own.
 - type: parallax
   id: FastSpace


### PR DESCRIPTION
## Описание PR
Я изменил стандартный параллакс на NES Green, но именно на уровне кода, потому что порывшись не нашёл, где айдишник стандартного параллакса ставится в загрузочном меню

## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс.

В случае, если ваш pull request привязан к запросу из нашего discord сервера, используйте образец, представленный далее.

Ссылка на заказ, предложение или баг-репорт
- [Баг-репорт/Заказ/Предложение](ссылка)-->

## Техническая информация
- [ ] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог
:cl: Illumy
- tweak: Стандартный параллакс, который ждёт вас при загрузке на сервер - изменился

