### PR TITLE
Небольшие фиксы

### DIFF
--- a/Content.Shared/Blocking/BlockingSystem.User.cs
+++ b/Content.Shared/Blocking/BlockingSystem.User.cs
@@ -32,7 +32,7 @@ public sealed partial class BlockingSystem
 
         SubscribeLocalEvent<BlockingComponent, ItemToggleActivateAttemptEvent>(OnItemToggleAttempt); //ADT-Tweak
         SubscribeLocalEvent<BlockingComponent, ChargeChangedEvent>(OnChargeChanged); //ADT-Tweak
-        SubscribeLocalEvent<BlockingComponent, ExaminedEvent>(OnCellSlotExamined); //ADT-Tweak
+        SubscribeLocalEvent<BlockingComponent, ExaminedEvent>(OnBatteryExamined); //ADT-Tweak
     }
 
     private void OnParentChanged(EntityUid uid, BlockingUserComponent component, ref EntParentChangedMessage args)
@@ -214,7 +214,7 @@ public sealed partial class BlockingSystem
         }
     }
 
-    private void OnCellSlotExamined(Entity<BlockingComponent> ent, ref ExaminedEvent args)
+    private void OnBatteryExamined(Entity<BlockingComponent> ent, ref ExaminedEvent args)
     {
         if (!TryComp<BatteryComponent>(ent, out var battery))
             return;
@@ -222,15 +222,9 @@ public sealed partial class BlockingSystem
         if (!ent.Comp.IsCharging)
             return;
 
-        OnBatteryExamined((ent.Owner, battery), ref args);
-    }
-
-    private void OnBatteryExamined(Entity<BatteryComponent> ent, ref ExaminedEvent args)
-    {
-        var chargePercent = _batterySystem.GetChargeLevel(ent.AsNullable()) * 100;
+        var chargePercent = _batterySystem.GetChargeLevel((ent.Owner, battery)) * 100;
         args.PushMarkup(Loc.GetString("power-cell-component-examine-details", ("currentCharge", $"{chargePercent:F0}")));
     }
-
     //ADT-Tweak-End
 
     /// <summary>

--- a/Content.Shared/Blocking/BlockingSystem.User.cs
+++ b/Content.Shared/Blocking/BlockingSystem.User.cs
@@ -4,14 +4,12 @@ using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
-//ADT-Tweak-Start
 using Content.Shared.Power.Components;
 using Content.Shared.Power.EntitySystems;
 using Content.Shared.Item.ItemToggle;
 using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Power;
-//ADT-Tweak-End
-
+using Content.Shared.Examine;
 
 namespace Content.Shared.Blocking;
 
@@ -34,6 +32,7 @@ public sealed partial class BlockingSystem
 
         SubscribeLocalEvent<BlockingComponent, ItemToggleActivateAttemptEvent>(OnItemToggleAttempt); //ADT-Tweak
         SubscribeLocalEvent<BlockingComponent, ChargeChangedEvent>(OnChargeChanged); //ADT-Tweak
+        SubscribeLocalEvent<BlockingComponent, ExaminedEvent>(OnCellSlotExamined); //ADT-Tweak
     }
 
     private void OnParentChanged(EntityUid uid, BlockingUserComponent component, ref EntParentChangedMessage args)
@@ -214,6 +213,24 @@ public sealed partial class BlockingSystem
             _batterySystem.SetCharge(uid, newCharge);
         }
     }
+
+    private void OnCellSlotExamined(Entity<BlockingComponent> ent, ref ExaminedEvent args)
+    {
+        if (!TryComp<BatteryComponent>(ent, out var battery))
+            return;
+
+        if (!ent.Comp.IsCharging)
+            return;
+
+        OnBatteryExamined((ent.Owner, battery), ref args);
+    }
+
+    private void OnBatteryExamined(Entity<BatteryComponent> ent, ref ExaminedEvent args)
+    {
+        var chargePercent = _batterySystem.GetChargeLevel(ent.AsNullable()) * 100;
+        args.PushMarkup(Loc.GetString("power-cell-component-examine-details", ("currentCharge", $"{chargePercent:F0}")));
+    }
+
     //ADT-Tweak-End
 
     /// <summary>

--- a/Resources/Prototypes/ADT/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/ADT/Catalog/Fills/Backpacks/duffelbag.yml
@@ -9,13 +9,13 @@
       storagebase: !type:AllSelector
         children:
         - id: ClothingHeadHatBeretMedic
