### PR TITLE
[ADD] Энерго-турель Центрального коммандования

### DIFF
--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/objects/devices/circuitboards/machine/turrets.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/objects/devices/circuitboards/machine/turrets.ftl
@@ -9,3 +9,6 @@ ent-WeaponEnergyTurretAIMachineCircuitboard = { ent-WeaponEnergyTurretStationMac
 ent-WeaponEnergyTurretCommandMachineCircuitboard = { ent-WeaponEnergyTurretStationMachineCircuitboardBase }
     .suffix = Командование
     .desc = { ent-WeaponEnergyTurretStationMachineCircuitboardBase.desc }
+ent-ADTWeaponEnergyTurretCentralCommandMachineCircuitboard = { ent-WeaponEnergyTurretStationMachineCircuitboardBase }
+    .suffix = Центральное Командование
+    .desc = { ent-WeaponEnergyTurretStationMachineCircuitboardBase.desc }

--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/objects/devices/circuitboards/machine/turrets.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/objects/devices/circuitboards/machine/turrets.ftl
@@ -10,5 +10,5 @@ ent-WeaponEnergyTurretCommandMachineCircuitboard = { ent-WeaponEnergyTurretStati
     .suffix = Командование
     .desc = { ent-WeaponEnergyTurretStationMachineCircuitboardBase.desc }
 ent-ADTWeaponEnergyTurretCentralCommandMachineCircuitboard = { ent-WeaponEnergyTurretStationMachineCircuitboardBase }
-    .suffix = Центральное Командование
+    .suffix = Центральное командование
     .desc = { ent-WeaponEnergyTurretStationMachineCircuitboardBase.desc }

--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/objects/devices/electronics/turret_controls.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/objects/devices/electronics/turret_controls.ftl
@@ -10,5 +10,5 @@ ent-WeaponEnergyTurretCommandControlPanelElectronics = { ent-WeaponEnergyTurretS
     .suffix = Командование
     .desc = { ent-WeaponEnergyTurretStationControlPanelElectronicsBase.desc }
 ent-ADTWeaponEnergyTurretCentralCommandControlPanelElectronics = { ent-WeaponEnergyTurretStationControlPanelElectronicsBase }
-    .suffix = Центральное Командование
+    .suffix = Центральное командование
     .desc = { ent-WeaponEnergyTurretStationControlPanelElectronicsBase.desc }

--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/objects/devices/electronics/turret_controls.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/objects/devices/electronics/turret_controls.ftl
@@ -9,3 +9,6 @@ ent-WeaponEnergyTurretAIControlPanelElectronics = { ent-WeaponEnergyTurretStatio
 ent-WeaponEnergyTurretCommandControlPanelElectronics = { ent-WeaponEnergyTurretStationControlPanelElectronicsBase }
     .suffix = Командование
     .desc = { ent-WeaponEnergyTurretStationControlPanelElectronicsBase.desc }
+ent-ADTWeaponEnergyTurretCentralCommandControlPanelElectronics = { ent-WeaponEnergyTurretStationControlPanelElectronicsBase }
+    .suffix = Центральное Командование
+    .desc = { ent-WeaponEnergyTurretStationControlPanelElectronicsBase.desc }

--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/objects/weapons/guns/turrets/turrets_energy.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/objects/weapons/guns/turrets/turrets_energy.ftl
@@ -10,5 +10,5 @@ ent-WeaponEnergyTurretCommand = { ent-WeaponEnergyTurretStationBase }
     .suffix = Командование
     .desc = { ent-WeaponEnergyTurretStationBase.desc }
 ent-ADTWeaponEnergyTurretCentralCommand = { ent-WeaponEnergyTurretStationBase }
-    .suffix = Центральное Командование
+    .suffix = Центральное командование
     .desc = { ent-WeaponEnergyTurretStationBase.desc }

--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/objects/weapons/guns/turrets/turrets_energy.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/objects/weapons/guns/turrets/turrets_energy.ftl
@@ -9,3 +9,6 @@ ent-WeaponEnergyTurretSecurity = { ent-WeaponEnergyTurretStationBase }
 ent-WeaponEnergyTurretCommand = { ent-WeaponEnergyTurretStationBase }
     .suffix = Командование
     .desc = { ent-WeaponEnergyTurretStationBase.desc }
+ent-ADTWeaponEnergyTurretCentralCommand = { ent-WeaponEnergyTurretStationBase }
+    .suffix = Центральное Командование
+    .desc = { ent-WeaponEnergyTurretStationBase.desc }

--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/structures/wallmounts/turret_controls.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/structures/wallmounts/turret_controls.ftl
@@ -12,5 +12,5 @@ ent-WeaponEnergyTurretCommandControlPanel = { ent-WeaponEnergyTurretStationContr
     .suffix = Командование
     .desc = { ent-WeaponEnergyTurretStationControlPanelBase.desc }
 ent-ADTWeaponEnergyTurretCentralCommandControlPanel = { ent-WeaponEnergyTurretStationControlPanelBase }
-    .suffix = Центральное Командование
+    .suffix = Центральное командование
     .desc = { ent-WeaponEnergyTurretStationControlPanelBase.desc }

--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/structures/wallmounts/turret_controls.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/structures/wallmounts/turret_controls.ftl
@@ -11,3 +11,6 @@ ent-WeaponEnergyTurretSecurityControlPanel = { ent-WeaponEnergyTurretStationCont
 ent-WeaponEnergyTurretCommandControlPanel = { ent-WeaponEnergyTurretStationControlPanelBase }
     .suffix = Командование
     .desc = { ent-WeaponEnergyTurretStationControlPanelBase.desc }
+ent-ADTWeaponEnergyTurretCentralCommandControlPanel = { ent-WeaponEnergyTurretStationControlPanelBase }
+    .suffix = Центральное Командование
+    .desc = { ent-WeaponEnergyTurretStationControlPanelBase.desc }

--- a/Resources/Prototypes/ADT/Access/centcomm.yml
+++ b/Resources/Prototypes/ADT/Access/centcomm.yml
@@ -1,0 +1,7 @@
+- type: accessGroup
+  id: CentralCommand
+  tags:
+  - BlueShield
+  - CentralCommand
+  - Magistrate
+  - IAA

--- a/Resources/Prototypes/ADT/Entities/Objects/Devices/Circuitboards/Machine/turrets.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Devices/Circuitboards/Machine/turrets.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: WeaponEnergyTurretStationMachineCircuitboardBase
   id: ADTWeaponEnergyTurretCentralCommandMachineCircuitboard
-  suffix: Command
+  suffix: CentralCommand
   components:
   - type: Sprite
     sprite: Objects/Misc/module.rsi

--- a/Resources/Prototypes/ADT/Entities/Objects/Devices/Circuitboards/Machine/turrets.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Devices/Circuitboards/Machine/turrets.yml
@@ -1,0 +1,10 @@
+- type: entity
+  parent: WeaponEnergyTurretStationMachineCircuitboardBase
+  id: ADTWeaponEnergyTurretCentralCommandMachineCircuitboard
+  suffix: Command
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: command
+  - type: MachineBoard
+    prototype: ADTWeaponEnergyTurretCentralCommand

--- a/Resources/Prototypes/ADT/Entities/Objects/Devices/Electronics/turret_controls.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Devices/Electronics/turret_controls.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: WeaponEnergyTurretStationControlPanelElectronicsBase
   id: ADTWeaponEnergyTurretCentralCommandControlPanelElectronics
-  suffix: Command
+  suffix: CentralCommand
   components:
   - type: Sprite
     sprite: Objects/Misc/module.rsi

--- a/Resources/Prototypes/ADT/Entities/Objects/Devices/Electronics/turret_controls.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Devices/Electronics/turret_controls.yml
@@ -1,0 +1,10 @@
+- type: entity
+  parent: WeaponEnergyTurretStationControlPanelElectronicsBase
+  id: ADTWeaponEnergyTurretCentralCommandControlPanelElectronics
+  suffix: Command
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: command
+  - type: ElectronicsBoard
+    prototype: ADTWeaponEnergyTurretCentralCommandControlPanel

--- a/Resources/Prototypes/ADT/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Weapons/Guns/turrets.yml
@@ -15,3 +15,24 @@
   - type: NpcFactionMember
     factions:
     - SpaceSecFaction
+
+- type: entity
+  parent: WeaponEnergyTurretStationBase
+  id: ADTWeaponEnergyTurretCentralCommand
+  suffix: CentralCommand
+  components:
+  - type: AccessReader
+    access: [["StationAi"], ["Command"]]
+  - type: TurretTargetSettings
+    exemptAccessLevels:
+    - CentralCommand
+    - BlueShield
+    - Magistrate
+    - IAA
+    - BasicSilicon
+    - Borg
+  - type: Machine
+    board: ADTWeaponEnergyTurretCentralCommandMachineCircuitboard
+  - type: DeviceNetwork
+    receiveFrequencyId: TurretControl
+    transmitFrequencyId: Turret

--- a/Resources/Prototypes/ADT/Entities/Structures/Wallmounts/turret_controls.yml
+++ b/Resources/Prototypes/ADT/Entities/Structures/Wallmounts/turret_controls.yml
@@ -1,0 +1,69 @@
+
+- type: entity
+  parent: WeaponEnergyTurretStationControlPanelBase
+  id: ADTWeaponEnergyTurretCentralCommandControlPanel
+  suffix: CentralCommand, AllGroups
+  components:
+  - type: AccessReader
+    access: [["StationAi"], ["CentralCommand"]]
+  - type: ContainerFill
+    containers:
+      board:
+      - ADTWeaponEnergyTurretCentralCommandControlPanelElectronics
+  - type: TurretTargetSettings
+    exemptAccessLevels:
+    - CentralCommand
+    - BlueShield
+    - Magistrate
+    - IAA
+    - BasicSilicon
+    - Borg
+  - type: DeployableTurretController
+    accessGroups:
+    - CentralCommand
+    - Cargo
+    - Command
+    - Engineering
+    - General
+    - Medical
+    - Research
+    - Security
+    - Service
+    - Silicon
+    accessLevels:
+    - CentralCommand
+    - BlueShield
+    - Magistrate
+    - IAA
+    - Armory
+    - Atmospherics
+    - Bar
+    - BasicSilicon
+    - Borg
+    - Brig
+    - Detective
+    - Captain
+    - Cargo
+    - Chapel
+    - Chemistry
+    - ChiefEngineer
+    - ChiefMedicalOfficer
+    - Command
+    - Cryogenics
+    - Engineering
+    - External
+    - HeadOfPersonnel
+    - HeadOfSecurity
+    - Hydroponics
+    - Janitor
+    - Kitchen
+    - Lawyer
+    - Maintenance
+    - Medical
+    - Quartermaster
+    - Research
+    - ResearchDirector
+    - Salvage
+    - Security
+    - Service
+    - Theatre

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/turret_controls.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/turret_controls.yml
@@ -1,7 +1,7 @@
 - type: entity
   abstract: true
   parent: BaseElectronics
-  id: WeaponEnergyTurretStationControlPanelElectronicsBase 
+  id: WeaponEnergyTurretStationControlPanelElectronicsBase
   name: sentry turret control panel electronics
   description: An electronics board used in a sentry turret control panel.
   components:
@@ -29,7 +29,7 @@
     state: science
   - type: ElectronicsBoard
     prototype: WeaponEnergyTurretAIControlPanel
-    
+
 - type: entity
   parent: WeaponEnergyTurretStationControlPanelElectronicsBase
   id: WeaponEnergyTurretCommandControlPanelElectronics

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_energy.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_energy.yml
@@ -6,7 +6,7 @@
   description: A high-tech autonomous weapons system designed to keep unauthorized personnel out of sensitive areas.
   components:
   - type: Anchorable
-    flags: 
+    flags:
     - Anchorable
   - type: Rotatable
   - type: Fixtures

--- a/Resources/Prototypes/Roles/Jobs/CentComm/official.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/official.yml
@@ -10,9 +10,10 @@
   canBeAntag: false
   accessGroups:
   - AllAccess
-  access:
-  - CentralCommand
   # Start ADT Tweak
+  - CentralCommand
+  # access:
+  # - CentralCommand
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]


### PR DESCRIPTION
## Описание PR
Были добавлена 4 прототипа, 2 платы, турелька и панель идентичные по функционалу, с разницой только в доступе

## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс.

В случае, если ваш pull request привязан к запросу из нашего discord сервера, используйте образец, представленный далее.

Ссылка на заказ, предложение или баг-репорт
- [Заказ](https://discord.com/channels/901772674865455115/1492138207847120926)

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог
:cl: Cethet
- add: Добавлены лазерные турели и панель управления их с доступом ЦК
- add: Должности ЦК теперь имеют доступы ОСЩ. АВД и магистрата