### PR TITLE
[FIX] Исправлены лаги от бук принтера

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Structures/Machines/Computers/book_printer.yml
+++ b/Resources/Prototypes/ADT/Entities/Structures/Machines/Computers/book_printer.yml
@@ -52,9 +52,9 @@
         - MachineMask
         layer:
         - MachineLayer
-  - type: ApcPowerReceiver
-  - type: ExtensionCableReceiver
-  - type: ActivatableUIRequiresPower
+#  - type: ApcPowerReceiver
+#  - type: ExtensionCableReceiver
+#  - type: ActivatableUIRequiresPower
   - type: Anchorable
   - type: Pullable
   - type: Damageable


### PR DESCRIPTION
## Описание PR
Временно отрубаем потребление энергии у бук принтера

## Почему / Баланс
Лаги во время ивента отрубаемя электричества

В случае, если ваш pull request привязан к запросу из нашего discord сервера, используйте образец, представленный далее.

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: FIREMIX
- fix: Временно бук принтеры работают теперь без требования к электричеству, чтобы избавиться от лагов
