### PR TITLE
Re-balance gamerule

### DIFF
--- a/Resources/Prototypes/ADT/GameRules/roundstart.yml
+++ b/Resources/Prototypes/ADT/GameRules/roundstart.yml
@@ -171,6 +171,28 @@
       - MindRoleTraitor
 
 - type: entity
+  parent: BaseTraitorRule
+  id: TraitorTripleGameRule
+  components:
+  - type: GameRule
+    minPlayers: 25
+    delay:
+      min: 240
+      max: 420
+  - type: AntagSelection
+    selectionTime: IntraPlayerSpawn
+    definitions:
+    - prefRoles: [ Traitor ]
+      max: 3
+      playerRatio: 10
+      blacklist:
+        components:
+        - AntagImmune
+      lateJoinAdditional: true
+      mindRoles:
+      - MindRoleTraitor
+
+- type: entity
   parent: BaseHereticRule
   id: HereticDuoGameRule
   components:
@@ -186,6 +208,61 @@
       lateJoinAdditional: true
       mindComponents:
       - type: HereticRole
+
+- type: entity
+  parent: BaseHereticRule
+  id: HereticTripleGameRule
+  components:
+  - type: HereticRule
+  - type: GameRule
+    minPlayers: 25
+  - type: AntagSelection
+    agentName: heretic-roundend-name
+    definitions:
+    - prefRoles: [ Heretic ]
+      max: 3
+      playerRatio: 15
+      lateJoinAdditional: true
+      mindComponents:
+      - type: HereticRole
+
+- type: entity
+  parent: BaseGameRule
+  id: ThiefSecretGameRule
+  components:
+  - type: ThiefRule
+  - type: AntagObjectives
+    objectives:
+    - EscapeThiefShuttleObjective
+  - type: AntagRandomObjectives
+    sets:
+    - groups: ThiefBigObjectiveGroups
+      prob: 0.7
+      maxPicks: 1
+    - groups: ThiefObjectiveGroups
+      maxPicks: 10
+    maxDifficulty: 2.5
+  - type: GameRule
+    minPlayers: 25
+  - type: AntagSelection
+    agentName: thief-round-end-agent-name
+    selectionTime: IntraPlayerSpawn
+    definitions:
+    - prefRoles: [ Thief ]
+      max: 2
+      playerRatio: 20
+      lateJoinAdditional: true
+      allowNonHumans: true
+      multiAntagSetting: NotExclusive
+      startingGear: ThiefGear
+      components:
+      - type: Thieving
+        stripTimeReduction: 2
+        stealthy: true
+      mindRoles:
+      - MindRoleThief
+      briefing:
+        sound: "/Audio/Misc/thief_greeting.ogg"
 
 - type: entity
   id: DynamicHardGamerule

--- a/Resources/Prototypes/ADT/game_presets.yml
+++ b/Resources/Prototypes/ADT/game_presets.yml
@@ -39,7 +39,7 @@
     - tatorlight
   name: traitorlight-title
   description: traitorlight-description
-  showInVote: true
+  showInVote: false
   rules:
     - TraitorLightGameRule
     - SubGamemodesRuleNoXenoborg
@@ -58,10 +58,13 @@
   description: antagtrio-description
   showInVote: false
   rules:
-    - TraitorDuoGameRule
-    - ChangelingDuo # ADT tweak
-    - HereticDuoGameRule
-    - SubGamemodesRule
+    - TraitorTripleGameRule
+    - HereticTripleGameRule
+    - ThiefSecretGameRule
+    # - ChangelingDuo # ADT tweak
+    # - TraitorDuoGameRule
+    # - HereticDuoGameRule
+    # - SubGamemodesRule
     - BasicStationEventScheduler
     - MeteorSwarmScheduler
     - SpaceTrafficControlEventScheduler
@@ -116,7 +119,7 @@
   name: dynamic-random-title
   minPlayers: 30
   description: dynamic-random-description
-  showInVote: true
+  showInVote: false
   rules:
     - DynamicRandomGamerule
   bannedRound: 1

--- a/Resources/Prototypes/Corvax/secret_weights.yml
+++ b/Resources/Prototypes/Corvax/secret_weights.yml
@@ -2,7 +2,8 @@
   id: CorvaxSecretDefault
   weights:
     Nukeops: 0.15
-    Traitor: 0.55
+    Traitor: 0.45
+    AntagTrio: 0.10
     Zombie: 0.05
     Extended: 0.05
     Survival: 0.10 

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -128,7 +128,7 @@
     - secret
     - sekrit
   name: secret-title
-  showInVote: false # ADT-Tweak
+  showInVote: true # ADT-Tweak
   description: secret-description
   rules:
     - Secret
@@ -169,7 +169,7 @@
   name: death-match-title
   description: death-match-description
   maxPlayers: 15
-  showInVote: true
+  showInVote: false
   supportedMaps: DeathMatchMapPool
   rules:
     - DeathMatch31

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -3,11 +3,11 @@
   weights:
     Nukeops: 0.15
     Traitor: 0.30
-    AntagTrio: 0.15
+    AntagTrio: 0.25
     Revolutionary: 0.15
     Heretic: 0.14
-    Changeling: 0.10
     KesslerSyndrome: 0.01
+    # Changeling: 0.10
     #Wizard: 0.05 # Why not, should probably be lower
     #Survival: 0
     #Zombie: 0


### PR DESCRIPTION
## Описание PR
Временно убран динамический режим из пулла выбора в голосовании.
Из пулла также убраны облегчённые трейторы, оставлены только `Extended` и `Secret`.

Для `Secret` обновлён скрытый пул режимов:
- убраны генокрады
- добавлен/обновлён смешанный вариант с фиксированным составом антагонистов
- состав `AntagTrio` изменён на 3 агента, 3 еретика и 2 вора

## Почему / Баланс
Нада

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
Не требуется.

## Чейнджлог
no cl, no fun