-        - id: ClothingOuterCoatAMG
-        - id: ADTClothingOuterCoatBrigmedicWB
+        - id: ClothingHeadHatBeretSecurityMedic
+        - id: ClothingHeadHelmetSecurityMedic
         - id: ClothingUniformJumpsuitBrigmedic
         - id: ClothingUniformJumpskirtBrigmedic
         - id: ADTClothingUniformJumpsuitBrigmedicTurtleneck
         - id: ADTClothingUniformJumpskirtBrigmedicTurtleneck
-        - id: ClothingHeadHelmetSecurityMedic # Corvax-Resprite
+        - id: ClothingOuterCoatAMG
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle
   id: ADTClothingBackpackDuffelSyndicateFilledAKMS

--- a/Resources/Prototypes/ADT/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/ADT/Catalog/Fills/Lockers/security.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
-  id: LockerBrigmedicFilledHardsuit
-  suffix: Filled, Hardsuit
+  id: LockerBrigmedicFilled
+  suffix: Filled
   parent: LockerBrigmedic
   components:
   - type: EntityTableContainerFill
@@ -33,6 +33,12 @@
           amount: 1
         - id: ADTHandheldCrewMonitorBrigmedic
         - id: JetInjector
+
+- type: entity
+  id: LockerBrigmedicFilledHardsuit
+  suffix: Filled, Hardsuit
+  parent: LockerBrigmedicFilled
+  components:
   - type: UserInterface
     interfaces:
       enum.SuitStorageUiKey.Key:
@@ -41,42 +47,3 @@
     options:
     - ADTClothingModsuitBackBrigmedic
     - ClothingOuterHardsuitBrigmedic
-
-- type: entity
-  id: LockerBrigmedicFilled
-  suffix: Filled
-  parent: LockerBrigmedic
-  components:
-  - type: EntityTableContainerFill
-    containers:
-      entity_storage: !type:AllSelector
-        children:
-        - id: ClothingEyesHudMedSec
-        - id: WeaponDisabler
-        - id: TrackingImplanter
-          amount: 4
-        - id: MedkitFilled
-        - id: MedkitCombatFilled
-        - id: MedkitAdvancedFilled
-          prob: 0.4
-        - id: MedkitOxygenFilled
-          prob: 0.3
-        - id: MedkitBruteFilled
-          prob: 0.3
-        - id: MedkitToxinFilled
-          prob: 0.3
-        - id: MedkitBurnFilled
-          prob: 0.7
-        - id: ClothingNeckCloakMoth #bzzz Moth-pocalypse
-          prob: 0.15
-        - id: BoxSyringe
-        - id: BoxPillCanister
-        - id: BoxBodyBag
-        - id: ClothingHandsGlovesNitrile
-        - id: ChemistryBottleEpinephrine
-          amount: 1
-        - id: BrigmedicDuffelbagClothing
-        - id: ADTHandheldCrewMonitorBrigmedic
-        - id: ADTBookSRPsec
-        - id: ADTBookSRPmed
-        - id: ADTBookPCDsec

--- a/Resources/Prototypes/ADT/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/ADT/Catalog/Fills/Lockers/security.yml
@@ -32,6 +32,7 @@
         - id: ChemistryBottleEpinephrine
           amount: 1
         - id: ADTHandheldCrewMonitorBrigmedic
+        - id: JetInjector
   - type: UserInterface
     interfaces:
       enum.SuitStorageUiKey.Key:
@@ -68,10 +69,6 @@
           prob: 0.7
         - id: ClothingNeckCloakMoth #bzzz Moth-pocalypse
           prob: 0.15
-        - id: ClothingOuterVestSecurityMedic # Corvax-Resprite
-          prob: 0.5
-        - id: ClothingOuterCoatLabSecurityMedic # Corvax-Resprite
-          prob: 0.5
         - id: BoxSyringe
         - id: BoxPillCanister
         - id: BoxBodyBag

--- a/Resources/Prototypes/ADT/Entities/Clothing/Back/mods.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/Back/mods.yml
@@ -572,6 +572,7 @@
     sprite: ADT/Clothing/Back/Modsuit/warden.rsi
     state: icon
   - type: ModSuit
+    maxComplexity: 10
     fullyEnabledSound:
       path: /Audio/ADT/Mecha/nominalnano.ogg
     clothingPrototypes:
@@ -594,6 +595,7 @@
     sprite: ADT/Clothing/Back/Modsuit/brigmedic.rsi
     state: icon
   - type: ModSuit
+    maxComplexity: 10
     fullyEnabledSound:
       path: /Audio/ADT/Mecha/nominalnano.ogg
     clothingPrototypes:

--- a/Resources/Prototypes/ADT/Entities/Objects/Shields/fullshield.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Shields/fullshield.yml
@@ -150,7 +150,6 @@
     - type: Battery
       maxCharge: 1200
       startingCharge: 1200
