### PR TITLE
fix: воксы больше не травятся при поедании плат

### DIFF
--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -75,6 +75,11 @@
         - !type:OrganType
           type: Arachnid
           shouldHave: false
+          #ADT Start
+        - !type:OrganType
+          type: Vox
+          shouldHave: false
+          #ADT End
         damage:
           types:
             Poison: 0.1
@@ -313,6 +318,12 @@
     Poison:
       effects:
       - !type:HealthChange
+      # ADT Start
+        conditions:
+        - !type:OrganType
+          type: Vox
+          shouldHave: false
+      # ADT End
         damage:
           types:
             Poison: 1.5

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -75,11 +75,11 @@
         - !type:OrganType
           type: Arachnid
           shouldHave: false
-          #ADT Start
+          #ADT-Tweak-Start
         - !type:OrganType
           type: Vox
           shouldHave: false
-          #ADT End
+          #ADT-Tweak-End
         damage:
           types:
             Poison: 0.1
@@ -318,12 +318,12 @@
     Poison:
       effects:
       - !type:HealthChange
-      # ADT Start
+      #ADT-Tweak-Start
         conditions:
         - !type:OrganType
           type: Vox
           shouldHave: false
-      # ADT End
+      #ADT-Tweak-End
         damage:
           types:
             Poison: 1.5


### PR DESCRIPTION
## Описание PR
Воксы больше не получают урон токсинами от кремния и меди, следовательно не получают урон при поедании плат
## Почему / Баланс
Потому что воксы не должны травиться от еды

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: AaidzzKirpich
- fix: При поедании плат воксами, медь и кремний больше не наносят урон токсинами, выполняя только питательную функцию
