### PR TITLE
fix droPod WarDeclared

### DIFF
--- a/Content.Server/ADT/Shuttles/DropPodConsoleSystem.cs
+++ b/Content.Server/ADT/Shuttles/DropPodConsoleSystem.cs
@@ -344,7 +344,7 @@ public sealed class DropPodConsoleSystem : EntitySystem
         var elapsed = _timing.CurTime - comp.LastLaunchTime;
         var cooldownReady = onDropPod && !alreadyLaunched && elapsed >= comp.Cooldown;
 
-        var isAtWar = false;
+        var isAtWar = comp.WarDeclaredTime != null;
         var warCooldownRemaining = 0;
         var warNukieArriveDelay = TimeSpan.Zero;
 
@@ -357,14 +357,13 @@ public sealed class DropPodConsoleSystem : EntitySystem
                 warNukieArriveDelay = nukeops.WarNukieArriveDelay;
                 if (warTime < nukeops.WarNukieArriveDelay)
                 {
-                    isAtWar = true;
                     warCooldownRemaining = (int)Math.Ceiling((nukeops.WarNukieArriveDelay - warTime).TotalSeconds);
                 }
                 break;
             }
         }
 
-        comp.WarDeclaredTime = isAtWar ? _timing.CurTime : comp.WarDeclaredTime;
+        comp.WarDeclaredTime = comp.WarDeclaredTime ?? _timing.CurTime;
 
         var tcCount = GetTcInSlot(uid);
         var currentCost = isAtWar ? comp.WarCost : comp.PeaceCost;


### PR DESCRIPTION
## Описание PR
Исправил дроп-под, теперь по истечении таймера в 15 минут при войне, сумма остаётся в состояние WAR а не сбрасывается.

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- fix: Дроп-под в случае войны больше не сбрасывает требуемое ТК по истечению таймера, сумма остаётся такой же - какой она и была назначена при объявлении войны.