### PR TITLE
 skip owner pointing

### DIFF
--- a/Content.Server/ADT/Pointing/PointingSystem.Chat.cs
+++ b/Content.Server/ADT/Pointing/PointingSystem.Chat.cs
@@ -29,8 +29,8 @@ internal sealed partial class PointingSystem
             return;
 
         var viewerList = viewers
-            .Distinct()
             .Append(sourceSession)
+            .Distinct()
             .Where(v => _adtNetConfig.GetClientCVar(v.Channel, ADTCCVars.EnableChatPointingIcons))
             .ToList();
 

--- a/Resources/Locale/ru-RU/entity-systems/pointing/pointing-system.ftl
+++ b/Resources/Locale/ru-RU/entity-systems/pointing/pointing-system.ftl
@@ -1,20 +1,16 @@
 ## PointingSystem
 
 pointing-system-try-point-cannot-reach = Вы не можете туда достать!
-pointing-system-point-at-self = Вы указываете на себя.
-pointing-system-point-at-other = Вы указываете на { $other }.
 ## ADT-Tweak start
-pointing-system-point-at-self-others = { CAPITALIZE($otherName) } указывает на себя.
+pointing-system-point-at-self = Вы указываете на себя
+pointing-system-point-at-other = Вы указываете на { $other }
+pointing-system-point-at-self-others = { CAPITALIZE($otherName) } указывает на себя
 pointing-system-point-at-other-others = { CAPITALIZE($otherName) } указывает на { $other }
 pointing-system-point-at-you-other = { CAPITALIZE($otherName) } указывает на вас
-## ADT-Tweak end
-pointing-system-point-at-tile = Вы указываете на { $tileName }.
-pointing-system-point-in-own-inventory-self = Вы указываете на свой { $item }.
-## ADT-Tweak start
+pointing-system-point-at-tile = Вы указываете на { $tileName }
+pointing-system-point-in-own-inventory-self = Вы указываете на свой { $item }
 pointing-system-point-in-own-inventory-others = { CAPITALIZE($pointer) } указывает на свой { $item }
-## ADT-Tweak end
-pointing-system-point-in-other-inventory-self = Вы указываете на { $item } у { $wearer }.
-## ADT-Tweak start
+pointing-system-point-in-other-inventory-self = Вы указываете на { $item } у { $wearer }
 pointing-system-point-in-other-inventory-target = { CAPITALIZE($pointer) } указывает на ваш { $item }
 pointing-system-point-in-other-inventory-others = { CAPITALIZE($pointer) } указывает на { $item } у { $wearer }
 pointing-system-other-point-at-tile = { CAPITALIZE($otherName) } указывает на { $tileName }


### PR DESCRIPTION
## Описание PR
Поменял условие - чтоб у отправителя не дублировался pointing

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- fix: `Показывает на` - больше не дублируется у отправителя
