### PR TITLE
Показ гендера человека в консоли учёта персонала вместо {$gender}

### DIFF
--- a/Content.Client/StationRecords/GeneralRecord.xaml.cs
+++ b/Content.Client/StationRecords/GeneralRecord.xaml.cs
@@ -37,7 +37,7 @@ public sealed partial class GeneralRecord : Control
             ("job", Loc.GetString(record.JobTitle))), defaultColor: Color.White);
         Species.SetMessage(Loc.GetString("general-station-record-console-record-species", ("species", Loc.GetString("species-name-" + record.Species.ToLower()))), defaultColor: Color.White);
         Gender.SetMessage(Loc.GetString("general-station-record-console-record-gender",
-            ("sex", Loc.GetString("station-records-sex-" + record.Profile.Sex.ToString().ToLower()))), defaultColor: Color.White);
+            ("gender", Loc.GetString("station-records-sex-" + record.Profile.Sex.ToString().ToLower()))), defaultColor: Color.White);
         // // ADT Station Records Showcase End
         Fingerprint.Text = Loc.GetString("general-station-record-console-record-fingerprint",
             ("fingerprint", record.Fingerprint ?? Loc.GetString("generic-not-available-shorthand")));


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
Изменил ключ локализации гендера с sex на gender
## Почему / Баланс

Ссылка на заказ, предложение или баг-репорт
- [Баг-репорт](https://discordapp.com/channels/901772674865455115/1445796176191426653)

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->
<img width="274" height="105" alt="{DD0D9D5E-B8D2-4026-88AC-D70A629914A0}" src="https://github.com/user-attachments/assets/3fb5e1a9-9e3d-4a34-8039-b211c96dc8e9" />

## Чейнджлог

:cl: Darkiich
- fix: Теперь в консоли учёта будет показывать гендер сущности вместо {$gender}
