### PR TITLE
BFUU Update: Хотфикс Магнитов

### DIFF
--- a/Content.Server/Salvage/Magnet/SalvageMagnetDataComponent.cs
+++ b/Content.Server/Salvage/Magnet/SalvageMagnetDataComponent.cs
@@ -29,7 +29,7 @@ public sealed partial class SalvageMagnetDataComponent : Component
     /// How long salvage will be active for before despawning.
     /// </summary>
     [DataField]
-    public TimeSpan ActiveTime;
+    public TimeSpan ActiveTime; //ADT-Tweak Magnet Update
 
     /// <summary>
     /// Cooldown between offerings after one ends.

--- a/Content.Server/Salvage/SalvageSystem.Magnet.cs
+++ b/Content.Server/Salvage/SalvageSystem.Magnet.cs
@@ -178,7 +178,7 @@ public sealed partial class SalvageSystem
             foreach (var ent in data.Comp.ActiveEntities)
             {
                 // ADT-Tweak - более безопасный способ удаления
-                Del(ent);
+                Del(ent); //ADT-Tweak Magnet Update
             }
 
             foreach (var entity in _detachEnts)
@@ -433,7 +433,7 @@ public sealed partial class SalvageSystem
             }
         }
 
-        Report(magnet.Owner, MagnetChannel, "salvage-system-announcement-arrived", ("timeLeft", (data.Comp.ActiveTime-_timing.CurTime).TotalSeconds));
+        Report(magnet.Owner, MagnetChannel, "salvage-system-announcement-arrived", ("timeLeft", (data.Comp.ActiveTime-_timing.CurTime).TotalSeconds)); //ADT Tweak Magnet Update
         _mapSystem.DeleteMap(salvMapXform.MapID);
 
         data.Comp.Announced = false;


### PR DESCRIPTION
## Описание PR
Пофикшен магнит, теперь игроки не удаляются, мертвые существа- удаляются, а время теперь в секундах и показывается время именно до удаления обломка, а не время+время сейчас

## Почему / Баланс
Баги

Ссылка на заказ, предложение или баг-репорт
- [Баг-репорт](https://discordapp.com/channels/901772674865455115/1443850707378901012)

## Техническая информация
Был изменен "фильтр" на добавление в список существ, которые удалялись, изменено безопасное удаление на обычное, изменен формат для отображения времени
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: Firemix
- fix: Исправлено отображение времени при вызове обломка
- fix: Теперь магнит удаляет мертвых существ с обломка, так что их трупы не будут загрязнять карту
- fix: Исправлено удаление, теперь игроков не удаляет с обломков(но все равно, на всякий случай, прошу не лежать на кроватях и не сидеть во время удаления обломка на креслах)
