### PR TITLE
Фикс работы мезонок со сканером для руды 

### DIFF
--- a/Content.Client/Mining/MiningOverlay.cs
+++ b/Content.Client/Mining/MiningOverlay.cs
@@ -36,6 +36,8 @@ public sealed class MiningOverlay : Overlay
 
         _spriteQuery = _entityManager.GetEntityQuery<SpriteComponent>();
         _xformQuery = _entityManager.GetEntityQuery<TransformComponent>();
+
+        ZIndex = 100; // ADT-Tweak 
     }
 
     protected override void Draw(in OverlayDrawArgs args)


### PR DESCRIPTION
## Описание PR
Теперь можно видеть руду одновременно нося мезонки и сканер минералов включенными. 

## Почему 
Фикс бага

Ссылка на баг-репорт
https://discord.com/channels/901772674865455115/1448807240114114650

## Техническая информация
Просто добавил приоритет отрисовки руды (изначально у всех стоит 0, поэтому выставил 100 (не сильно шарю какие там приоритеты есть, поэтому выставил как можно выше на всякий случай)). 
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: godot04
- fix: Исправлена проблема мезонок со сканером руды (теперь их можно одновременно использовать). 
