### PR TITLE
[TWEAK] showChatJobIconsCheckBox, Console ID mod.IconJob and Loudspeaker

### DIFF
--- a/Content.Client/ADT/UserInterface/RichText/IconTag.cs
+++ b/Content.Client/ADT/UserInterface/RichText/IconTag.cs
@@ -27,6 +27,9 @@ public sealed class IconTag : IMarkupTag
     {
         control = null;
 
+        if (!_cfg.GetCVar(ADTCCVars.EnableJobIconAnimation) || !_cfg.GetCVar(ADTCCVars.EnableChatJobIcons))
+            return false;
+
         if (!node.Attributes.TryGetValue("src", out var id) || id.StringValue == null)
             return false;
 
@@ -36,9 +39,8 @@ public sealed class IconTag : IMarkupTag
             return false;
 
         var spec = jobProto.Icon;
-        var enableJobAnim = _cfg.GetCVar(ADTCCVars.EnableJobIconAnimation);
 
-        control = CreateIconControl(spec, enableJobAnim);
+        control = CreateIconControl(spec);
 
         if (control != null && node.Attributes.TryGetValue("tooltip", out var tooltip) && tooltip.StringValue != null)
             control.ToolTip = tooltip.StringValue;
@@ -46,13 +48,13 @@ public sealed class IconTag : IMarkupTag
         return control != null;
     }
 
-    private Control? CreateIconControl(SpriteSpecifier spec, bool enableAnimation)
+    private Control? CreateIconControl(SpriteSpecifier spec)
     {
         try
         {
             var state = _spriteSystem!.RsiStateLike(spec);
 
-            if (state.IsAnimated && enableAnimation)
+            if (state.IsAnimated)
                 return CreateAnimatedIcon(spec);
 
             return CreateStaticIcon(spec);

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml
@@ -18,6 +18,7 @@
                 <CheckBox Name="ShowLoocAboveHeadCheckBox" Text="{Loc 'ui-options-show-looc-on-head'}" />
                 <CheckBox Name="FancySpeechBubblesCheckBox" Text="{Loc 'ui-options-fancy-speech'}" />
                 <CheckBox Name="FancyNameBackgroundsCheckBox" Text="{Loc 'ui-options-fancy-name-background'}" />
+                <CheckBox Name="ShowChatJobIconsCheckBox" Text="{Loc 'ui-options-show-chat-job-icons'}" /> <!-- ADT-Tweak -->
                 <Label Text="{Loc 'ui-options-general-cursor'}"
                        StyleClasses="LabelKeyText"/>
                 <CheckBox Name="ShowHeldItemCheckBox" Text="{Loc 'ui-options-show-held-item'}" />

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
@@ -54,6 +54,7 @@ public sealed partial class MiscTab : Control
         Control.AddOptionCheckBox(CCVars.ChatFancyNameBackground, FancyNameBackgroundsCheckBox);
         Control.AddOptionCheckBox(CCVars.StaticStorageUI, StaticStorageUI);
         Control.AddOptionCheckBox(ADTCCVars.OfferModeIndicatorsPointShow, ShowOfferModeIndicatorsCheckBox); // ADT-Tweak
+        Control.AddOptionCheckBox(ADTCCVars.EnableChatJobIcons, ShowChatJobIconsCheckBox); // ADT-Tweak
         Control.Initialize();
     }
 }

--- a/Content.Server/ADT/Radio/EntitySystems/ServerRadioJobIconSystem.cs
+++ b/Content.Server/ADT/Radio/EntitySystems/ServerRadioJobIconSystem.cs
@@ -18,15 +18,24 @@ public sealed class ServerRadioJobIconSystem : SharedRadioJobIconSystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<IdCardComponent, IdCardJobChangedEvent>(OnIdCardJobChanged);
+        SubscribeLocalEvent<IdCardComponent, EntInsertedIntoContainerMessage>(OnIdCardInserted);
+        SubscribeLocalEvent<IdCardComponent, EntRemovedFromContainerMessage>(OnIdCardRemoved);
     }
 
