### PR TITLE
Убрана гост-роль Бехонкера

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
@@ -5,17 +5,19 @@
   abstract: true
   description: A floating demon aspect of the honkmother.
   components:
-    - type: GhostRole
-      allowMovement: true
-      makeSentient: true
-      name: ghost-role-information-behonker-name
-      description: ghost-role-information-behonker-description
-      rules: ghost-role-information-antagonist-rules
-      mindRoles:
-      - MindRoleGhostRoleSoloAntagonist
-      raffle:
-        settings: default
-    - type: GhostTakeoverAvailable
+  # ADT-Tweak start: Benoker Ghost Role Remove
+    # - type: GhostRole
+    #   allowMovement: true
+    #   makeSentient: true
+    #   name: ghost-role-information-behonker-name
+    #   description: ghost-role-information-behonker-description
+    #   rules: ghost-role-information-antagonist-rules
+    #   mindRoles:
+    #   - MindRoleGhostRoleSoloAntagonist
+    #   raffle:
+    #     settings: default
+    # - type: GhostTakeoverAvailable
+  # ADT-Tweak end: Benoker Ghost Role Remove
     - type: HTN
       rootTask:
         task: SimpleRangedHostileCompound


### PR DESCRIPTION
## Описание PR
Убрана лишь **гост-роль**, сам **моб остался**
## Почему / Баланс
История та же что и с погибелью
На обломке/карте спавнится сильная ролька с бесплатным джетом+лазеркой, игрок берет её и идёт РДМить экипаж на станции. 
Во время лоупопов такая хуйня может убить пол экипажа.
## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог

:cl: Archeron
- remove: Убрана гост-роль бехонкера