### PR TITLE
[FIX] КПБ больше не ходят по воде

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/ADT/Entities/Mobs/Player/silicon_base.yml
@@ -35,6 +35,7 @@
             - MobMask
           layer:
             - MobLayer
+    - type: FloorOcclusion
     - type: MovementSpeedModifier
       baseWalkSpeed: 3
       baseSprintSpeed: 4

--- a/Resources/Prototypes/ADT/Entities/Mobs/Species/ipc.yml
+++ b/Resources/Prototypes/ADT/Entities/Mobs/Species/ipc.yml
@@ -170,6 +170,7 @@
   - type: IpcScreen
     selectSlotTime: 0
     changeSlotTime: 0
+  - type: AnimatedEmotes
 
 - type: entity
   save: false


### PR DESCRIPTION
## Описание PR
- Исправляет баг, из-за которого КПБ не могли делать сальто, прыгать и крутиться.
- Исправляет визуальный баг, из-за которого КПБ не погружались в воду.

## Почему / Баланс
- [Баг-репорт](https://discord.com/channels/901772674865455115/1437075485782839400)

## Медиа
<img width="260" height="259" alt="image" src="https://github.com/user-attachments/assets/dd713f76-5319-4a62-a9b9-796af2c2aea3" />

## Чейнджлог

:cl: Kerfus
- fix: КПБ больше не ходят по воде.
- fix: Теперь КПБ могут делать сальто и прыгать.
