### PR TITLE
[TWEAK] зажигалки и ADT пачки сигарет

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -165,13 +165,6 @@
   components:
   - type: Sprite
     sprite: ADT/Objects/Consumable/Smokeables/Cigarettes/we_ya_gold_packet.rsi
-  - type: Storage
-    grid:
-    - 0,0,9,1
-    whitelist:
-      tags:
-      - Cigarette
-      - ADTLighter
   - type: StorageFill
     contents:
     - id: ADTWeYaGoldCigarette
@@ -187,13 +180,6 @@
   components:
   - type: Sprite
     sprite: ADT/Objects/Consumable/Smokeables/Cigarettes/executive_select_packet.rsi
-  - type: Storage
-    grid:
-    - 0,0,9,1
-    whitelist:
-      tags:
-      - Cigarette
-      - ADTLighter
   - type: StorageFill
     contents:
     - id: ADTExecutiveSelectCigarette


### PR DESCRIPTION
## Описание PR
Теперь зажигалки можно положить во все пачки сигарет из торгового автомата.

## Почему / Баланс
Не логично, что не во все пачки сигарет можно было засунуть зажигалку.

## Техническая информация
Добавил вайтлист для всех пачек сигарет.

:cl: Chebur
- tweak: зажигалки можно положить во все пачки сигарет из торгового автомата, кроме маленькой пачки.