### PR TITLE
переводчикикики

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Objects/Devices/translators.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Devices/translators.yml
@@ -163,19 +163,6 @@
   - type: StaticPrice
     price: 1500
 
-- type: entity
-  id: VoxPidginTranslator
-  parent: [ Translator ]
-  name: VoxPidgin translator
-  description: "Translates speech."
-  components:
-  - type: HandheldTranslator
-    languages:
-      GalacticCommon: BadSpeak
-      VoxPidgin: BadSpeak
-  - type: StaticPrice
-    price: 1500
-
 # - type: entity
 #   id: ArachnidTranslator
 #   parent: [ Translator ]

--- a/Resources/Prototypes/ADT/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Misc/implanters.yml
@@ -177,15 +177,6 @@
     implant: DevTranslatorImplant
 
 - type: entity
-  id: VoxPidginTranslatorImplanter
-  name: VoxCommon Translator implanter
-  parent: BaseImplantOnlyImplanter
-  components:
-  - type: Implanter
-    implant: VoxPidginTranslatorImplant
-
-
-- type: entity
   id: ScratchesTranslatorImplanter
   name: ScratchesCommon Translator implanter
   parent: BaseImplantOnlyImplanter

--- a/Resources/Prototypes/ADT/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Misc/subdermal_implants.yml
@@ -274,17 +274,6 @@
 
 - type: entity
   parent: BaseTranslatorImplant
-  id: VoxPidginTranslatorImplant
-  name: translator implant
-  # description: This implant grants language knowledge.
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: TranslatorImplant
-    languages:
-      VoxPidgin: BadSpeak
-
-- type: entity
-  parent: BaseTranslatorImplant
   id: ScratchesTranslatorImplant
   name: translator implant
   # description: This implant grants language knowledge.

--- a/Resources/Prototypes/ADT/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/ADT/Recipes/Lathes/Packs/science.yml
@@ -23,7 +23,6 @@
   - BubblishTranslator
   - NekomimeticTranslator
   - DraconicTranslator
-  - VoxPidginTranslator
   - ScratchesTranslator
   - SolCommonTranslator
   - RootSpeakTranslator
@@ -37,7 +36,6 @@
   - NekomimeticTranslatorImplanter
   - DraconicTranslatorImplanter
   - CanilunztTranslatorImplanter
-  - VoxPidginTranslatorImplanter
   - ScratchesTranslatorImplanter
   - SolCommonTranslatorImplanter
   - RootSpeakTranslatorImplanter

--- a/Resources/Prototypes/ADT/Recipes/Lathes/translators.yml
+++ b/Resources/Prototypes/ADT/Recipes/Lathes/translators.yml
@@ -54,17 +54,6 @@
     Copper: 100
 
 - type: latheRecipe
-  id: VoxPidginTranslator
-  result: VoxPidginTranslator
-  completetime: 2
-  materials:
-    Steel: 500
-    Glass: 100
-    Plastic: 50
-    Gold: 50
-    Copper: 100
-
-- type: latheRecipe
   id: RootSpeakTranslator
   result: RootSpeakTranslator
   completetime: 2
@@ -422,18 +411,6 @@
     Glass: 100
     Plastic: 50
     Gold: 50
-    Copper: 100
-
-- type: latheRecipe
-  id: VoxPidginTranslatorImplanter
-  result: VoxPidginTranslatorImplanter
-  completetime: 2
-  materials:
-    Steel: 500
-    Glass: 500
-    Plastic: 100
-    Gold: 50
-    Silver: 50
     Copper: 100
 
 - type: latheRecipe

--- a/Resources/Prototypes/ADT/Research/translators.yml
+++ b/Resources/Prototypes/ADT/Research/translators.yml
@@ -14,7 +14,6 @@
   - NekomimeticTranslator
   - DraconicTranslator
   - SolCommonTranslator
-  - VoxPidginTranslator
   - ScratchesTranslator
   - RootSpeakTranslator
   - GalacticCommonTranslatorImplanter
@@ -49,7 +48,6 @@
   - DraconicTranslatorImplanter
   - CanilunztTranslatorImplanter
   - SolCommonTranslatorImplanter
-  - VoxPidginTranslatorImplanter
   - ScratchesTranslatorImplanter
   - RootSpeakTranslatorImplanter
   - AnimalTranslator


### PR DESCRIPTION
## Описание PR
Удалены переводчики с Вокс-Пиджин

## Почему / Баланс
Потому что никто не смеет вмешиваться в дела Стаи, а язык воксов не должен быть доступен пыльникам

## Чейнджлог
:cl: Aaidzz
- remove: Удалены переводчики и языковые импланты Вокс-Пиджин. Переговоры с воксами-рейдерами не дали никаких плодов, в связи с чем NanoTrasen прекращает спонсировать технологию перевода с Вокс-Пиджин на Общегалактический.