### PR TITLE
remove Jug dispensers > add Canister dispenser

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
@@ -36,15 +36,15 @@
     containers:
       storagebase: !type:AllSelector
         children:
-        - id: DrinkAleBottleFullGrowler
-        - id: DrinkBeerGrowler
-        - id: DrinkCoffeeLiqueurBottleFull
-        - id: DrinkCognacBottleFull
-        - id: DrinkGinBottleFull
-        - id: DrinkMeadJug
-        - id: DrinkRumBottleFull
-        - id: DrinkTequilaBottleFull
-        - id: DrinkVermouthBottleFull
-        - id: DrinkVodkaBottleFull
-        - id: DrinkWhiskeyBottleFull
-        - id: DrinkWineBottleFull
+        - ADTDrinkAleCanister #ADT_Tweak, бутылки заменены на канистры
+        - ADTDrinkBeerCanister
+        - ADTDrinkCoffeeLiqueurCanister
+        - ADTDrinkCognacCanister
+        - ADTDrinkGinCanister
+        - ADTDrinkMeadCanister
+        - ADTDrinkRumCanister
+        - ADTDrinkTequilaCanister
+        - ADTDrinkVermouthCanister
+        - ADTDrinkVodkaCanister
+        - ADTDrinkWhiskeyCanister
+        - ADTDrinkWineCanister #ADT_Tweak, бутылки заменены на канистры

--- a/Resources/Prototypes/Entities/Structures/Dispensers/chem.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/chem.yml
@@ -59,23 +59,23 @@
     containers:
       storagebase: !type:AllSelector
         children:
-        - id: JugAluminium
-        - id: JugCarbon
-        - id: JugChlorine
-        - id: JugCopper
-        - id: JugEthanol
-        - id: JugFluorine
-        - id: JugSugar
-        - id: JugHydrogen
-        - id: JugIodine
-        - id: JugIron
-        - id: JugLithium
-        - id: JugMercury
-        - id: JugNitrogen
-        - id: JugOxygen
-        - id: JugPhosphorus
-        - id: JugPotassium
-        - id: JugRadium
-        - id: JugSilicon
-        - id: JugSodium
-        - id: JugSulfur
+        - ADTReagentCanisterAluminium #ADT_Tweak, бутылки заменены на канистры
+        - ADTReagentCanisterCarbon
+        - ADTReagentCanisterChlorine
+        - ADTReagentCanisterCopper
+        - ADTReagentCanisterEthanol
+        - ADTReagentCanisterFluorine
+        - ADTReagentCanisterSugar
+        - ADTReagentCanisterHydrogen
+        - ADTReagentCanisterIodine
+        - ADTReagentCanisterIron
+        - ADTReagentCanisterLithium
+        - ADTReagentCanisterMercury
+        - ADTReagentCanisterNitrogen
+        - ADTReagentCanisterOxygen
+        - ADTReagentCanisterPhosphorus
+        - ADTReagentCanisterPotassium
+        - ADTReagentCanisterRadium
+        - ADTReagentCanisterSilicon
+        - ADTReagentCanisterSodium
+        - ADTReagentCanisterSulfur #ADT_Tweak, бутылки заменены на канистры

--- a/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
@@ -34,22 +34,22 @@
     containers:
       storagebase: !type:AllSelector
         children:
-        - id: DrinkCoconutWaterJug
-        - id: DrinkCoffeeJug
-        - id: DrinkColaBottleFull
-        - id: DrinkCreamCartonXL
-        - id: DrinkDrGibbJug
-        - id: DrinkEnergyDrinkJug
-        - id: DrinkGreenTeaJug
-        - id: DrinkIceJug
-        - id: DrinkJuiceLimeCartonXL
-        - id: DrinkJuiceOrangeCartonXL
-        - id: DrinkLemonLimeJug
-        - id: DrinkRootBeerJug
-        - id: DrinkSodaWaterBottleFull
-        - id: DrinkSpaceMountainWindBottleFull
-        - id: DrinkSpaceUpBottleFull
-        - id: DrinkSugarJug
-        - id: DrinkTeaJug
-        - id: DrinkTonicWaterBottleFull
-        - id: DrinkWaterMelonJuiceJug
+        - ADTDrinkCoconutWaterCanister #ADT_Tweak, бутылки заменены на канистры
+        - ADTDrinkCoffeeCanister
+        - ADTDrinkColaCanister
+        - ADTDrinkCreamCanister
+        - ADTDrinkDrGibbCanister
+        - ADTDrinkEnergyDrinkCanister
+        - ADTDrinkGreenTeaCanister
+        - ADTDrinkIceCanister
+        - ADTDrinkJuiceLimeCanister
+        - ADTDrinkJuiceOrangeCanister
+        - ADTDrinkLemonLimeCanister
+        - ADTDrinkRootBeerCanister
+        - ADTDrinkSodaWaterCanister
+        - ADTDrinkSpaceMountainWindCanister
+        - ADTDrinkSpaceUpCanister
+        - ADTDrinkSugarCanister
+        - ADTDrinkTeaCanister
+        - ADTDrinkTonicWaterCanister
+        - ADTDrinkJuiceWatermelonCanister #ADT_Tweak, бутылки заменены на канистры


### PR DESCRIPTION
## Описание PR
В раздатчиках химикатов, алкоголя и безалкогольных напитков ёмкости для реагентов заменены на канистры объёмом 600 единиц.

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- tweak: В химических раздатчиках заменена бутылка, на канистру вместимостью 600 единиц.
- tweak: В раздатчиках алкоголя и газировки заменена бутылка, на канистру 600 единиц.