### PR TITLE
Крыша 

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -104,7 +104,7 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
             return;
 
         EnsureComp<ShuttleComponent>(ev.EntityUid);
-        //EnsureComp<ImplicitRoofComponent>(ev.EntityUid); ADT-remove
+        //EnsureComp<ImplicitRoofComponent>(ev.EntityUid); ADT-tweak: удалена крыша
     }
 
     private void OnShuttleStartup(EntityUid uid, ShuttleComponent component, ComponentStartup args)


### PR DESCRIPTION
## Описание PR
Крыша теперь не добавляется автоматически гридам. Было это убрано по нескольким причинам, включая "затенение" карты силли айленд. Админы и ивентеры могут самостоятельно добавить крышу

## Почему / Баланс

Ссылка на заказ, предложение или баг-репорт
https://discord.com/channels/901772674865455115/1438778445072171058/1438778445072171058

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: LightSurvivor
- remove: Крыша теперь не добавляется автоматически гридам. Было это убрано по нескольким причинам, включая "затенение" карты силли айленд. Админы, ивентеры и мапперы могут самостоятельно добавить крышу
