### PR TITLE
[TWEAK] Флейты и замены слов

### DIFF
--- a/Resources/Locale/ru-RU/ADT/speech/speech-adt-chatsan.ftl
+++ b/Resources/Locale/ru-RU/ADT/speech/speech-adt-chatsan.ftl
@@ -96,5 +96,14 @@ accent-adt_chatsanitize-words-27-1 = чек
 accent-adt_chatsanitize-words-27-2 = чекай
 accent-adt_chatsanitize-replace-27 = смотри
 
-accent-adt_chatsanitize-words-28 = idk
-accent-adt_chatsanitize-replace-28 = не знаю
+accent-adt_chatsanitize-words-28 = вайбово
+accent-adt_chatsanitize-replace-28 = атмосферно
+
+accent-adt_chatsanitize-words-29 = фрик
+accent-adt_chatsanitize-replace-29 = чудак
+
+accent-adt_chatsanitize-words-30 = фрики
+accent-adt_chatsanitize-replace-30 = чудаки
+
+accent-adt_chatsanitize-words-31 = прив
+accent-adt_chatsanitize-replace-31 = здравствуйте

--- a/Resources/Locale/ru-RU/ADT/speech/speech-adt-chatsan.ftl
+++ b/Resources/Locale/ru-RU/ADT/speech/speech-adt-chatsan.ftl
@@ -96,14 +96,17 @@ accent-adt_chatsanitize-words-27-1 = чек
 accent-adt_chatsanitize-words-27-2 = чекай
 accent-adt_chatsanitize-replace-27 = смотри
 
-accent-adt_chatsanitize-words-28 = вайбово
-accent-adt_chatsanitize-replace-28 = атмосферно
+accent-adt_chatsanitize-words-28 = idk
+accent-adt_chatsanitize-replace-28 = не знаю
 
-accent-adt_chatsanitize-words-29 = фрик
-accent-adt_chatsanitize-replace-29 = чудак
+accent-adt_chatsanitize-words-29 = вайбово
+accent-adt_chatsanitize-replace-29 = атмосферно
 
-accent-adt_chatsanitize-words-30 = фрики
-accent-adt_chatsanitize-replace-30 = чудаки
+accent-adt_chatsanitize-words-30 = фрик
+accent-adt_chatsanitize-replace-30 = чудак
 
-accent-adt_chatsanitize-words-31 = прив
-accent-adt_chatsanitize-replace-31 = здравствуйте
+accent-adt_chatsanitize-words-31 = фрики
+accent-adt_chatsanitize-replace-31 = чудаки
+
+accent-adt_chatsanitize-words-32 = прив
+accent-adt_chatsanitize-replace-32 = здравствуйте

--- a/Resources/Prototypes/ADT/Accents/word_replacements.yml
+++ b/Resources/Prototypes/ADT/Accents/word_replacements.yml
@@ -116,3 +116,6 @@
     accent-adt_chatsanitize-words-27-1: accent-adt_chatsanitize-replace-27
     accent-adt_chatsanitize-words-27-2: accent-adt_chatsanitize-replace-27
     accent-adt_chatsanitize-words-28: accent-adt_chatsanitize-replace-28
+    accent-adt_chatsanitize-words-29: accent-adt_chatsanitize-replace-29
+    accent-adt_chatsanitize-words-30: accent-adt_chatsanitize-replace-30
+    accent-adt_chatsanitize-words-31: accent-adt_chatsanitize-replace-31

--- a/Resources/Prototypes/ADT/Accents/word_replacements.yml
+++ b/Resources/Prototypes/ADT/Accents/word_replacements.yml
@@ -119,3 +119,4 @@
     accent-adt_chatsanitize-words-29: accent-adt_chatsanitize-replace-29
     accent-adt_chatsanitize-words-30: accent-adt_chatsanitize-replace-30
     accent-adt_chatsanitize-words-31: accent-adt_chatsanitize-replace-31
+    accent-adt_chatsanitize-words-32: accent-adt_chatsanitize-replace-32

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_wind.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_wind.yml
@@ -57,6 +57,11 @@
   name: clarinet
   description: Skweedward tintacklays.
   components:
+  #ADT-Tweak-Start
+  - type: Item
+    size: Small
+    storedRotation: -45
+  #ADT-Tweak-End
   - type: Instrument
     program: 71
   - type: Sprite
@@ -68,6 +73,11 @@
   name: flute
   description: Reaching new heights of being horrifyingly shrill.
   components:
+  #ADT-Tweak-Start
+  - type: Item
+    size: Small
+    storedRotation: -45
+  #ADT-Tweak-End
   - type: Instrument
     program: 73
   - type: Sprite
@@ -79,6 +89,11 @@
   name: recorder
   description: Comes in various colors of fashionable plastic!
   components:
+  #ADT-Tweak-Start
+  - type: Item
+    size: Small
+    storedRotation: -45
+  #ADT-Tweak-End
   - type: Instrument
     program: 74
   - type: Sprite


### PR DESCRIPTION
## Описание PR
- Флейта, блокфлейта и кларнет теперь занимают в два раза меньше места в хранилищах и помещаются в карманы.
- Удалены лишние замены слов и добавлено пару новых

## Почему / Баланс
- Флейты не настолько большие чтобы занимать 2x2 места

## Медиа
<img width="224" height="128" alt="image" src="https://github.com/user-attachments/assets/84731f16-ed4e-4bf4-9425-823d4b23e24e" />

## Чейнджлог

:cl: Kerfus
- tweak: Изменена флейта, блокфлейта и кларнет - теперь они занимают в 2 раза меньше места и помещаются в карман.
