### PR TITLE
add ChatVisibilityCheck

### DIFF
--- a/Content.Server/ADT/Bark/Systems/SpeechBarksSystem.cs
+++ b/Content.Server/ADT/Bark/Systems/SpeechBarksSystem.cs
@@ -8,6 +8,8 @@ using Robust.Shared.Player;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Content.Shared.Chat;
+using Content.Server.Examine;
+using Content.Shared.Ghost;
 
 namespace Content.Server.ADT.SpeechBarks;
 
@@ -18,6 +20,7 @@ public sealed class SpeechBarksSystem : EntitySystem
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly MindSystem _mind = default!;
     [Dependency] private readonly ISharedPlayerManager _player = default!;
+    [Dependency] private readonly ExamineSystem _examineSystem = default!;
     private bool _isEnabled = false;
 
     public override void Initialize()
@@ -44,6 +47,9 @@ public sealed class SpeechBarksSystem : EntitySystem
         foreach (var ent in _lookup.GetEntitiesInRange(Transform(uid).Coordinates, 10f))
         {
             if (!_mind.TryGetMind(ent, out _, out var mind) || mind.UserId == null || !_player.TryGetSessionById(mind.UserId, out var session))
+                continue;
+
+            if (!HasComp<GhostHearingComponent>(ent) && !_examineSystem.InRangeUnOccluded(ent, uid, 10f))
                 continue;
 
             RaiseNetworkEvent(new PlaySpeechBarksEvent(

--- a/Content.Server/ADT/Chat/ChatSystem.ADT.cs
+++ b/Content.Server/ADT/Chat/ChatSystem.ADT.cs
@@ -85,6 +85,9 @@ public sealed partial class ChatSystem
                 continue;
             listener = session.AttachedEntity.Value;
 
+            if (!data.Observer && !HasLineOfSight(listener, source, WhisperMuffledRange))
+                continue;
+
             bool condition = true;
             foreach (var item in lang.Conditions.Where(x => x.RaiseOnListener))
             {

--- a/Content.Server/ADT/Chat/ChatVisibilityCheckSystem.cs
+++ b/Content.Server/ADT/Chat/ChatVisibilityCheckSystem.cs
@@ -1,0 +1,53 @@
+using Content.Server.Examine;
+
+namespace Content.Server.ADT.Chat;
+public sealed class ChatVisibilityCheckSystem : EntitySystem
+{
+    [Dependency] private readonly ExamineSystem _examineSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ChatVisibilityCheckEvent>(HandleVisibilityCheck);
+    }
+
+    private void HandleVisibilityCheck(ref ChatVisibilityCheckEvent ev)
+    {
+        if (ev.Target is null)
+        {
+            ev.Visible = false;
+            return;
+        }
+
+        if (ev.Source == ev.Target.Value)
+            return;
+
+        if (ev.IgnoreWalls)
+        {
+            ev.Visible = InRange(ev.Source, ev.Target.Value, ev.Range);
+            return;
+        }
+
+        if (!_examineSystem.InRangeUnOccluded(ev.Source, ev.Target.Value, ev.Range))
+        {
+            ev.Visible = false;
+            return;
+        }
+    }
+
+    private bool InRange(EntityUid origin, EntityUid other, float range)
+    {
+        if (Deleted(origin) || Deleted(other))
+            return false;
+
+        var xformOrigin = Transform(origin);
+        var xformOther = Transform(other);
+
+        if (xformOrigin.MapID != xformOther.MapID)
+            return false;
+
+        return xformOrigin.Coordinates.TryDistance(EntityManager, xformOther.Coordinates, out var distance)
+               && distance <= range;
+    }
+}
+

--- a/Content.Server/ADT/Chat/Events/ChatVisibilityCheckEvent.cs
+++ b/Content.Server/ADT/Chat/Events/ChatVisibilityCheckEvent.cs
@@ -1,0 +1,21 @@
+namespace Content.Server.ADT.Chat;
+
+[ByRefEvent]
+public struct ChatVisibilityCheckEvent(EntityUid source, EntityUid? target, float range, bool ignoreWalls = false)
+{
+    [DataField]
+    public EntityUid Source { get; } = source;
+
+    [DataField]
+    public EntityUid? Target { get; } = target;
+
+    [DataField]
+    public float Range { get; } = range;
+
+    [DataField]
+    public bool IgnoreWalls { get; } = ignoreWalls;
+
+    [DataField]
+    public bool Visible { get; set; } = true;
+}
+

--- a/Content.Server/ADT/Language/LanguageTypes/Emotes.cs
+++ b/Content.Server/ADT/Language/LanguageTypes/Emotes.cs
@@ -119,6 +119,11 @@ public sealed partial class Emotes : ILanguageType
                 continue;
             listener = session.AttachedEntity.Value;
 
+            // ADT-Tweak start
+            if (!data.Observer && !chat.HasLineOfSight(listener, uid, ignoreWalls: message.TrimEnd().EndsWith("!")))
+                continue;
+            // ADT-Tweak end
+
             var entRange = chat.MessageRangeCheck(session, data, range);
             if (entRange == ChatSystem.MessageRangeCheckResult.Disallowed)
                 continue;
@@ -201,6 +206,11 @@ public sealed partial class Emotes : ILanguageType
             if (session.AttachedEntity is not { Valid: true } playerEntity)
                 continue;
             listener = session.AttachedEntity.Value;
+
+            // ADT-Tweak start
+            if (!data.Observer && !chat.HasLineOfSight(listener, uid))
+                continue;
+            // ADT-Tweak end
 
             var entRange = chat.MessageRangeCheck(session, data, range);
             if (entRange == ChatSystem.MessageRangeCheckResult.Disallowed)

--- a/Content.Server/ADT/Language/LanguageTypes/Generic.cs
+++ b/Content.Server/ADT/Language/LanguageTypes/Generic.cs
@@ -127,7 +127,8 @@ public sealed partial class Generic : ILanguageType
             ("message", coloredLanguageMessage));
 
         // Send
-        chat.SendInVoiceRange(ChatChannel.Local, message, wrappedMessage, wrappedLanguageMessage, uid, range, language: Language);
+        var isShout = message.TrimEnd().EndsWith("!");
+        chat.SendInVoiceRange(ChatChannel.Local, message, wrappedMessage, wrappedLanguageMessage, uid, range, language: Language, ignoreWalls: isShout);
         success = true;
     }
 

--- a/Content.Server/ADT/Pointing/PointingSystem.Chat.cs
+++ b/Content.Server/ADT/Pointing/PointingSystem.Chat.cs
@@ -3,6 +3,7 @@ using Content.Server.Chat.Managers;
 using Content.Shared.ADT.CCVar;
 using Content.Shared.ADT.Pointing;
 using Content.Shared.Chat;
+using Content.Shared.Ghost;
 using Robust.Server.Configuration;
 using Robust.Shared.Player;
 
@@ -32,6 +33,19 @@ internal sealed partial class PointingSystem
             .Append(sourceSession)
             .Distinct()
             .Where(v => _adtNetConfig.GetClientCVar(v.Channel, ADTCCVars.EnableChatPointingIcons))
+            .Where(v =>
+            {
+                if (v.AttachedEntity is not { Valid: true } ent)
+                    return false;
+
+                if (ent == source)
+                    return true;
+
+                if (HasComp<GhostComponent>(ent))
+                    return true;
+
+                return _examine.InRangeUnOccluded(ent, source, PointingRange);
+            })
             .ToList();
 
         if (viewerList.Count == 0)

--- a/Content.Server/ADT/Pointing/PointingSystem.Chat.cs
+++ b/Content.Server/ADT/Pointing/PointingSystem.Chat.cs
@@ -41,7 +41,7 @@ internal sealed partial class PointingSystem
                 if (ent == source)
                     return true;
 
-                if (HasComp<GhostComponent>(ent))
+                if (HasComp<GhostHearingComponent>(ent))
                     return true;
 
                 return _examine.InRangeUnOccluded(ent, source, PointingRange);

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -651,7 +651,7 @@ public sealed partial class ChatSystem : SharedChatSystem
             ("entityName", name),
             ("message", FormattedMessage.EscapeText(message)));
 
