### PR TITLE
fix vulpkanin.yml

### DIFF
--- a/Resources/Prototypes/Body/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Body/Species/vulpkanin.yml
@@ -222,9 +222,13 @@
     tallscale: 1
     short: true
     shortscale: 0.9
-  - type: Tag
-    tags:
-    - ADTDogEmotes
+   - type: Tag
+     tags:
+     - CanPilot
+     - FootstepSound
+     - DoorBumpOpener
+     - AnomalyHost
+     - ADTDogEmotes
   # ADT-Tweak: End
 
 

--- a/Resources/Prototypes/Body/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Body/Species/vulpkanin.yml
@@ -222,13 +222,13 @@
     tallscale: 1
     short: true
     shortscale: 0.9
-   - type: Tag
-     tags:
-     - CanPilot
-     - FootstepSound
-     - DoorBumpOpener
-     - AnomalyHost
-     - ADTDogEmotes
+  - type: Tag
+    tags:
+    - CanPilot
+    - FootstepSound
+    - DoorBumpOpener
+    - AnomalyHost
+    - ADTDogEmotes
   # ADT-Tweak: End
 
 


### PR DESCRIPTION
## Описание PR
Вернул тэги вульпам, т.к при обновление они утерялись.

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- fix: Вульпы научились управлять шаттлом, открывать шлюзы касанием, быть хостом для аномалий, а так же производить звук при ходьбе.
