### PR TITLE
[ADD] Spray light lights

### DIFF
--- a/Content.Server/ADT/Paint/PaintPoweredLightSystem.cs
+++ b/Content.Server/ADT/Paint/PaintPoweredLightSystem.cs
@@ -1,0 +1,17 @@
+using Content.Shared.ADT.Paint;
+using Robust.Server.GameObjects;
+using Robust.Shared.GameObjects;
+
+namespace Content.Server.ADT.Paint;
+public sealed class PaintPoweredLightSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
+
+    public void TryUpdateLightColor(EntityUid uid, ColorPaintedComponent painted)
+    {
+        if (!TryComp<PointLightComponent>(uid, out var pointLight))
+            return;
+
+        _pointLight.SetColor(uid, painted.Color, pointLight);
+    }
+}

--- a/Content.Server/ADT/Paint/PaintSystem.cs
+++ b/Content.Server/ADT/Paint/PaintSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Verbs;
 using Content.Shared.Whitelist;
 using Content.Shared.Inventory;
 using Content.Shared.Nutrition.EntitySystems;
+using Content.Server.ADT.Paint;
 
 namespace Content.Server.ADT.Paint;
 
@@ -25,6 +26,7 @@ public sealed class PaintSystem : SharedPaintSystem
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly OpenableSystem _openable = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private readonly PaintPoweredLightSystem _paintPoweredLight = default!;
 
     public override void Initialize()
     {
@@ -113,6 +115,8 @@ public sealed class PaintSystem : SharedPaintSystem
             paint.Color = entity.Comp.Color; // set the target color to the color specified in the spray paint yml.
             _audio.PlayPvs(entity.Comp.Spray, entity);
             paint.Enabled = true;
+
+            _paintPoweredLight.TryUpdateLightColor(target, paint);
 
             if (HasComp<InventoryComponent>(target)) // Paint any clothing the target is wearing.
             {


### PR DESCRIPTION
## Описание PR
Теперь вы можете использовать баллончики с краской для покраски осветительных приборов, ламп и других предметов, и они будут иметь цвет краски освещение, которую вы использовали.

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<img width="556" height="522" alt="2026-04-13_03-50-49" src="https://github.com/user-attachments/assets/33975f3a-0ed6-4448-9a83-eee99da81a8c" />

## Чейнджлог
:cl: CrimeMoot
- add: При покраске осветительных приборов с баллончика с краской, теперь окрашивается и свет.