### PR TITLE
[ADD] Мини-холодильник (LockerMiniFreezer) в меню крафта

### DIFF
--- a/Resources/Locale/en-US/ADT/construction/recipes/tallbox.ftl
+++ b/Resources/Locale/en-US/ADT/construction/recipes/tallbox.ftl
@@ -1,0 +1,1 @@
+construction-recipe-closet-minifreezer = mini fridge

--- a/Resources/Locale/ru-RU/ADT/construction/recipes/tallbox.ftl
+++ b/Resources/Locale/ru-RU/ADT/construction/recipes/tallbox.ftl
@@ -1,0 +1,1 @@
+construction-recipe-closet-minifreezer = мини-холодильник

--- a/Resources/Prototypes/ADT/Recipes/Crafting/Graphs/storage/tallbox.yml
+++ b/Resources/Prototypes/ADT/Recipes/Crafting/Graphs/storage/tallbox.yml
@@ -1,0 +1,42 @@
+- type: constructionGraph
+  id: ClosetMiniFreezer
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: done
+      steps:
+      - material: Steel
+        amount: 3
+      - material: Cable
+        amount: 2
+        doAfter: 5
+      - tag: FreezerElectronics
+        name: construction-graph-tag-freezer-electronics
+        icon:
+          sprite: Objects/Misc/module.rsi
+          state: door_electronics
+  - node: done
+    entity: LockerMiniFreezer
+    edges:
+    - to: start
+      steps:
+      - tool: Screwing
+        doAfter: 5
+      conditions:
+      - !type:StorageWelded
+        welded: false
+      - !type:Locked
+        locked: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 3
+      - !type:SpawnPrototype
+        prototype: CableApcStack1
+        amount: 2
+      - !type:SpawnPrototype
+        prototype: FreezerElectronics
+        amount: 1
+      - !type:EmptyAllContainers
+      - !type:DeleteEntity

--- a/Resources/Prototypes/ADT/Recipes/Crafting/tallbox.yml
+++ b/Resources/Prototypes/ADT/Recipes/Crafting/tallbox.yml
@@ -1,0 +1,8 @@
+- type: construction
+  id: ClosetMiniFreezer
+  name: construction-recipe-closet-minifreezer
+  graph: ClosetMiniFreezer
+  startNode: start
+  targetNode: done
+  category: construction-category-storage
+  objectType: Structure

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -247,6 +247,13 @@
     stateDoorClosed: minifreezer_door
   - type: AccessReader
     access: [ [ "Bar" ] ]
+# ADT-Tweak-Start: Construction компонент для крафта мини-холодильника
+  - type: Construction
+    graph: ClosetMiniFreezer
+    node: done
+    containers:
+    - entity_storage
+# ADT-Tweak-End
 
 # Botanist
 - type: entity


### PR DESCRIPTION
## Описание PR
Добавлен мини-холодильник (LockerMiniFreezer) в меню крафта.

Крафт: 3 стали + 2 кабеля + FreezerElectronics, как у обычного холодильника, но с 3 стали вместо 4.

## Почему / Баланс
Мини-бар прикольная штука, получить которую можно было только через админов или на карте Origin. Добавление мини-бара в меню крафта упростит его получение и улучшит внешний вид бара.

Ссылка на заказ, предложение или баг-репорт
- [Предложение](https://discord.com/channels/901772674865455115/1522169011142656030/1522169011142656030)

## Техническая информация
- `Resources/Prototypes/ADT/Recipes/Crafting/tallbox.yml` — новый рецепт крафта (категория Storage)
- `Resources/Prototypes/ADT/Recipes/Crafting/Graphs/storage/tallbox.yml` — новый граф крафта ClosetMiniFreezer
- `Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml` — Construction компонент на LockerMiniFreezer (с ADT-Tweak маркером)
- `Resources/Locale/en-US/ADT/construction/recipes/tallbox.ftl` — английская локализация
- `Resources/Locale/ru-RU/ADT/construction/recipes/tallbox.ftl` — русская локализация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа

## Чейнджлог

:cl: WikiHampter
- add: Добавлен мини-холодильник в меню крафта (3 стали + 2 кабеля + FreezerElectronics)