### PR TITLE
Вилка и 3 зубца

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
@@ -49,7 +49,7 @@
     attackRate: 1.5
     damage:
       types:
-        Piercing: 5
+        Piercing: 3
 
 - type: entity
   parent: UtensilBasePlastic

--- a/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
@@ -49,7 +49,7 @@
     attackRate: 1.5
     damage:
       types:
-        Piercing: 3
+        Piercing: 3 #ADT-Tweak
 
 - type: entity
   parent: UtensilBasePlastic


### PR DESCRIPTION
## Описание PR
У вилки имеется 3 зубца, однако ранее почему то при ударе вилкой, цели удара наносилось 5 урона уколами, а не 3, как надо. Ведь всего 3 зубца колят, но никак не 5. 

## Почему / Баланс
Сделать вилку более логичной.

Ссылка на заказ, предложение или баг-репорт
- 

## Техническая информация

- [X] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [X] PR закончен и требует просмотра изменений.

## Медиа
<img width="134" height="167" alt="image" src="https://github.com/user-attachments/assets/9e5883ac-2b01-4878-bec4-fffa1dfad7d5" />

## Чейнджлог

:cl: Sipay
- tweak: Изменен урон вилкой с 5 уколов до 3 уколов.
