### PR TITLE
снизил цену перчаток с 60 до 6 тк

### DIFF
--- a/Resources/Prototypes/ADT/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/ADT/Catalog/uplink_catalog.yml
@@ -1351,7 +1351,7 @@
   icon: { sprite: /Textures/ADT/Clothing/Hands/Gloves/guerrilla.rsi, state: icon }
   productEntity: ADTClothingHandsGlovesGuerrilla
   cost:
-    Telecrystal: 60
+    Telecrystal: 6
   categories:
   - UplinkWearables
   conditions:


### PR DESCRIPTION
## Описание PR
цену снизил...
## Почему / Баланс
дорого, слишком
## Техническая информация
uplink_catalog.yml, там цену снизил
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: FIneter75
- tweak: Изменена стоимость партизанских перчаток в аплинке яо(60->6)