### PR TITLE
remove MessyDrinker vulp

### DIFF
--- a/Resources/Prototypes/Body/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Body/Species/vulpkanin.yml
@@ -153,8 +153,6 @@
         color: "#ccac1f"
       Burn:
         sprite: Mobs/Effects/burn_damage.rsi
-  - type: MessyDrinker
-    spillChance: 0.33
   - type: Speech
     speechSounds: Vulpkanin
     speechVerb: Vulpkanin


### PR DESCRIPTION
## Описание PR
Вульпы научились пить не проливая

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог
:cl: CrimeMoot
- tweak: Вульпы научились пить, не разливая содержимость.
