### PR TITLE
[FIX] overhaul and BORIS

### DIFF
--- a/Content.Server/ADT/Silicons/Borgs/AiRemoteControlSystem.cs
+++ b/Content.Server/ADT/Silicons/Borgs/AiRemoteControlSystem.cs
@@ -14,10 +14,12 @@ using Content.Shared.Verbs;
 using Content.Shared.Destructible;
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;
+using Content.Shared.Damage.Systems;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 using Content.Shared.Mobs.Systems;
+using Robust.Shared.Containers;
 
 namespace Content.Server.ADT.Silicons.Borgs;
 
@@ -32,6 +34,7 @@ public sealed class AiRemoteControlSystem : SharedAiRemoteControlSystem
     [Dependency] private readonly MetaDataSystem _metaData = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly SharedContainerSystem _containers = default!;
 
     public override void Initialize()
     {
@@ -43,6 +46,7 @@ public sealed class AiRemoteControlSystem : SharedAiRemoteControlSystem
         SubscribeLocalEvent<AiRemoteControllerComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
         SubscribeLocalEvent<AiRemoteControllerComponent, DestructionEventArgs>(OnBorgDestroyed);
         SubscribeLocalEvent<AiRemoteControllerComponent, MobStateChangedEvent>(OnBorgMobStateChanged);
+        SubscribeLocalEvent<StationAiBrainComponent, MobStateChangedEvent>(OnAiMobStateChanged);
         SubscribeLocalEvent<StationAiHeldComponent, RemoteDeviceActionMessage>(OnUiRemoteAction);
         SubscribeLocalEvent<StationAiHeldComponent, ToggleRemoteDevicesScreenEvent>(OnToggleRemoteDevicesScreen);
     }
@@ -171,6 +175,21 @@ public sealed class AiRemoteControlSystem : SharedAiRemoteControlSystem
             var returnEvent = new ReturnMindIntoAiEvent { Key = RemoteDevicesUiKey.Key };
             RaiseLocalEvent(entity.Owner, returnEvent, true);
         }
+    }
+
+    private void OnAiMobStateChanged(Entity<StationAiBrainComponent> ai, ref MobStateChangedEvent args)
+    {
+        if (!_mobState.IsIncapacitated(ai.Owner, args.Component))
+            return;
+
+        if (!TryComp<StationAiHeldComponent>(ai.Owner, out var heldComp) || heldComp.CurrentConnectedEntity == null)
+            return;
+
+        var borg = heldComp.CurrentConnectedEntity.Value;
+        if (!TryComp<AiRemoteControllerComponent>(borg, out _))
+            return;
+
+        RaiseLocalEvent(borg, new ReturnMindIntoAiEvent { Key = RemoteDevicesUiKey.Key }, true);
     }
 
     private void OnToggleRemoteDevicesScreen(EntityUid uid, StationAiHeldComponent component, ToggleRemoteDevicesScreenEvent args)

--- a/Resources/Prototypes/ADT/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/ADT/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -10,10 +10,6 @@
     voice: sentrybot
   - type: BorgSwitchableSubtype
     borgSubtype: default_security
-  - type: ShowMindShieldIcons
-  - type: ShowJobIcons
-  - type: ShowCriminalRecordIcons
-  - type: ShowContrabandDetails
 
 - type: entity
   id: ADTBorgChassisKerfusNT

--- a/Resources/Prototypes/ADT/borg_types.yml
+++ b/Resources/Prototypes/ADT/borg_types.yml
@@ -28,3 +28,9 @@
   # Pet
   petSuccessString: petting-success-generic-cyborg
   petFailureString: petting-failure-generic-cyborg
+
+  addComponents:
+  - type: ShowMindShieldIcons
+  - type: ShowJobIcons
+  - type: ShowCriminalRecordIcons
+  - type: ShowContrabandDetails

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -368,6 +368,7 @@
     - id: HandTeleporter
     - id: RubberStampRd
     # ADT-Tweak-Start
+    - id: ADTAiRemoteBrain
     - id: ADTBookSRPcmd
     - id: ADTBookSRPrnd
     - id: ADTBookPCDcmd

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -91,8 +91,8 @@
   - type: SiliconLawProvider
     laws: NTDefault # Corvax-NTDefault
   - type: IonStormTarget
-#  - type: Inventory
-#    templateId: borg
+  - type: Inventory
+    templateId: borg
   - type: Hands
     showInHands: false
     disableExplosionRecursion: true


### PR DESCRIPTION
## Описание PR
Исправил баги в ходе игры:
https://github.com/AdventureTimeSS14/space_station_ADT/pull/2807
https://github.com/AdventureTimeSS14/space_station_ADT/pull/2800

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- add: При уничтожении ядро ИИ, если ИИ в это время был в борге от БОРИСа, то его насильно выкидывает и отправляет обратно в ядро. Где в следствие он уже умер.
- add: В шкафу научного руководителя сразу есть одна готовая плата БОРИСа для ИИ.
- tweak: Боргам возращён слот под шлем.
- fix: Охранные худы для СБ борга.
