### PR TITLE
fix hypo and EssenceEldritch

### DIFF
--- a/Content.Server/ADT/Atmos/Rotting/UnRottingSystem.cs
+++ b/Content.Server/ADT/Atmos/Rotting/UnRottingSystem.cs
@@ -1,0 +1,20 @@
+using Content.Shared.Atmos.Rotting;
+using Content.Shared.ADT.Atmos.Rotting;
+using Robust.Shared.GameObjects;
+
+namespace Content.Server.ADT.Atmos.Rotting;
+
+public sealed partial class UnRottingSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<UnRottingComponent, IsRottingEvent>(OnIsRotting);
+    }
+
+    private void OnIsRotting(EntityUid uid, UnRottingComponent component, ref IsRottingEvent args)
+    {
+        args.Handled = true;
+    }
+}

--- a/Content.Server/ADT/Chemistry/Systems/InjectorsBlockerSystem.cs
+++ b/Content.Server/ADT/Chemistry/Systems/InjectorsBlockerSystem.cs
@@ -1,7 +1,9 @@
 using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Events;
 using Content.Shared.Inventory;
+using Content.Server.Chemistry.Components;
 using Content.Server.Medical;
 
 namespace Content.Server.Chemistry.EntitySystems;
@@ -19,16 +21,45 @@ public sealed class InjectorsBlockerSystem : EntitySystem
 
     private void OnInjectAttempt(EntityUid uid, InjectorsBlockerComponent comp, InjectAttemptEvent args)
     {
+        if (args.Cancelled)
+            return;
+
+        if (args.UsedInjector != EntityUid.Invalid && InjectorIgnoresBlockers(args.UsedInjector))
+            return;
+
         args.Cancel();
     }
 
     private void OnInjectRelayAttempt(EntityUid uid, InjectorsBlockerComponent comp, InventoryRelayedEvent<InjectAttemptEvent> args)
     {
+        if (args.Args.Cancelled)
+            return;
+
+        if (args.Args.UsedInjector != EntityUid.Invalid && InjectorIgnoresBlockers(args.Args.UsedInjector))
+            return;
+
         args.Args.Cancel();
+    }
+
+    private bool InjectorIgnoresBlockers(EntityUid injectorUid)
+    {
+        if (TryComp<InjectorComponent>(injectorUid, out var injector))
+            return injector.IgnoreBlockers;
+
+        if (TryComp<BaseSolutionInjectOnEventComponent>(injectorUid, out var eventInjector))
+            return eventInjector.IgnoreBlockers;
+
+        return false;
     }
 
     private void OnTargetBeforeInject(EntityUid uid, InjectorsBlockerComponent comp, TargetBeforeInjectEvent args)
     {
+        if (args.Cancelled)
+            return;
+
+        if (InjectorIgnoresBlockers(args.UsedInjector))
+            return;
+
         args.Cancel();
     }
 }

