### PR TITLE
[TWEAK] Резоми на БМ и КЦК

### DIFF
--- a/Resources/Prototypes/ADT/Roles/Jobs/CentComm/centcom_consultant.yml
+++ b/Resources/Prototypes/ADT/Roles/Jobs/CentComm/centcom_consultant.yml
@@ -39,7 +39,6 @@
     - !type:SpeciesRequirement
       inverted: true
       species:
-      - Resomi
       - Vox
   weight: 15
   startingGear: ADTCentcomConsultantGear

--- a/Resources/Prototypes/ADT/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/ADT/Roles/Jobs/Security/brigmedic.yml
@@ -13,7 +13,6 @@
     - !type:SpeciesRequirement
       inverted: true
       species:
-      - Resomi
       - Vox
   startingGear: BrigmedicGear
   icon: "JobIconBrigmedic"


### PR DESCRIPTION
## Описание PR
- Позволяет Резоми брать роли Бригмедика и Консультанта Центрального Командования.

## Почему / Баланс
- Первая роль просто военный врач который даже процедуры СБ исполнять не может, а второй прокаченный юрист.
- [Предложение](https://discord.com/channels/901772674865455115/1466032955435782174/1466032955435782174)

## Чейнджлог

:cl: Kerfus
- tweak: Теперь Резоми смогут брать роли Бригмедика и Консультанта Центрального Командования. [Предложка]