### PR TITLE
[TWEAK] Изменены доступы к протолату и принтеру плат.

### DIFF
--- a/Resources/Prototypes/ADT/Wires/layouts.yml
+++ b/Resources/Prototypes/ADT/Wires/layouts.yml
@@ -2,14 +2,3 @@
 
 - type: wireLayout
   id: IPC
-
-- type: wireLayout
-  id: ADTLatheWithAccess
-  dummyWires: 4
-  wires:
-  - !type:PowerWireAction
-  - !type:PowerWireAction
-    pulseTimeout: 15
-  - !type:AccessWireAction
-  - !type:LogWireAction
-  - !type:AiInteractWireAction

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -186,26 +186,12 @@
   - type: Machine
     board: ProtolatheMachineCircuitboard
   # ADT-tweak Start
-  - type: UserInterface
-    interfaces:
-      enum.LatheUiKey.Key:
-        type: LatheBoundUserInterface
-      enum.ResearchClientUiKey.Key:
-        type: ResearchClientBoundUserInterface
-      enum.WiresUiKey.Key:
-        type: WiresBoundUserInterface
   - type: StationAiWhitelist
   - type: ActivatableUIRequiresAccess
   - type: AccessReader
-    breakOnAccessBreaker: true
     access:
       - [Research]
       - [Engineering]
-  - type: Wires
-    layoutId: ADTLatheWithAccess
-  - type: Electrified
-    enabled: false
-    usesApcPower: true
   # ADT-tweak End
   - type: MaterialStorage
     whitelist:
@@ -270,26 +256,11 @@
   - type: Machine
     board: ProtolatheHyperConvectionMachineCircuitboard
   # ADT-tweak Start
-  - type: UserInterface
-    interfaces:
-      enum.LatheUiKey.Key:
-        type: LatheBoundUserInterface
-      enum.ResearchClientUiKey.Key:
-        type: ResearchClientBoundUserInterface
-      enum.WiresUiKey.Key:
-        type: WiresBoundUserInterface
-  - type: StationAiWhitelist
   - type: ActivatableUIRequiresAccess
   - type: AccessReader
-    breakOnAccessBreaker: true
     access:
       - [Research]
       - [Engineering]
-  - type: Wires
-    layoutId: ADTLatheWithAccess
-  - type: Electrified
-    enabled: false
-    usesApcPower: true
   # ADT-tweak End
 
 - type: entity
@@ -312,25 +283,11 @@
   - type: Machine
     board: CircuitImprinterMachineCircuitboard
   # ADT-tweak Start
-  - type: UserInterface
-    interfaces:
-      enum.LatheUiKey.Key:
-        type: LatheBoundUserInterface
-      enum.ResearchClientUiKey.Key:
-        type: ResearchClientBoundUserInterface
-      enum.WiresUiKey.Key:
-        type: WiresBoundUserInterface
   - type: StationAiWhitelist
   - type: ActivatableUIRequiresAccess
   - type: AccessReader
-    breakOnAccessBreaker: true
     access:
       - [Research]
-  - type: Wires
-    layoutId: ADTLatheWithAccess
-  - type: Electrified
-    enabled: false
-    usesApcPower: true
   # ADT-tweak End
   - type: Lathe
     producingSound: /Audio/Machines/circuitprinter.ogg
@@ -387,25 +344,10 @@
   - type: Machine
     board: CircuitImprinterHyperConvectionMachineCircuitboard
   # ADT-tweak Start
-  - type: UserInterface
-    interfaces:
-      enum.LatheUiKey.Key:
-        type: LatheBoundUserInterface
-      enum.ResearchClientUiKey.Key:
-        type: ResearchClientBoundUserInterface
-      enum.WiresUiKey.Key:
-        type: WiresBoundUserInterface
-  - type: StationAiWhitelist
   - type: ActivatableUIRequiresAccess
   - type: AccessReader
-    breakOnAccessBreaker: true
     access:
       - [Research]
-  - type: Wires
-    layoutId: ADTLatheWithAccess
-  - type: Electrified
-    enabled: false
-    usesApcPower: true
   # ADT-tweak End
 
 - type: entity


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->

Протолат теперь имеет доступ только для учёных и инженеров, принтер плат - только для учёных.

## Почему / Баланс

Люми попросил.

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог

:cl: WsWiss
- tweak: Протолат теперь могут использовать лишь сотрудники научного и инженерного отделов. Принтер плат могут использовать только сотрудники научного отдела.

