### PR TITLE
Epic book printer fix

### DIFF
--- a/Content.Server/ADT/BookPrinter/Components/BookPrinterComponent.cs
+++ b/Content.Server/ADT/BookPrinter/Components/BookPrinterComponent.cs
@@ -39,5 +39,9 @@ namespace Content.Server.ADT.BookPrinter.Components
 
         [DataField, ViewVariables(VVAccess.ReadWrite)]
         public float CartridgeUsage = 5.0f;
+
+        public TimeSpan LastUiUpdate;
+
+        public static TimeSpan VisualsChangeDelay = TimeSpan.FromSeconds(1);
     }
 }

--- a/Content.Server/ADT/BookPrinter/CooldownManager.cs
+++ b/Content.Server/ADT/BookPrinter/CooldownManager.cs
@@ -18,7 +18,7 @@ namespace Content.Server.ADT.BookPrinter
 
         public bool IsUploadAvailable()
         {
-            if (!_cfg.GetCVar(ADTCCVars.BookPrinterUploadCooldownEnabled))
+            if (!IsCooldownEnabled())
                 return true;
 
             if (_lastUploadTime == null)
@@ -32,7 +32,7 @@ namespace Content.Server.ADT.BookPrinter
 
         public TimeSpan GetRemainingCooldown()
         {
-            if (!_cfg.GetCVar(ADTCCVars.BookPrinterUploadCooldownEnabled) || _lastUploadTime == null)
+            if (!IsCooldownEnabled() || _lastUploadTime == null)
                 return TimeSpan.Zero;
 
             var cooldownDuration = TimeSpan.FromSeconds(_cfg.GetCVar(ADTCCVars.BookPrinterUploadCooldown));
@@ -55,11 +55,6 @@ namespace Content.Server.ADT.BookPrinter
         public bool IsCooldownEnabled()
         {
             return _cfg.GetCVar(ADTCCVars.BookPrinterUploadCooldownEnabled);
-        }
-
-        public void ResetCooldown()
-        {
-            _lastUploadTime = null;
         }
     }
 }


### PR DESCRIPTION
## Описание PR
Теперь принтер книг не вызывает массовые лаги у всех окружающих его игроков.

## Почему / Баланс
Я случайно создал лаг машину, ихихихихихи

## Техническая информация
Обновил логику обновления интерфейса. Интерфейс теперь обновляется не каждый кадр 24/7, а только при нескольких условиях. К тому же, теперь обновление происходит раз в секунду, что, так-то, гораздо лучше.
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог

🆑 KashRas2
- fix: Принтер книг теперь не вызывает массовые лаги вокруг себя. Трепещать Перри РТХ5090 я изобрел оптимизацияинатор.