### PR TITLE
[REMOVE] УРАНКИ - ВСЕ

### DIFF
--- a/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml
@@ -1,6 +1,6 @@
 ﻿<DefaultWindow xmlns="https://spacestation14.io"
             xmlns:cc="clr-namespace:Content.Client.Administration.UI.Bwoink"
-            SetSize="900 500"
+            SetSize="1150 500"
             HeaderClass="windowHeaderAlert"
             TitleClass="windowTitleAlert"
             Title="{Loc 'bwoink-user-title'}" >

--- a/Content.Shared/ADT/Trigger/Components/RemoveEnsnareOnTriggerComponent.cs
+++ b/Content.Shared/ADT/Trigger/Components/RemoveEnsnareOnTriggerComponent.cs
@@ -1,0 +1,7 @@
+using Content.Shared.Trigger.Components.Effects;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.ADT.Trigger;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class RemoveEnsnareOnTriggerComponent : BaseXOnTriggerComponent;

--- a/Content.Shared/ADT/Trigger/Systems/RemoveEnsnareOnTriggerSystem.cs
+++ b/Content.Shared/ADT/Trigger/Systems/RemoveEnsnareOnTriggerSystem.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using Content.Shared.Ensnaring;
+using Content.Shared.Ensnaring.Components;
+using Content.Shared.Movement.Systems;
+using Content.Shared.Trigger;
+
+namespace Content.Shared.ADT.Trigger;
+
+public sealed class RemoveEnsnareOnTriggerSystem : XOnTriggerSystem<RemoveEnsnareOnTriggerComponent>
+{
+    [Dependency] private readonly SharedEnsnareableSystem _ensnareable = default!;
+    [Dependency] private readonly MovementSpeedModifierSystem _speedModifier = default!;
+
+    protected override void OnTrigger(Entity<RemoveEnsnareOnTriggerComponent> ent, EntityUid target, ref TriggerEvent args)
+    {
+        if (!TryComp<EnsnareableComponent>(target, out var ensnareable) || !ensnareable.IsEnsnared)
+            return;
+
+        var freed = false;
+        foreach (var ensnare in ensnareable.Container.ContainedEntities.ToArray())
+        {
+            if (!TryComp<EnsnaringComponent>(ensnare, out var ensnaring))
+                continue;
+
+            _ensnareable.ForceFree(ensnare, ensnaring);
+            freed = true;
+        }
+
+        if (freed)
+            _speedModifier.RefreshMovementSpeedModifiers(target);
+
+        args.Handled = true;
+    }
+}

--- a/Resources/Prototypes/ADT/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/ADT/Recipes/Lathes/Packs/security.yml
@@ -10,8 +10,8 @@
   id: ADTMagazineUraniumPack
   recipes:
   - ADTMagazineMagnumIncendiary
-  - ADTMagazineMagnumUranium
-  - ADTMagazineShotgunUranium
+  # - ADTMagazineMagnumUranium # ADT-Tweak - вырезан крафт урановых патронов, перенесён в AmmoTechFabUraniumStatic
+  # - ADTMagazineShotgunUranium # ADT-Tweak - вырезан крафт урановых патронов, перенесён в AmmoTechFabUraniumStatic
 
 # ADT-Tweak start - урановые патроны, вынесенные из веток исследований СБ, доступны только на патронфабе
 - type: latheRecipePack

--- a/Resources/Prototypes/ADT/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/ADT/Recipes/Lathes/Packs/security.yml
@@ -13,6 +13,26 @@
   - ADTMagazineMagnumUranium
   - ADTMagazineShotgunUranium
 
+# ADT-Tweak start - урановые патроны, вынесенные из веток исследований СБ, доступны только на патронфабе
+- type: latheRecipePack
+  id: AmmoTechFabUraniumStatic
+  recipes:
+  - MagazineRifleUranium
+  - MagazineBoxRifleUranium
+  - MagazineLightRifleUranium
+  - MagazineBoxLightRifleUranium
+  - MagazinePistolUranium
+  - MagazinePistolSubMachineGunUranium
+  - MagazineBoxPistolUranium
+  - SpeedLoaderMagnumUranium
+  - MagazineBoxMagnumUranium
+  - BoxShotgunUranium
+  - ADTMagazineMagnumUranium
+  - ADTMagazineShotgunUranium
+  - ADTMagazineBoxMagnumLesserUranium
+  - ADTSpeedLoaderMagnumLesserUranium
+# ADT-Tweak end
+
 
 - type: latheRecipePack
   id: ADTAttachmentPack

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -20,7 +20,7 @@
     RiotLaserShield: 2
     ADTClothingBeltJudo: 3 #ADT tweak
     ADTBookPTSD: 4 #ADT tweak