-    private void OnIdCardJobChanged(EntityUid uid, IdCardComponent component, ref IdCardJobChangedEvent args)
+    private void OnIdCardInserted(EntityUid uid, IdCardComponent component, EntInsertedIntoContainerMessage args)
     {
-        if (args.PlayerUid.HasValue && Exists(args.PlayerUid.Value) && !Deleted(args.PlayerUid.Value) && !Terminating(args.PlayerUid.Value))
-        {
-            UpdateRadioJobIcon(args.PlayerUid.Value);
-        }
+        UpdateOwnerRadioCache(args.Container.Owner);
+    }
+
+    private void OnIdCardRemoved(EntityUid uid, IdCardComponent component, EntRemovedFromContainerMessage args)
+    {
+        UpdateOwnerRadioCache(args.Container.Owner);
+    }
+
+    private void UpdateOwnerRadioCache(EntityUid entity)
+    {
+        if (TryComp<InventoryComponent>(entity, out var _))
+            UpdateRadioJobIcon(entity);
     }
 
     protected override (string iconId, string jobName) GetJobIcon(EntityUid entity)

--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -146,10 +146,15 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
         _idCard.TryChangeFullName(targetId, newFullName, player: player);
         _idCard.TryChangeJobTitle(targetId, newJobTitle, player: player);
 
-        if (_prototype.Resolve(newJobProto, out var job)
-            && _prototype.Resolve(job.Icon, out var jobIcon))
+        // ADT-Tweak start
+        JobPrototype? job = null;
+        if (newJobProto.Id != string.Empty)
+            _prototype.TryIndex(newJobProto, out job);
+
+        if (job != null && _prototype.Resolve(job.Icon, out var jobIcon))
         {
-            _idCard.TryChangeJobIcon(targetId, jobIcon, player: player);
+            _idCard.TryChangeJobIcon(targetId, jobIcon);
+        // ADT-Tweake end
             _idCard.TryChangeJobDepartment(targetId, job);
         }
 

--- a/Content.Shared/ADT/CCVar/ADTCCVars.cs
+++ b/Content.Shared/ADT/CCVar/ADTCCVars.cs
@@ -293,11 +293,19 @@ public sealed class ADTCCVars
         CVarDef.Create("misc.space_whale_spawn_distance", 1965, CVar.SERVER);
 
     /// <summary>
-    /// If enabled, job icons in chat and status icons are animated.
-    /// When disabled, only static icons will be shown.
+    /// If enabled, job icons in chat and status icons are available.
+    /// When disabled on server, icons will not be shown for anyone.
+    /// Players can also disable icons in their client settings.
     /// </summary>
     public static readonly CVarDef<bool> EnableJobIconAnimation =
