### PR TITLE
[ADD] bannedGroup

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -35,6 +35,7 @@ using Content.Server.Voting.Managers;
 using Content.Shared.Voting;
 using Content.Shared.FixedPoint;
 using Content.Shared.ADT.LastWords;
+using Content.Server.GameTicking.Presets;
 
 namespace Content.Server.GameTicking
 {
@@ -460,7 +461,21 @@ namespace Content.Server.GameTicking
             // Добавляем текущий пресет в бан-лист, если у него указан BannedRound > 0
             if (CurrentPreset != null && CurrentPreset.BannedRound.HasValue && CurrentPreset.BannedRound.Value > 0)
             {
-                PlayedPresets[CurrentPreset.ID] = CurrentPreset.BannedRound.Value;
+                // Если у пресета есть группа бана, блокируем все пресеты из этой группы
+                if (!string.IsNullOrEmpty(CurrentPreset.BannedGroup))
+                {
+                    foreach (var preset in _prototypeManager.EnumeratePrototypes<GamePresetPrototype>())
+                    {
+                        if (preset.BannedGroup == CurrentPreset.BannedGroup)
+                        {
+                            PlayedPresets[preset.ID] = CurrentPreset.BannedRound.Value;
+                        }
+                    }
+                }
+                else
+                {
+                    PlayedPresets[CurrentPreset.ID] = CurrentPreset.BannedRound.Value;
+                }
             }
             // ADT-Tweak-end
 

--- a/Content.Server/GameTicking/Presets/GamePresetPrototype.cs
+++ b/Content.Server/GameTicking/Presets/GamePresetPrototype.cs
@@ -55,6 +55,21 @@ namespace Content.Server.GameTicking.Presets
         /// </example>
         [DataField]
         public int? BannedRound = 0;
+
+        /// <summary>
+        /// Группа режимов, которые блокируются вместе после использования любого режима из этой группы.
+        /// </summary>
+        /// <remarks>
+        /// Если указан BannedGroup, то при использовании любого режима из этой группы, все режимы группы
+        /// будут заблокированы на количество раундов, указанное в BannedRound.
+        /// Это позволяет создавать категории взаимозаменяемых режимов.
+        /// </remarks>
+        /// <example>
+        /// Например, "Extended" и "TraitorLight" могут быть в одной группе "ExtendedLike".
+        /// После игры в один из них, оба будут недоступны для голосования.
+        /// </example>
+        [DataField]
+        public string? BannedGroup;
         //ADT-Tweak-End
     }
 }

--- a/Resources/Prototypes/ADT/game_presets.yml
+++ b/Resources/Prototypes/ADT/game_presets.yml
@@ -48,6 +48,8 @@
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
     - CrewTransferScheduler #ADT tweak
+  bannedRound: 1
+  bannedGroup: ExtendedLike
 
 #Версия всего понемногу
 - type: gamePreset

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -91,6 +91,10 @@
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
   - CrewTransferScheduler #ADT tweak
+  # ADT-Tweak start
+  bannedRound: 1
+  bannedGroup: ExtendedLike
+  # ADT-Tweak end
 
 - type: gamePreset
   id: Greenshift


### PR DESCRIPTION
## Описание PR
Добавлены группы блокировать, теперь можно блокировать несколько режимов за раз из одной категории. Например: теперь Расширенный и Агенты-лёгкие являются одной категории. Если один их них будет выбран в ходе голосовании, то они оба будут недоступны в следующем.

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- add: Теперь режим Расширенный и Агенты-лёгкие являются одной категорией в голосовании. Если один из них был выбран в ходе голосовании и победил, то в следующем раунде оба этих голосование будут недоступны.