-    ADTWeaponTonfa: 2 #ADT tweak
+    # ADTWeaponTonfa: 2 #ADT tweak вырезана тонфа
     # RiotBulletShield: 2 ADT no nullet shield
     RadioHandheldSecurity: 5
     Bola: 5 #ADT tweak

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -154,6 +154,8 @@
   - type: TriggerOnActivateImplant
   - type: UncuffOnTrigger
     targetUser: true
+  - type: RemoveEnsnareOnTrigger # ADT-Tweak - имплант свободы снимает ещё и болы
+    targetUser: true
 
 - type: entity
   parent: BaseSubdermalImplant

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -535,6 +535,9 @@
       unlitRunningState: unlit-building
       staticPacks:
       - SecurityAmmoStatic
+      # ADT-Tweak start - урановые патроны, вырезанные из веток исследований СБ
+      - AmmoTechFabUraniumStatic
+      # ADT-Tweak end
     - type: EmagLatheRecipes
       emagStaticPacks:
       - SyndicateAmmoStatic

--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -108,32 +108,32 @@
   recipes:
   - BoxBeanbag
   - BoxShotgunIncendiary
-  - BoxShotgunUranium
+  # - BoxShotgunUranium # ADT-Tweak - вырезан крафт урановых патронов
   - BoxShellTranquilizer
   - MagazineBoxLightRifleIncendiary
-  - MagazineBoxLightRifleUranium
+  # - MagazineBoxLightRifleUranium # ADT-Tweak - вырезан крафт урановых патронов
   - MagazineBoxMagnumIncendiary
-  - MagazineBoxMagnumUranium
+  # - MagazineBoxMagnumUranium # ADT-Tweak - вырезан крафт урановых патронов
   - ADTMagazineBoxMagnumLesserIncendiary # ADT tweak
-  - ADTMagazineBoxMagnumLesserUranium # ADT tweak
+  # - ADTMagazineBoxMagnumLesserUranium # ADT tweak # ADT-Tweak - вырезан крафт урановых патронов
   - MagazineBoxPistolIncendiary
-  - MagazineBoxPistolUranium
+  # - MagazineBoxPistolUranium # ADT-Tweak - вырезан крафт урановых патронов
   - MagazineBoxRifleIncendiary
-  - MagazineBoxRifleUranium
+  # - MagazineBoxRifleUranium # ADT-Tweak - вырезан крафт урановых патронов
   - MagazineLightRifleIncendiary
-  - MagazineLightRifleUranium
+  # - MagazineLightRifleUranium # ADT-Tweak - вырезан крафт урановых патронов
   - MagazinePistolIncendiary
-  - MagazinePistolUranium
+  # - MagazinePistolUranium # ADT-Tweak - вырезан крафт урановых патронов
   - MagazinePistolSubMachineGunIncendiary
-  - MagazinePistolSubMachineGunUranium
+  # - MagazinePistolSubMachineGunUranium # ADT-Tweak - вырезан крафт урановых патронов
   - MagazineRifleIncendiary
-  - MagazineRifleUranium
+  # - MagazineRifleUranium # ADT-Tweak - вырезан крафт урановых патронов
   - MagazineShotgunBeanbag
   - MagazineShotgunIncendiary
   - SpeedLoaderMagnumIncendiary
-  - SpeedLoaderMagnumUranium
+  # - SpeedLoaderMagnumUranium # ADT-Tweak - вырезан крафт урановых патронов
   - ADTSpeedLoaderMagnumLesserIncendiary # ADT tweak
