### PR TITLE
[TWEAK] Окна и давление

### DIFF
--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Entities/Structures/Windows/windows.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Entities/Structures/Windows/windows.yml
@@ -123,7 +123,7 @@
 
 - type: entity
   id: ADTWindowFrameless
-  parent: BaseStructure
+  parent: [BaseDeltaPressureGlass, BaseStructure]
   name: frameless window
   description: Don't smudge up the glass down there.
   placement:
@@ -216,7 +216,7 @@
 
 - type: entity
   id: ADTWindowDirectionalFrameless
-  parent: BaseStructure
+  parent: [BaseDeltaPressureGlassQuarter, BaseStructure]
   name: frameless directional window
   description: Don't smudge up the glass down there.
   placement:

--- a/Resources/Prototypes/Atmospherics/Thresholds/deltapressure.yml
+++ b/Resources/Prototypes/Atmospherics/Thresholds/deltapressure.yml
@@ -7,8 +7,8 @@
   id: BaseDeltaPressureReinforcedPlasma
   components:
   - type: DeltaPressure
-    minPressure: 150000
-    minPressureDelta: 100000
+    minPressure: 999999 #ADT-Tweak 150000 > 999999
+    minPressureDelta: 999999 #ADT-Tweak 100000 > 999999
     scalingType: Linear
     scalingPower: 0.0001
 
@@ -18,8 +18,8 @@
   id: BaseDeltaPressureReinforcedPlasmaQuarter
   components:
   - type: DeltaPressure
-    minPressure: 37500
-    minPressureDelta: 25000
+    minPressure: 999999 #ADT-Tweak 37500 > 999999
+    minPressureDelta: 999999 #ADT-Tweak 25000 > 999999
     scalingType: Threshold
 
 ## For plasma windows
@@ -49,8 +49,8 @@
   id: BaseDeltaPressureReinforcedGlass
   components:
   - type: DeltaPressure
-    minPressure: 15000
-    minPressureDelta: 10000
+    minPressure: 999999 #ADT-Tweak 15000 > 999999
+    minPressureDelta: 999999 #ADT-Tweak 10000 > 999999
     scalingType: Threshold
 
 ## For quarter reinforced glass windows
@@ -59,8 +59,8 @@
   id: BaseDeltaPressureReinforcedGlassQuarter
   components:
   - type: DeltaPressure
-    minPressure: 3750
-    minPressureDelta: 2500
+    minPressure: 999999 #ADT-Tweak 3750 > 999999
+    minPressureDelta: 999999 #ADT-Tweak 2500 > 999999
 
 ## For glass windows
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Windows/mining.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/mining.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: MiningWindow
   name: mining window
-  parent: WindowRCDResistant
+  parent: [BaseDeltaPressureReinforcedGlass, WindowRCDResistant]
   components:
   - type: Sprite
     drawdepth: WallTops


### PR DESCRIPTION
## Описание PR
- Бронированные, шахтёрские, пластитановые а так же окна шаттла больше не будут получать урон от давления газов

## Почему / Баланс
- [Окон не существует](https://discord.com/channels/901772674865455115/1474374604096278609/1474374604096278609)

## Медиа
Не ломаются от давления (демонстрация):
<img width="560" height="486" alt="image" src="https://github.com/user-attachments/assets/559502d4-46dd-49bf-b731-35a48d2e48c9" />

## Чейнджлог

:cl: Kerfus
- tweak: Теперь бронированные, шахтёрские, пластитановые а так же окна шаттла больше не будут получать урон от давления газов.