-        SendInVoiceRange(ChatChannel.LOOC, message, wrappedMessage, wrappedMessage, source, hideChat ? ChatTransmitRange.HideChat : ChatTransmitRange.Normal, player.UserId, ignoreLanguage: true); // ADT Languages
+        SendInVoiceRange(ChatChannel.LOOC, message, wrappedMessage, wrappedMessage, source, hideChat ? ChatTransmitRange.HideChat : ChatTransmitRange.Normal, player.UserId, ignoreLanguage: true, checkVisibility: false); // ADT Languages
         _adminLogger.Add(LogType.Chat, LogImpact.Low, $"LOOC from {source}: {message}");
     }
 
@@ -749,10 +749,19 @@ public sealed partial class ChatSystem : SharedChatSystem
         return initialResult;
     }
 
+    // ADT-Tweak start
+    public bool HasLineOfSight(EntityUid listener, EntityUid? source, float range = VoiceRange, bool ignoreWalls = false)
+    {
+        var ev = new ChatVisibilityCheckEvent(listener, source, range, ignoreWalls);
+        RaiseLocalEvent(ref ev);
+        return ev.Visible;
+    }
+    // ADT-Tweak end
+
     /// <summary>
     ///     Sends a chat message to the given players in range of the source entity.
     /// </summary>