-  - ADTSpeedLoaderMagnumLesserUranium # ADT tweak
+  # - ADTSpeedLoaderMagnumLesserUranium # ADT tweak # ADT-Tweak - вырезан крафт урановых патронов
 
 - type: latheRecipePack
   id: SecurityWeapons

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -22,7 +22,7 @@
     state: incendiarydisplay
   discipline: Arsenal
   tier: 1
-  cost: 10000
+  cost: 23000 #ADT-tweak
   recipeUnlocks:
   - BoxShotgunIncendiary
   - MagazineRifleIncendiary
@@ -86,37 +86,35 @@
   - SalvageWeapons
   # ADT Research Console Rework end
 
-- type: technology
-  id: UraniumMunitions
-  name: research-technology-uranium-munitions
-  icon:
-    sprite: Objects/Materials/Sheets/other.rsi
-    state: uranium
-  discipline: Arsenal
-  tier: 1
-  cost: 7500
-  recipeUnlocks:
-  - MagazineRifleUranium
-  - MagazinePistolUranium
-  - MagazinePistolSubMachineGunUranium
-  - MagazineLightRifleUranium
-  - SpeedLoaderMagnumUranium
-  - MagazineBoxPistolUranium
-  - MagazineBoxMagnumUranium
-  # ADT-Tweak start
-  - ADTMagazineShotgunUranium
-  - ADTMagazineMagnumUranium
-  - ADTSpeedLoaderMagnumLesserUranium
-  - ADTMagazineBoxMagnumLesserUranium
-  # ADT-Tweak end
-  - MagazineBoxLightRifleUranium
-  - MagazineBoxRifleUranium
-  - BoxShotgunUranium
-  # ADT Research Console Rework start
-  position: 2,-2
-  requiredTech:
-  - DraconicMunitions
-  # ADT Research Console Rework end
+# ADT-Tweak start - вырезаны урановые патроны из исследований
+#- type: technology
+#  id: UraniumMunitions
+#  name: research-technology-uranium-munitions
+#  icon:
+#    sprite: Objects/Materials/Sheets/other.rsi
+#    state: uranium
+#  discipline: Arsenal
+#  tier: 1
+#  cost: 7500
+#  recipeUnlocks:
+#  - MagazineRifleUranium
+#  - MagazinePistolUranium
+#  - MagazinePistolSubMachineGunUranium
+#  - MagazineLightRifleUranium
+#  - SpeedLoaderMagnumUranium
+#  - MagazineBoxPistolUranium
+#  - MagazineBoxMagnumUranium
+#  - ADTMagazineShotgunUranium
+#  - ADTMagazineMagnumUranium
+#  - ADTSpeedLoaderMagnumLesserUranium
+#  - ADTMagazineBoxMagnumLesserUranium
+#  - MagazineBoxLightRifleUranium
+#  - MagazineBoxRifleUranium
+#  - BoxShotgunUranium
+#  position: 2,-2
+#  requiredTech:
+#  - DraconicMunitions
+# ADT-Tweak end
 
 - type: technology
   id: AdvancedRiotControl
@@ -164,7 +162,7 @@
   # ADT Research Console Rework start
   position: 2,-3
   requiredTech:
-  - UraniumMunitions
+  - DraconicMunitions # ADT-Tweak - было UraniumMunitions, вырезано из исследований
   # ADT Research Console Rework end
 
 # - type: technology #ADT_Tweak - электрорюкзак перенесен в технологию контроля беспорядков


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
Удалила исследования урановых патронов и добавила их в техфаб патронов, так же добавила триггер для снятия болы у импланта свободы
## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс.

В случае, если ваш pull request привязан к запросу из нашего discord сервера, используйте образец, представленный далее.

Ссылка на заказ, предложение или баг-репорт
- [Баг-репорт/Заказ/Предложение](ссылка)-->
Уранки были слишком имбовыми, работают по факту как ББшки, при этом изучаются в два клика. Оставила их ОБР в аплинке их + в патронфабе, так что полностью они не были удалены. Так же добавила снятие болы у импланты фридом
## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог

:cl: Minokaa
- remove: Урановые патроны из древа исследований.
- tweak: Имплант свободы снимает теперь еще и болы.
- remove: Тонфа из СБ теха.
- fix: Изменена ширина окна АХелпа.