-    - type: PowerCell
     - type: BatterySelfRecharger
       autoRecharge: true
       autoRechargeRate: 10

--- a/Resources/Prototypes/ADT/Entities/Objects/Weapons/Guns/Battery/battery_gun.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Weapons/Guns/Battery/battery_gun.yml
@@ -563,7 +563,7 @@
   - type: RunAndGunSpreadModifier
     modifier: 0.1
   - type: Gun
-    fireRate: 1
+    fireRate: 3
     projectileSpeed: 45
     selectedMode: SemiAuto
     availableModes:

--- a/Resources/Prototypes/ADT/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -104,7 +104,7 @@
       zeroVisible: true
     - type: Gun
       minAngle: 18
-      maxAngle: 29
+      maxAngle: 22
       fireRate: 7
       burstFireRate: 8
       soundGunshot:

--- a/Resources/Prototypes/ADT/Loadouts/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Jobs/Security/brigmedic.yml
@@ -9,6 +9,16 @@
   equipment:
     head: ClothingHeadHelmetSecurityMedic
 
+- type: loadout
+  id: ADTClothingHeadHatBeretSecurityMedic
+  equipment:
+    head: ClothingHeadHatBeretSecurityMedic
+
+- type: loadout
+  id: ADTClothingHeadHatBeretMedic
+  equipment:
+    head: ClothingHeadHatBeretMedic
+
 # Jumpsuit
 - type: loadout
   id: ADTUniformJumpsuitBrigmedic
@@ -103,20 +113,19 @@
 
 # outerwear
 - type: loadout
-  id: ADTOuterCoatBrigmedicWB
-  equipment:
-    outerClothing: ADTClothingOuterCoatBrigmedicWB
-
-- type: loadout
-  id: ADTOuterVestSecurityMedic
-  equipment:
-    outerClothing: ClothingOuterVestSecurityMedic
-
-- type: loadout
   id: ADTOuterCoatLabSecurityMedic
   equipment:
     outerClothing: ClothingOuterCoatLabSecurityMedic
 
+- type: loadout
+  id: ADTClothingOuterVestArmorMedSec
+  equipment:
+    outerClothing: ClothingOuterVestArmorMedSec
+
+- type: loadout
+  id: ADTClothingOuterCoatAMG
+  equipment:
+    outerClothing: ClothingOuterCoatAMG
 
 # PDA
 

--- a/Resources/Prototypes/ADT/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/ADT/Loadouts/loadout_groups.yml
@@ -678,6 +678,8 @@
   loadouts:
   - ADTHeadHatBeretBrigmedic
   - ADTHeadHelmetSecurityMedic
+  - ADTClothingHeadHatBeretSecurityMedic
+  - ADTClothingHeadHatBeretMedic
 
   #neck
 - type: loadoutGroup
@@ -740,8 +742,8 @@
   minLimit: 0
   maxLimit: 1
   loadouts:
-  - ADTOuterCoatBrigmedicWB
-  - ADTOuterVestSecurityMedic
+  - ADTClothingOuterCoatAMG
+  - ADTClothingOuterVestArmorMedSec
   - ADTOuterCoatLabSecurityMedic
 
 ## повар

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -473,7 +473,7 @@
         Slash: 0.85
         Piercing: 0.65
         Heat: 0.85
-        Caustic: 0.75
+        Caustic: 0.70 #ADT-Tweak -> 0.75
 
 - type: entity
   parent: ClothingOuterStorageFoldableBase


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
Обновление лодаута бригмедика, убрав ему бесполезные жилетки и ветровки, добавив вместо них бронежилет и его халат, добавление инъектора в шкаф бма, чутка подредачила разброс у утапа СЩ и скорострельность его пистолетика. Подправила макс очки модулей у модов варда и бригмеда. Поправила энергощит СЩ, теперь он не суется в устройства как батарейка.

## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс.

В случае, если ваш pull request привязан к запросу из нашего discord сервера, используйте образец, представленный далее.

Ссылка на заказ, предложение или баг-репорт
- [Баг-репорт/Заказ/Предложение](ссылка)-->

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [X] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [X] PR закончен и требует просмотра изменений.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог

:cl: Cethet
- tweak: Изменение лодаута бригмедика, добавление в него двух его беретов, бронежилета и халата
- tweak: Добавлен инъектор в шкаф бригмедика
- tweak: Уменьшен разброс у пистолета-пулемета СЩ и увеличена скорострельность пистолета с того же набора с ПП
- fix: Энергетический щит Синего щита больше нельзя вставить в устройства как батарейку