--- a/Content.Server/Chemistry/EntitySystems/SolutionInjectOnEventSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionInjectOnEventSystem.cs
@@ -42,7 +42,7 @@ public sealed class SolutionInjectOnCollideSystem : EntitySystem
         // ADT Injector blocking start
         if (!entity.Comp.IgnoreBlockers)
         {
-            var ev = new InjectAttemptEvent();
+            var ev = new InjectAttemptEvent(entity.Owner);
             RaiseLocalEvent(args.Target, ev);
             if (ev.Cancelled)
                 return;
@@ -57,7 +57,7 @@ public sealed class SolutionInjectOnCollideSystem : EntitySystem
         // ADT Injector blocking start
         if (!entity.Comp.IgnoreBlockers)
         {
-            var ev = new InjectAttemptEvent();
+            var ev = new InjectAttemptEvent(entity.Owner);
             RaiseLocalEvent(args.Embedded, ev);
             if (ev.Cancelled)
                 return;
@@ -79,7 +79,7 @@ public sealed class SolutionInjectOnCollideSystem : EntitySystem
                 // ADT Injector blocking start
                 if (!entity.Comp.IgnoreBlockers)
                 {
-                    var ev = new InjectAttemptEvent();
+                    var ev = new InjectAttemptEvent(entity.Owner);
                     RaiseLocalEvent(ent, ev);
                     if (ev.Cancelled)
                         continue;

--- a/Content.Shared/ADT/Atmos/Rotting/UnRottingComponent.cs
+++ b/Content.Shared/ADT/Atmos/Rotting/UnRottingComponent.cs
@@ -1,0 +1,8 @@
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared.ADT.Atmos.Rotting;
+
+[RegisterComponent]
+public sealed partial class UnRottingComponent : Component
+{
+}

--- a/Content.Shared/ADT/Chemistry/Events/InjectAttemptEvent.cs
+++ b/Content.Shared/ADT/Chemistry/Events/InjectAttemptEvent.cs
@@ -6,8 +6,14 @@ public sealed class InjectAttemptEvent : CancellableEntityEventArgs, IInventoryR
 {
     // Whenever locational damage is a thing, this should just check only that bit of armour.
     public SlotFlags TargetSlots { get; } = ~SlotFlags.POCKET;
+    public EntityUid UsedInjector = EntityUid.Invalid;
 
     public InjectAttemptEvent()
     {
+    }
+
+    public InjectAttemptEvent(EntityUid usedInjector)
+    {
+        UsedInjector = usedInjector;
     }
 }

--- a/Resources/Prototypes/ADT/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/ADT/Entities/Mobs/Species/base.yml
@@ -10,6 +10,7 @@
   id: ADTBaseMobSpeciesOrganicUnRotting
   abstract: true
   components:
+  - type: UnRotting # ADT-Tweak
   - type: MobState # ADT-Tweak
   - type: OfferItem
   - type: PickupHumans
@@ -63,4 +64,3 @@
   - type: BloodCough
     postingSayDamage: blood-cough
   - type: TimeDespawnDamage
-  - type: Embalmed

--- a/Resources/Prototypes/ADT/Heretic/Entities/Objects/Specific/heretic.yml
+++ b/Resources/Prototypes/ADT/Heretic/Entities/Objects/Specific/heretic.yml
@@ -58,7 +58,7 @@
         maxVol: 100
         canReact: false
         reagents:
-        - ReagentId: EldritchEssence
+        - ReagentId: EssenceEldritch
           Quantity: 100
 
 - type: entity

--- a/Resources/Prototypes/ADT/Heretic/Reagents/reagents.yml
+++ b/Resources/Prototypes/ADT/Heretic/Reagents/reagents.yml
@@ -4,9 +4,8 @@
   description: flavor-complex-eldritch
 
 - type: reagent
-  id: EldritchEssence
-  parent: BaseDrink
-  group: Unknown
+  id: EssenceEldritch
+  group: Medicine
   name: reagent-name-eldritch
   desc: reagent-desc-eldritch
   physicalDesc: reagent-physical-desc-eldritch

--- a/Resources/Prototypes/Reagents/Consumable/Drink/base_drink.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/base_drink.yml
@@ -5,7 +5,7 @@
   slipData:
     requiredSlipSpeed: 3.5
   metabolisms:
-    Drink: # ADT-Tweak: Digestion
+    Digestion:
       effects:
       - !type:SatiateThirst
         factor: 3
@@ -26,7 +26,7 @@
   parent: BaseDrink
   abstract: true
   metabolisms:
-    Drink:
+    Digestion:
       effects:
       - !type:SatiateThirst
         factor: 2

--- a/Resources/Prototypes/Reagents/Consumable/Drink/base_drink.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/base_drink.yml
@@ -5,7 +5,7 @@
   slipData:
     requiredSlipSpeed: 3.5
   metabolisms:
-    Digestion:
+    Drink: # ADT-Tweak: Digestion
       effects:
       - !type:SatiateThirst
         factor: 3
@@ -26,7 +26,7 @@
   parent: BaseDrink
   abstract: true
   metabolisms:
-    Digestion:
+    Drink:
       effects:
       - !type:SatiateThirst
         factor: 2

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -821,7 +821,9 @@
           type: [ Shadekin ]
         damage:
           types:
-            Blunt: -12 # ADT-Tweak ## Лечит механические повреждения на 4 (12/3)
+            Blunt: -3
+            Piercing: -3
+            Slash: -3
             Bloodloss: -1
       - !type:HealthChange
         conditions:


### PR DESCRIPTION
## Описание PR
https://discord.com/channels/901772674865455115/1521592109709394003
https://discord.com/channels/901772674865455115/1521520013906018616
https://discord.com/channels/901772674865455115/1521295102129999903

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- fix: Теперь гипоспрей может инжектить в унатхов/кобальтов, игнорируя их чешую.
- fix: Зловещею эссенция теперь можно пить, и она попадает в кровоток через глотки.
- fix: Реагент Олигомеры Полипри теперь лечит все виды механического повреждение на 3.
- fix: Воксы теперь не гниют.