-        CVarDef.Create("adt.job_icon_animation_enabled", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+        CVarDef.Create("adt.job_icon_animation_enabled", true, CVar.SERVER | CVar.REPLICATED | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Client-side setting to toggle job icons in chat.
+    /// Icons are only shown if both server and client allow them.
+    /// </summary>
+    public static readonly CVarDef<bool> EnableChatJobIcons =
+        CVarDef.Create("adt.chat_job_icons_enabled", true, CVar.CLIENTONLY | CVar.ARCHIVE);
 
     /*
     * Headshot

--- a/Content.Shared/ADT/Radio/EntitySystems/SharedRadioJobIconSystem.cs
+++ b/Content.Shared/ADT/Radio/EntitySystems/SharedRadioJobIconSystem.cs
@@ -65,6 +65,25 @@ public abstract class SharedRadioJobIconSystem : EntitySystem
         }
     }
 
+    public void UpdateRadioJobIcon(EntityUid uid, ProtoId<JobIconPrototype> iconId, string jobName)
+    {
+        if (!Exists(uid) || Deleted(uid))
+            return;
+
+        if (!_radioJobIconQuery.TryGetComponent(uid, out var component))
+            component = EnsureComp<RadioJobIconComponent>(uid);
+
+        if (component.JobIconId.Id != iconId.Id || component.JobName != jobName)
+        {
+            component.JobIconId = iconId;
+            component.JobName = jobName;
+            Dirty(uid, component);
+
+            var ev = new RadioJobIconUpdatedEvent(iconId.Id, jobName);
+            RaiseLocalEvent(uid, ref ev);
+        }
+    }
+
     protected virtual (string iconId, string jobName) GetJobIcon(EntityUid entity)
     {
         var iconId = "JobIconNoId";

--- a/Content.Shared/ADT/Radio/IdCardJobChangedEvent.cs
+++ b/Content.Shared/ADT/Radio/IdCardJobChangedEvent.cs
@@ -1,4 +1,0 @@
-namespace Content.Shared.ADT.Radio;
-
-[ByRefEvent]
-public readonly record struct IdCardJobChangedEvent(EntityUid? PlayerUid);

--- a/Content.Shared/Access/Systems/SharedIdCardSystem.cs
+++ b/Content.Shared/Access/Systems/SharedIdCardSystem.cs
@@ -166,7 +166,7 @@ public abstract class SharedIdCardSystem : EntitySystem
         return true;
     }
 
-    public bool TryChangeJobIcon(EntityUid uid, JobIconPrototype jobIcon, IdCardComponent? id = null, EntityUid? player = null)
+    public bool TryChangeJobIcon(EntityUid uid, JobIconPrototype jobIcon, IdCardComponent? id = null, EntityUid? player = null, string? jobNameOverride = null) // ADT-Tweak
     {
         if (!Resolve(uid, ref id))
         {
@@ -189,7 +189,10 @@ public abstract class SharedIdCardSystem : EntitySystem
 
         // ADT-Tweak start
         if (player.HasValue && Exists(player.Value) && !Deleted(player.Value) && !Terminating(player.Value))
-            _radioJobIcon.UpdateRadioJobIcon(player.Value);
+        {
+            var displayName = jobNameOverride ?? jobIcon.LocalizedJobName;
+            _radioJobIcon.UpdateRadioJobIcon(player.Value, jobIcon.ID, displayName);
+        }
         // ADT-Tweak end
 
         return true;

--- a/Resources/Locale/ru-RU/ADT/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/ru-RU/ADT/escape-menu/ui/options-menu.ftl
@@ -29,3 +29,5 @@ ui-options-hud-theme-detective = Детектив
 ui-options-hud-theme-coscult = Космический культ
 ui-options-hud-theme-xeno = Ксеноморф
 ui-options-hud-theme-trasenknox = Олдскул
+
+ui-options-show-chat-job-icons = Показывать иконки должностей в чате

--- a/Resources/Prototypes/ADT/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/Ears/headsets_alt.yml
@@ -14,5 +14,5 @@
   id: ADTClothingHeadsetAltLoudspeaker
   components:
   - type: Loudspeaker
-    canToggle: false
-    affectRadio: false
+    canToggle: true
+    affectRadio: true

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -49,6 +49,8 @@
     price: 800
   - type: ResearchClient
   - type: TechnologyDatabase
+  - type: RadioJobIconOverride # ADT-Tweak
+    iconId: JobIconMachine
 
 # a lathe that can be sped up with space lube / slowed down with glue
 - type: entity
@@ -245,8 +247,6 @@
     - SecurityExplosives
     - SecurityEquipment
     - SecurityWeapons
-  - type: RadioJobIconOverride # ADT-Tweak
-    iconId: JobIconMachine
 
 - type: entity
   id: ProtolatheHyperConvection


### PR DESCRIPTION
## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- fix: Исправлены кастомное редактирование описаний должностей через консоль ID карт.
- fix: Изменение должности через консоль ID карт теперь выставляет иконку должности в рацию, а не ставит "Неизвестно"
- add: В настройках под категорией "Речи" появилось переключение отображение иконок в рацию, изначально - активно.
- tweak: Функция громко-говорителя была возвращена в полноразмерные гарнитуры.