### PR TITLE
fix and tweak ghosUI

### DIFF
--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
@@ -187,7 +187,15 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
                 AlignContent = FlexBox.FlexAlignContent.SpaceBetween
             };
 
-            foreach (var (subCategory, warps) in sortedWarps)
+            var sortedSubCategories = sortedWarps.OrderBy(kvp =>
+            {
+                var warps = kvp.Value;
+                if (warps == null || warps.Count == 0)
+                    return int.MaxValue;
+                return warps.Min(w => w.DepartmentWeight);
+            }).ToList();
+
+            foreach (var (subCategory, warps) in sortedSubCategories)
             {
                 if(warps.Count == 0)
                     continue;

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
@@ -27,8 +27,6 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
         private Dictionary<string, List<GhostWarp>> _deadOther = [];
         private Dictionary<string, List<GhostWarp>> _leftOther = [];
 
-        private Dictionary<string, List<GhostWarp>> _aliveAntags = [];
-        private Dictionary<string, List<GhostWarp>> _deadAntags = []; // Добавляем отдельный словарь для мертвых антагов
         private Dictionary<string, List<GhostWarp>> _places = [];
         private Dictionary<string, List<GhostWarp>> _other = [];
 
@@ -61,8 +59,6 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
             _leftPlayers.Clear();
             _deadOther.Clear();
             _leftOther.Clear();
-            _aliveAntags.Clear();
-            _deadAntags.Clear(); // Очищаем новый словарь
             _places.Clear();
             _other.Clear();
 
@@ -83,10 +79,6 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
                 FilterLocalWarps(_alivePlayers, warp, WarpGroup.AliveDepartment);
                 FilterLocalWarps(_deadPlayers, warp, WarpGroup.DeadDepartment);
                 FilterLocalWarps(_leftPlayers, warp, WarpGroup.Left);
-
-                FilterLocalWarps(_aliveAntags, warp, WarpGroup.AliveAntag);
-                FilterLocalWarps(_deadAntags, warp, WarpGroup.DeadAntag); // Используем отдельный словарь для мертвых антагов
-
                 FilterLocalWarps(_ghostPlayers, warp, WarpGroup.Ghost);
                 FilterLocalWarps(_other, warp, WarpGroup.AliveOther);
                 FilterLocalWarps(_deadOther, warp, WarpGroup.DeadOther);
@@ -127,12 +119,12 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
         private void AddButtons()
         {
             // Добавляем проверку на наличие данных
-            var hasData = _aliveAntags.Count > 0 || _alivePlayers.Count > 0 || 
+            var hasData = _alivePlayers.Count > 0 || 
                           _ghostPlayers.Count > 0 || _leftPlayers.Count > 0 || 
-                          _deadPlayers.Count > 0 || _deadAntags.Count > 0 ||
+                          _deadPlayers.Count > 0 ||
                           _places.Count > 0 || _other.Count > 0 ||
                           _deadOther.Count > 0 || _leftOther.Count > 0;
-            
+
             if (!hasData)
             {
                 // Добавляем сообщение, если нет данных
@@ -149,8 +141,6 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
             }
 
             // ADT-TWEAK START
-            AddButtons(_aliveAntags, "ghost-teleport-menu-antagonists-label");
-            AddButtons(_deadAntags, "ghost-teleport-menu-dead-antagonists-label");
             AddButtons(_alivePlayers, "ghost-teleport-menu-alive-label");
             AddButtons(_ghostPlayers, "ghost-teleport-menu-ghosts-label");
             AddButtons(_leftPlayers, "ghost-teleport-menu-left-label", true);

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -317,20 +317,18 @@ namespace Content.Server.Ghost
                 return;
             }
 
-            // WWDP EDIT START
             if (IsHiddenFromGhostWarps(target) || !IsValidWarpTarget(target))
             {
                 Log.Warning($"User {args.SenderSession.Name} tried to warp to an invalid/hidden target: {ToPrettyString(target)}");
                 return;
             }
-            // WWDP EDIT END
 
             WarpTo(attached, target);
         }
 
         private void OnGhostnadoRequest(GhostnadoRequestEvent msg, EntitySessionEventArgs args)
         {
-            if (args.SenderSession.AttachedEntity is not { Valid: true } uid // WD EDIT
+            if (args.SenderSession.AttachedEntity is not { Valid: true } uid
                 || !_ghostQuery.HasComp(uid))
             {
                 Log.Warning($"User {args.SenderSession.Name} tried to ghostnado without being a ghost.");
@@ -374,6 +372,9 @@ namespace Content.Server.Ghost
                     continue;
 
                 if (!IsValidWarpTarget(entity))
+                    continue;
+
+                if (TryComp<GhostComponent>(entity, out var ghostComp) && ghostComp.CanGhostInteract)
                     continue;
 
                 if (TryComp<RoleCacheComponent>(entity, out var roleCacheComponent))

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -392,17 +392,6 @@ namespace Content.Server.Ghost
                         addedWarp = true;
                     }
 
-                    if (roleCacheComponent.IsAntag &&
-                        _prototypeManager.TryIndex(roleCacheComponent.LastAntagPrototype, out var antagPrototype))
-                    {
-                        var antagName = Loc.GetString(antagPrototype.Name);
-                        var warp = SetupWarp(entity, mindContainer, antagName, AntagonistButtonColor, null);
-                        warp.Group |= WarpGroup.Antag;
-
-                        warps.Add(warp);
-                        addedWarp = true;
-                    }
-
                     if (!addedWarp)
                     {
                         var warp = SetupWarp(entity, mindContainer, 

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -384,7 +384,7 @@ namespace Content.Server.Ghost
                         _jobs.TryGetDepartment(jobPrototype.ID, out var departmentPrototype))
                     {
                         var departmentName = Loc.GetString($"department-{departmentPrototype.ID}");
-                        var jobName = Loc.GetString($"job-name-{jobPrototype.ID.ToLower()}");
+                        var jobName = Loc.GetString(jobPrototype.Name);
                         var warp = SetupWarp(entity, mindContainer, departmentName, departmentPrototype.Color, jobName, departmentPrototype.Weight);
                         warp.Group |= WarpGroup.Department;
 

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -385,7 +385,7 @@ namespace Content.Server.Ghost
                     {
                         var departmentName = Loc.GetString($"department-{departmentPrototype.ID}");
                         var jobName = Loc.GetString($"job-name-{jobPrototype.ID.ToLower()}");
-                        var warp = SetupWarp(entity, mindContainer, departmentName, departmentPrototype.Color, jobName);
+                        var warp = SetupWarp(entity, mindContainer, departmentName, departmentPrototype.Color, jobName, departmentPrototype.Weight);
                         warp.Group |= WarpGroup.Department;
 
                         warps.Add(warp);
@@ -427,7 +427,7 @@ namespace Content.Server.Ghost
             return warps;
         }
 
-        private GhostWarp SetupWarp(EntityUid entity, MindContainerComponent mindContainer, string subGroup, Color? color, string? description)
+        private GhostWarp SetupWarp(EntityUid entity, MindContainerComponent mindContainer, string subGroup, Color? color, string? description, int departmentWeight = 0)
         {
             var hasAnyMind = mindContainer.Mind != null;
             var isDead = _mobState.IsDead(entity);
@@ -453,7 +453,7 @@ namespace Content.Server.Ghost
             if (string.IsNullOrEmpty(description))
                 description = metadata.EntityDescription;
 
-            var warp = new GhostWarp(GetNetEntity(entity), metadata.EntityName, subGroup, description, color);
+            var warp = new GhostWarp(GetNetEntity(entity), metadata.EntityName, subGroup, description, color, departmentWeight);
 
             if(isLeft)
                 warp.Group |= WarpGroup.Left;

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -138,30 +138,33 @@ namespace Content.Shared.Ghost
      /// An player body a ghost can warp to.
      /// This is used as part of <see cref="GhostWarpsResponseEvent"/>
      /// </summary>
-     [Serializable, NetSerializable]
-     public struct GhostWarp
-     {
-         public GhostWarp(NetEntity entity, string displayName, string subGroup, string description, Color? color)
-         {
-             Entity = entity;
-             DisplayName = displayName;
-             SubGroup = subGroup;
-             Color = color;
-             Description = description;
-         }
+      [Serializable, NetSerializable]
+      public struct GhostWarp
+      {
+          public GhostWarp(NetEntity entity, string displayName, string subGroup, string description, Color? color, int departmentWeight = 0)
+          {
+              Entity = entity;
+              DisplayName = displayName;
+              SubGroup = subGroup;
+              Color = color;
+              Description = description;
+              DepartmentWeight = departmentWeight;
+          }
 
-         public NetEntity Entity { get; }
+          public NetEntity Entity { get; }
 
-         public string DisplayName { get; }
-         public string SubGroup { get; }
-         public string Description { get; }
+          public string DisplayName { get; }
+          public string SubGroup { get; }
+          public string Description { get; }
 
-         public Color? Color { get; }
+          public Color? Color { get; }
 
-         public WarpGroup Group { get; set; } = WarpGroup.Location;
+          public int DepartmentWeight { get; } // ADT-TWEAK: weight for department sorting
 
-         public bool HasMind { get; set; } = true; // ADT-Tweak
-     }
+          public WarpGroup Group { get; set; } = WarpGroup.Location;
+
+          public bool HasMind { get; set; } = true; // ADT-Tweak
+      }
 
      [Serializable, NetSerializable, Flags]
      public enum WarpGroup

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -2,7 +2,7 @@
   id: Cargo
   name: department-Cargo
   description: department-Cargo-description
-  color: "#A46106"
+  color: "#8B5005" # ADT-Tweak
   weight: -5 # ADT EDIT
   roles:
   - CargoTechnician
@@ -14,7 +14,7 @@
   id: Civilian
   name: department-Civilian
   description: department-Civilian-description
-  color: "#9FED58"
+  color: "#8AD44A" # ADT-Tweak
   weight: -4 # ADT EDIT
   roles:
   - Bartender
@@ -85,7 +85,7 @@
   id: Engineering
   name: department-Engineering
   description: department-Engineering-description
-  color: "#EFB341"
+  color: "#D99A30" # ADT-Tweak
   weight: -6 # ADT EDIT
   roles:
   - AtmosphericTechnician
@@ -98,7 +98,7 @@
   id: Medical
   name: department-Medical
   description: department-Medical-description
-  color: "#52B4E9"
+  color: "#3FA0D6" # ADT-Tweak
   weight: -7 # ADT EDIT
   roles:
   - Chemist
@@ -116,7 +116,7 @@
   id: Security
   name: department-Security
   description: department-Security-description
-  color: "#DE3A3A"
+  color: "#C42D2D" # ADT-Tweak
   weight: -3 # ADT EDIT
   roles:
   - HeadOfSecurity
@@ -135,7 +135,7 @@
   id: Science
   name: department-Science
   description: department-Science-description
-  color: "#D381C9"
+  color: "#B86EAA" # ADT-Tweak
   weight: -8 # ADT EDIT
   roles:
   - ResearchDirector
@@ -150,7 +150,7 @@
   id: Silicon
   name: department-Silicon
   description: department-Silicon-description
-  color: "#D381C9"
+  color: "#B86EAA" # ADT-Tweak
   weight: -9 # ADT EDIT
   roles:
   - Borg


### PR DESCRIPTION
## Описание PR
Поменяй приоритеты показа GhostUI, теперь показывает по силе департамента.
Изменил цвет некоторых ярких отделов чтоб глазам не было плохо. Убрал показ антагонистов по просьбе админов. Aghost скрыт из GhostUI по просьбе админов.

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- tweak: Цвета отделов стали не такие токсичные
- tweak: Призраков администраторов больше нельзя найти в телепорт призраков
- tweak: Антагонисты больше не указаны в телепорте призраков
- tweak: Порядок отображение в телепорте призраков, теперь идут сначала ЦК роли, потом кмд и так по списку.
