### PR TITLE
[FIX] диагональная решётка и окна

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Windows/clockwork.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/clockwork.yml
@@ -125,6 +125,7 @@
   - type: Tag
     tags:
     - Diagonal
+    - Window #ADT-Tweak
   - type: IconSmooth
     mode: Diagonal
     key: windows

--- a/Resources/Prototypes/Entities/Structures/Windows/mining.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/mining.yml
@@ -67,6 +67,7 @@
   - type: Tag
     tags:
     - Diagonal
+    - Window #ADT-Tweak
   - type: IconSmooth
     mode: Diagonal
     key: walls #corvax smooth

--- a/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
@@ -125,6 +125,7 @@
   - type: Tag
     tags:
     - Diagonal
+    - Window #ADT-Tweak
   - type: IconSmooth
     mode: Diagonal
     key: walls  # Corvax-Resprite

--- a/Resources/Prototypes/Entities/Structures/Windows/plastitanium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/plastitanium.yml
@@ -173,6 +173,12 @@
   components:
   - type: ExaminableDamage
     messages: null
+  #ADT-Tweak-Start
+  - type: Tag
+    tags:
+    - Diagonal
+    - Window
+  #ADT-Tweak-End
 
 - type: entity
   id: PlastitaniumWindowDiagonal
@@ -217,3 +223,9 @@
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: RGlass
+  #ADT-Tweak-Start
+  - type: Tag
+    tags:
+    - Diagonal
+    - Window
+  #ADT-Tweak-End

--- a/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
@@ -132,6 +132,7 @@
   - type: Tag
     tags:
     - Diagonal
+    - Window #ADT-Tweak
   - type: IconSmooth
     mode: Diagonal
     key: walls  # Corvax-Resprite

--- a/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
@@ -130,6 +130,7 @@
   - type: Tag
     tags:
     - Diagonal
+    - Window #ADT-Tweak
   - type: IconSmooth
     mode: Diagonal
     key: walls  # Corvax-Resprite

--- a/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
@@ -127,6 +127,7 @@
   - type: Tag
     tags:
     - Diagonal
+    - Window #ADT-Tweak
   - type: IconSmooth
     mode: Diagonal
     key: walls  # Corvax-Resprite

--- a/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
@@ -70,6 +70,7 @@
   - type: Tag
     tags:
     - Diagonal
+    - Window #ADT-Tweak
   - type: IconSmooth
     mode: Diagonal
     key: walls  # Corvax-Resprite

--- a/Resources/Prototypes/Entities/Structures/Windows/uranium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/uranium.yml
@@ -120,6 +120,7 @@
   - type: Tag
     tags:
     - Diagonal
+    - Window #ADT-Tweak
   - type: IconSmooth
     mode: Diagonal
     key: walls  # Corvax-Resprite


### PR DESCRIPTION
## Описание PR
- Добавляет всем диагональным окнам тэг: "Window"

## Почему / Баланс
- Чтобы диагональные решётки больше не били током сквозь окна
- [Баг-репорт](https://discord.com/channels/901772674865455115/1454343049512620082/1454343049512620082)

## Чейнджлог

:cl: Kerfus
- fix: Диагональные решётки больше не будут нагло бить экипаж током сквозь окна.
