### PR TITLE
[FIX] Редактор персонажа

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
@@ -119,8 +119,10 @@
                             </BoxContainer>
                             <!-- Hair -->
                             <BoxContainer Margin="10" Orientation="Horizontal">
+                                <!-- ADT Midround Customization Start -->
                                 <humanoid:SingleMarkingPicker MinHeight="500" Name="HairStylePicker" Category="Hair" />
                                 <humanoid:SingleMarkingPicker MinHeight="500" Name="FacialHairPicker" Category="FacialHair" />
+                                <!-- ADT Midround Customization End -->
                             </BoxContainer>
                             <!-- Eyes -->
                             <BoxContainer Margin="10" Orientation="Vertical">


### PR DESCRIPTION
## Описание PR
- Исправляет меню с причёсками в редакторе персонажа

## Почему / Баланс
- Чтобы по станции не бегали лысые фелиниды :sob:
- [Баг-репорт](https://discord.com/channels/901772674865455115/1443902188849201204)

## Медиа
Было:
<img width="575" height="283" alt="image" src="https://github.com/user-attachments/assets/ff145692-0b01-4d51-bc52-5c4e3a98ff28" />
Стало:
<img width="1187" height="457" alt="image" src="https://github.com/user-attachments/assets/0faebdc6-a6e9-4209-be8f-16865ea10c50" />

## Чейнджлог

:cl: Kerfus
- fix: Теперь экипаж не страдает от космической радиации и снова может выбирать причёски в редакторе персонажа. (remove: Удалены лысые фелиниды :sob:)
