### PR TITLE
fix heretic

### DIFF
--- a/Content.Server/ADT/GameTicking/Rules/HereticRuleSystem.cs
+++ b/Content.Server/ADT/GameTicking/Rules/HereticRuleSystem.cs
@@ -64,7 +64,7 @@ public sealed partial class HereticRuleSystem : GameRuleSystem<HereticRuleCompon
         if (grid == null)
             return;
 
-        for (int i = 0; i < _rand.Next(3, 5); i++)
+        for (int i = 0; i < _rand.Next(6, 12); i++)
             if (TryFindRandomTile(out var _, out var _, out var _, out var coords))
                 Spawn("EldritchInfluence", coords);
     }

--- a/Content.Server/ADT/GameTicking/Rules/HereticRuleSystem.cs
+++ b/Content.Server/ADT/GameTicking/Rules/HereticRuleSystem.cs
@@ -64,7 +64,7 @@ public sealed partial class HereticRuleSystem : GameRuleSystem<HereticRuleCompon
         if (grid == null)
             return;
 
-        for (int i = 0; i < _rand.Next(6, 12); i++)
+        for (int i = 0; i < _rand.Next(6, 8); i++)
             if (TryFindRandomTile(out var _, out var _, out var _, out var coords))
                 Spawn("EldritchInfluence", coords);
     }

--- a/Resources/Prototypes/ADT/Heretic/Entities/Structures/Specific/Heretic/eldritch_influence.yml
+++ b/Resources/Prototypes/ADT/Heretic/Entities/Structures/Specific/Heretic/eldritch_influence.yml
@@ -12,7 +12,7 @@
     state: icon
   - type: Clickable
   - type: Visibility
-    layer: 64
+    layer: 128
 
 - type: entity
   id: EldritchInfluenceIntermediate


### PR DESCRIPTION
## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- tweak: Спавн разломов увеличился, ранее было 3-5, теперь он повышен до 6-8.
- fix: Еретик теперь видит собственные разломы.