### PR TITLE
изоляция инженерных скафандров

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -23,6 +23,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.5
   - type: Armor
+  - type: Insulated
     modifiers:
       coefficients:
         Blunt: 0.7 # ADT-Tweak 0.9 -> 0.7
@@ -61,6 +62,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.6 # ADT-Tweak 0.5 -> 0.6
   - type: Armor
+  - type: Insulated
     modifiers:
       coefficients:
   # ADT-Tweak-Start
@@ -434,6 +436,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.5 # ADT-Tweak 0.2 -> 0.5
   - type: Armor
+  - type: Insulated
     modifiers:
       coefficients:
         Blunt: 0.8
@@ -662,7 +665,7 @@
     price: 5000
   # ADT-Tweak start
   - type: DNALocker
-  - type: ClothingGrantComponent 
+  - type: ClothingGrantComponent
     component:
     - type: SupermatterImmune
   - type: SupermatterImmune
@@ -1052,6 +1055,7 @@
     clothingPrototype: ClothingHeadHelmetHardsuitERTEngineer
   - type: FireProtection
     reduction: 0.8
+  - type: Insulated
   - type: DNALocker # ADT-Tweak костыль
     enabled: false
   # ADT-Tweak-start


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
К скафандру инженера, инж ОБР, атмоса и СИ был добавлен компонент изоляции
## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс. --!>
Инженерные скафандры по логике должны иметь изоляционное свойство для защиты носителя при работе.
В случае, если ваш pull request привязан к запросу из нашего discord сервера, используйте образец, представленный далее.

Ссылка на заказ, предложение или баг-репорт
<!-- [Баг-репорт/Заказ/Предложение](ссылка)--> https://discord.com/channels/901772674865455115/1532161357045039265

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [X] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [X] PR закончен и требует просмотра изменений.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется--> https://discord.com/channels/901772674865455115/1532161357045039265/1532161357045039265

## Чейнджлог


:cl: (SosiskaKiller456)
- add: Добавлено изоляционное свойство инженерных скафандров


