### PR TITLE
[ADD] Мини-холодильник (LockerMiniFreezer) в меню крафта

### DIFF
--- a/Resources/Locale/en-US/construction/recipes/tallbox.ftl
+++ b/Resources/Locale/en-US/construction/recipes/tallbox.ftl
@@ -1,1 +1,2 @@
 construction-recipe-closet-freezer = closet freezer
+construction-recipe-closet-minifreezer = mini fridge

--- a/Resources/Locale/ru-RU/construction/recipes/tallbox.ftl
+++ b/Resources/Locale/ru-RU/construction/recipes/tallbox.ftl
@@ -1,1 +1,2 @@
 construction-recipe-closet-freezer = холодильник-шкаф
+construction-recipe-closet-minifreezer = мини-холодильник

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -247,6 +247,11 @@
     stateDoorClosed: minifreezer_door
   - type: AccessReader
     access: [ [ "Bar" ] ]
+  - type: Construction
+    graph: ClosetMiniFreezer
+    node: done
+    containers:
+    - entity_storage
 
 # Botanist
 - type: entity

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/storage/tallbox.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/storage/tallbox.yml
@@ -105,6 +105,49 @@
       - !type:DeleteEntity
 
 - type: constructionGraph
+  id: ClosetMiniFreezer
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: done
+      steps:
+      - material: Steel
+        amount: 3
+      - material: Cable
+        amount: 2
+        doAfter: 5
+      - tag: FreezerElectronics
+        name: construction-graph-tag-freezer-electronics
+        icon:
+          sprite: Objects/Misc/module.rsi
+          state: door_electronics
+  - node: done
+    entity: LockerMiniFreezer
+    edges:
+    - to: start
+      steps:
+      - tool: Screwing
+        doAfter: 5
+      conditions:
+      - !type:StorageWelded
+        welded: false
+      - !type:Locked
+        locked: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 3
+      - !type:SpawnPrototype
+        prototype: CableApcStack1
+        amount: 2
+      - !type:SpawnPrototype
+        prototype: FreezerElectronics
+        amount: 1
+      - !type:EmptyAllContainers
+      - !type:DeleteEntity
+
+- type: constructionGraph
   id: GunSafe
   start: start
   graph:

--- a/Resources/Prototypes/Recipes/Crafting/tallbox.yml
+++ b/Resources/Prototypes/Recipes/Crafting/tallbox.yml
@@ -24,6 +24,15 @@
   objectType: Structure
 
 - type: construction
+  id: ClosetMiniFreezer
+  name: construction-recipe-closet-minifreezer
+  graph: ClosetMiniFreezer
+  startNode: start
+  targetNode: done
+  category: construction-category-storage
+  objectType: Structure
+
+- type: construction
   id: GunSafe
   graph: GunSafe
   startNode: start


### PR DESCRIPTION
## Описание PR
Добавлен мини-холодильник (LockerMiniFreezer / минибар) в меню крафта.

Крафт: 3 стали + 2 кабеля + FreezerElectronics, как у обычного холодильника, но с 3 стали вместо 4.

## Почему / Баланс
Мини-бар прикольная штука, получить которую можно было только через админов или на карте Origin. Добавление мини-бара в меню крафта упростит его получение и улучшит внешний вид бара.

Ссылка на заказ, предложение или баг-репорт
- [Предложение](https://discord.com/channels/901772674865455115/1522169011142656030/1522169011142656030)

## Техническая информация
- Добавлен новый граф крафта `ClosetMiniFreezer` в `Resources/Prototypes/Recipes/Crafting/Graphs/storage/tallbox.yml`
- Добавлен рецепт в меню крафта в `Resources/Prototypes/Recipes/Crafting/tallbox.yml` (категория Storage)
- Добавлен Construction компонент на `LockerMiniFreezer` в `lockers.yml`
- Добавлены локали (en-US / ru-RU)

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<img width="956" height="491" alt="image" src="https://github.com/user-attachments/assets/1a65e0f0-b488-472e-a22f-f7f46c5bfb9b" />

<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог

:cl: WikiHampter
- add: Добавлен мини-холодильник в меню крафта (3 стали + 2 кабеля + FreezerElectronics)