### PR TITLE
[ADD] Латиница в именах

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -29,7 +29,7 @@ namespace Content.Shared.Preferences
     [Serializable, NetSerializable]
     public sealed partial class HumanoidCharacterProfile : ICharacterProfile
     {
-        private static readonly Regex RestrictedNameRegex = new("[^A-Za-zА-Яа-яёЁ0-9' -.,!?]"); //ADT-Tweak
+        private static readonly Regex RestrictedNameRegex = new("[^A-Za-zА-Яа-яёЁ0-9' _.<>^%~ -]"); //ADT-Tweak
         private static readonly Regex ICNameCaseRegex = new(@"^(?<word>\w)|\b(?<word>\w)(?=\w*$)");
 
         public const int MaxNameLength = 96;    // ну тип ADT


### PR DESCRIPTION
## Описание PR
- Позволяет сохранять персонажей с латиницей и знаками пунктуации в имени.

## Почему / Баланс
Q: Зачем?
A: Позволит КПБ делать более креативные имена, которые сходятся с их [текущим лором.](https://wiki.ss220.space/index.php/Комплексный_позитронный_блок?ysclid=mjm3ts452m932845760)
Q: Это будут абьюзить, ставя запрещённые/сомнительные имена.
A: Это и так могут делать, то что у набегаторов будет возможность писать на латинице особо сути не изменит.

## Техническая информация
- Расширяет пулл допустимых символов.

## Чейнджлог

:cl: Kerfus
- add: Теперь КПБ могут использовать латиницу и знаки пунктуации в своих именах.
