### PR TITLE
Исправлено отображение стульев

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -22,7 +22,7 @@
         - TableMask
   - type: Sprite
     sprite: Structures/Furniture/chairs.rsi
-    drawdepth: ThinPipe
+    drawdepth: Objects #ADT-Tweak
     noRot: true
   - type: Strap
     position: Stand


### PR DESCRIPTION
## Описание PR


## Почему / Баланс
Фикс

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
Стулья отображались выше персонажа. Теперь это исправлено
<img width="764" height="494" alt="image" src="https://github.com/user-attachments/assets/0c7df1cf-c48c-4826-bb07-a5bc5032e7b9" />


## Чейнджлог
:cl: LightSurvivor
- fix: Исправлено отображение стульев. Раньше слой стульев отображался выше персонажа. 