-    public void SendInVoiceRange(ChatChannel channel, string message, string wrappedMessage, string wrappedLanguageMessage, EntityUid source, ChatTransmitRange range, NetUserId? author = null, ProtoId<LanguagePrototype>? language = null, bool ignoreLanguage = false)  // ADT Languages
+    public void SendInVoiceRange(ChatChannel channel, string message, string wrappedMessage, string wrappedLanguageMessage, EntityUid source, ChatTransmitRange range, NetUserId? author = null, ProtoId<LanguagePrototype>? language = null, bool ignoreLanguage = false, bool checkVisibility = true, bool ignoreWalls = false)  // ADT Languages
     {
         // ADT Languages start
         var lang = language != null ? _prototypeManager.Index(language.Value) : _language.GetCurrentLanguage(source);
@@ -764,6 +773,11 @@ public sealed partial class ChatSystem : SharedChatSystem
             if (session.AttachedEntity is not { Valid: true } playerEntity)
                 continue;
             listener = session.AttachedEntity.Value;
+
+            // ADT-Tweak start
+            if (checkVisibility && !data.Observer && !HasLineOfSight(listener, source, ignoreWalls: ignoreWalls))
+                continue;
+            // ADT-Tweak end
 
             bool condition = true;
             foreach (var item in lang.Conditions.Where(x => x.RaiseOnListener))

--- a/Content.Server/Corvax/TTS/TTSSystem.cs
+++ b/Content.Server/Corvax/TTS/TTSSystem.cs
@@ -11,6 +11,8 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Content.Server.ADT.Language;
 using Content.Shared.ADT.Language;
+using Content.Server.Examine;
+using Content.Shared.Ghost;
 
 namespace Content.Server.Corvax.TTS;
 
@@ -23,6 +25,7 @@ public sealed partial class TTSSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _xforms = default!;
     [Dependency] private readonly IRobustRandom _rng = default!;
     [Dependency] private readonly LanguageSystem _language = default!;  // ADT Languages
+    [Dependency] private readonly ExamineSystem _examineSystem = default!;
 
     private readonly List<string> _sampleText =
         new()
@@ -124,7 +127,19 @@ public sealed partial class TTSSystem : EntitySystem
         if (languageSoundData is null) return;
         // ADT Languages end
 
-        RaiseNetworkEvent(new PlayTTSEvent(soundData, languageSoundData, language, GetNetEntity(uid)), Filter.Pvs(uid));
+        // ADT-Tweak start
+        var ttsEvent = new PlayTTSEvent(soundData, languageSoundData, language, GetNetEntity(uid));
+        var receptions = Filter.Pvs(uid).Recipients;
+        foreach (var session in receptions)
+        {
+            if (!session.AttachedEntity.HasValue) continue;
+
+            if (!HasComp<GhostHearingComponent>(session.AttachedEntity.Value) && !_examineSystem.InRangeUnOccluded(session.AttachedEntity.Value, uid, ChatSystem.VoiceRange))
+                continue;
+
+            RaiseNetworkEvent(ttsEvent, session);
+        }
+        // ADT-Tweak end
     }
 
     private async void HandleWhisper(EntityUid uid, string message, string obfMessage, string speaker, LanguagePrototype language)
@@ -162,6 +177,11 @@ public sealed partial class TTSSystem : EntitySystem
             var distance = (sourcePos - _xforms.GetWorldPosition(xform, xformQuery)).Length();
             if (distance > ChatSystem.VoiceRange * ChatSystem.VoiceRange)
                 continue;
+
+            // ADT-Tweak start
+            if (!HasComp<GhostHearingComponent>(session.AttachedEntity.Value) && !_examineSystem.InRangeUnOccluded(session.AttachedEntity.Value, uid, ChatSystem.WhisperMuffledRange))
+                continue;
+            // ADT-Tweak end
 
             RaiseNetworkEvent(distance > ChatSystem.WhisperClearRange ? obfTtsEvent : fullTtsEvent, session);
         }


### PR DESCRIPTION
## Описание PR
Добавлена проверка на прямую видимость над игроком. Это значит:
— Игрок не услышит другого игрока, если тот за стеной. Это касается и обычной речи, и шепотом. В том числе и Emote действие игрока.
— Игрок не будет видеть на что показывает другой игрок, если его не видно
— Игрок Будет слышать через стену, даже если он не видит игрока при условии, что игрок будет кричать используя "!" в конце.

TODO:
- [x] Надо адаптировать скрытие речи Барков, чтоб звука не была.
- [x] Надо адаптировать скрытие речи ТТС, чтоб звука не была

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- add: игроки больше не слышат голоса (и не видят в чате), не видят указатели направления (указание на место или объект) и не могут увидеть Emote действия других игроков (так же в чате не показывает), если те находятся за пределами их видимости. Данное правило игнорируется, если говорящий использует в конце предложение крик "!", такое слово слышат все через стены, даже если игрока не видно. Только в отношение речи.