### PR TITLE
Revork optimization xeno

### DIFF
--- a/Content.Client/ADT/Xenobiology/UI/SlimeScannerWindow.xaml
+++ b/Content.Client/ADT/Xenobiology/UI/SlimeScannerWindow.xaml
@@ -33,6 +33,8 @@
                                         <PanelContainer Name="ColorDisplay" MinWidth="30" MinHeight="30" Margin="0 0 10 0" />
                                         <Label Name="BreedNameLabel" Text="" StyleClasses="LabelHeading" />
                                     </BoxContainer>
+                                    <RichTextLabel Name="DensityWarningLabel" Text="" StyleClasses="LabelSubText"
+                                                   HorizontalExpand="True" Margin="0 8 0 8" Visible="False" />
                                     <GridContainer Columns="2" Margin="0 5 0 0">
                                         <Label Text="{Loc 'slime-scanner-mutation-chance'}" StyleClasses="LabelKeyText"/>
                                         <Label Name="MutationChanceLabel"/>

--- a/Content.Client/ADT/Xenobiology/UI/SlimeScannerWindow.xaml.cs
+++ b/Content.Client/ADT/Xenobiology/UI/SlimeScannerWindow.xaml.cs
@@ -74,6 +74,31 @@ public sealed partial class SlimeScannerWindow : BaseWindow
             {
                 MutationsContainer.AddChild(new Label { Text = Loc.GetString("slime-scanner-no-mutations") });
             }
+
+            if (msg.LocalSlimeCount.HasValue && msg.MaxSlimesPerGrid.HasValue && msg.BreedingSlowdown.HasValue)
+            {
+                DensityWarningLabel.Visible = true;
+                DensityWarningLabel.HorizontalExpand = true;
+                DensityWarningLabel.Text = Loc.GetString(
+                    "slime-scanner-population-ok",
+                    ("count", msg.LocalSlimeCount.Value),
+                    ("max", msg.MaxSlimesPerGrid.Value));
+
+                if (msg.BreedingSlowdown.Value > 0f)
+                {
+                    var pct = (int)MathF.Round(msg.BreedingSlowdown.Value * 100f);
+                    var warning = Loc.GetString(
+                        "slime-scanner-overcrowding-warning",
+                        ("count", msg.LocalSlimeCount.Value),
+                        ("max", msg.MaxSlimesPerGrid.Value),
+                        ("pct", pct));
+                    DensityWarningLabel.SetMarkup(warning);
+                }
+            }
+            else
+            {
+                DensityWarningLabel.Visible = false;
+            }
         }
         else if (msg.Reagents != null && msg.Reagents.Count > 0)
         {
@@ -88,11 +113,11 @@ public sealed partial class SlimeScannerWindow : BaseWindow
                 var colorRect = new PanelContainer { MinWidth = 20, MinHeight = 20, Margin = new Thickness(0, 0, 5, 0) };
                 colorRect.PanelOverride = new StyleBoxFlat(color);
                 row.AddChild(colorRect);
-                
+
                 var reagentName = reagentInfo.ReagentId;
                 if (_prototypes.TryIndex<ReagentPrototype>(reagentInfo.ReagentId, out var reagentProto))
                     reagentName = reagentProto.LocalizedName;
-                
+
                 row.AddChild(new Label { Text = reagentName });
                 ReagentsContainer.AddChild(row);
             }

--- a/Content.Server/ADT/Xenobiology/SlimeScannerSystem.cs
+++ b/Content.Server/ADT/Xenobiology/SlimeScannerSystem.cs
@@ -2,12 +2,15 @@ using Robust.Server.GameObjects;
 using Content.Shared.ADT.Xenobiology;
 using Content.Shared.ADT.Xenobiology.Components;
 using Content.Shared.ADT.Xenobiology.Components.Equipment;
+using Content.Shared.ADT.Xenobiology.Systems;
 using Content.Shared.Chemistry.Reaction;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Configuration;
+using Content.Shared.ADT.CCVar;
 using System.Linq;
 
 namespace Content.Server.ADT.Xenobiology;
@@ -18,6 +21,8 @@ public sealed partial class SlimeScannerSystem : EntitySystem
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
+    [Dependency] private readonly XenobiologySystem _xenobio = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
 
     public override void Initialize()
     {
@@ -52,7 +57,7 @@ public sealed partial class SlimeScannerSystem : EntitySystem
             return;
 
         _audioSystem.PlayPvs(ent.Comp.ScanningEndSound, ent.Owner);
-        
+
         OpenScannerUI(args.User, ent.Owner, args.Target.Value);
         args.Handled = true;
     }
@@ -77,7 +82,7 @@ public sealed partial class SlimeScannerSystem : EntitySystem
             return;
 
         _uiSystem.OpenUi(scanner, SlimeScannerUiKey.Key, user);
-        
+
         var msg = BuildScannedMessage(target);
         if (msg != null)
             _uiSystem.ServerSendUiMessage(scanner, SlimeScannerUiKey.Key, msg);
@@ -88,12 +93,17 @@ public sealed partial class SlimeScannerSystem : EntitySystem
         if (TryComp<SlimeComponent>(target, out var slime))
         {
             var breed = _prot.Index<BreedPrototype>(slime.Breed);
-            
+
             var breedName = Loc.GetString(breed.BreedName);
-            
+
             var mutations = slime.PotentialMutations
                 .Select(id => Loc.GetString(_prot.Index<BreedPrototype>(id).BreedName))
                 .ToList();
+
+            var slimeEnt = new Entity<SlimeComponent>(target, slime);
+            var density = _xenobio.GetLocalSlimeDensity(slimeEnt);
+            var slowdown = _xenobio.GetBreedingSlowdown(slimeEnt);
+            var maxSlimes = _cfg.GetCVar(SimpleStationCCVars.XenobiologyMaxSlimesPerGrid);
 
             return new SlimeScannerScannedMessage(
                 GetNetEntity(target),
@@ -102,7 +112,10 @@ public sealed partial class SlimeScannerSystem : EntitySystem
                 slime.MutationChance,
                 mutations,
                 slime.ExtractsProduced,
-                null);
+                null,
+                density,
+                maxSlimes,
+                slowdown);
         }
 
         if (TryComp<SlimeExtractComponent>(target, out var _) &&

--- a/Content.Shared/ADT/CCVar/CCVars.cs
+++ b/Content.Shared/ADT/CCVar/CCVars.cs
@@ -57,4 +57,27 @@ public sealed class SimpleStationCCVars
     public static readonly CVarDef<float> XenobiologyBreedingInterval =
         CVarDef.Create("vg.xenobiology.breeding_interval", 1f, CVar.SERVERONLY);
 
+    /// <summary>
+    ///     The maximum number of slimes allowed on the same grid before breeding
+    ///     becomes increasingly throttled. This is a soft cap driven by a progressive
+    ///     slowdown rather than a hard stop. Players are expected to cull the population.
+    /// </summary>
+    public static readonly CVarDef<int> XenobiologyMaxSlimesPerGrid =
+        CVarDef.Create("xenobiology.max_slimes_per_grid", 60, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     The number of slimes on a grid at which breeding slowdown begins to take effect.
+    ///     Below this value, breeding is unaffected.
+    /// </summary>
+    public static readonly CVarDef<int> XenobiologyBreedingSlowdownStart =
+        CVarDef.Create("xenobiology.breeding_slowdown_start", 30, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     How aggressively breeding is throttled once the population exceeds the slowdown start.
+    ///     A value of 1.0 means offspring count is reduced linearly with the population,
+    ///     hitting zero at the max cap. Lower values make the slowdown gentler.
+    /// </summary>
+    public static readonly CVarDef<float> XenobiologyBreedingSlowdownFactor =
+        CVarDef.Create("xenobiology.breeding_slowdown_factor", 0.6f, CVar.SERVERONLY);
+
 }

--- a/Content.Shared/ADT/Xenobiology/Components/SlimeComponent.cs
+++ b/Content.Shared/ADT/Xenobiology/Components/SlimeComponent.cs
@@ -147,4 +147,7 @@ public sealed partial class SlimeComponent : Component
     /// </summary>
     [DataField]
     public SoundPathSpecifier EatSound = new("/Audio/Voice/Talk/slime.ogg");
+
+    [DataField, AutoNetworkedField]
+    public float FriendSightRange = 10f;
 }

--- a/Content.Shared/ADT/Xenobiology/SlimeScannerScannedMessage.cs
+++ b/Content.Shared/ADT/Xenobiology/SlimeScannerScannedMessage.cs
@@ -12,6 +12,9 @@ public sealed class SlimeScannerScannedMessage : BoundUserInterfaceMessage
     public List<string>? Mutations;
     public int? ExtractsProduced;
     public List<ExtractReagentInfo>? Reagents;
+    public int? LocalSlimeCount;
+    public int? MaxSlimesPerGrid;
+    public float? BreedingSlowdown;
 
     public SlimeScannerScannedMessage(
         NetEntity targetEntity,
@@ -20,7 +23,10 @@ public sealed class SlimeScannerScannedMessage : BoundUserInterfaceMessage
         float? mutationChance,
         List<string>? mutations,
         int? extractsProduced,
-        List<ExtractReagentInfo>? reagents)
+        List<ExtractReagentInfo>? reagents,
+        int? localSlimeCount = null,
+        int? maxSlimesPerGrid = null,
+        float? breedingSlowdown = null)
     {
         TargetEntity = targetEntity;
         BreedName = breedName;
@@ -29,6 +35,9 @@ public sealed class SlimeScannerScannedMessage : BoundUserInterfaceMessage
         Mutations = mutations;
         ExtractsProduced = extractsProduced;
         Reagents = reagents;
+        LocalSlimeCount = localSlimeCount;
+        MaxSlimesPerGrid = maxSlimesPerGrid;
+        BreedingSlowdown = breedingSlowdown;
     }
 }
 

--- a/Content.Shared/ADT/Xenobiology/Systems/XenobiologySystem.Breeding.cs
+++ b/Content.Shared/ADT/Xenobiology/Systems/XenobiologySystem.Breeding.cs
@@ -108,6 +108,14 @@ public partial class XenobiologySystem
             return;
 
         var offspringCount = _random.Next(1, ent.Comp.MaxOffspring + 1);
+
+        var slowdown = GetBreedingSlowdown(ent);
+        if (slowdown >= 1f)
+            return;
+
+        if (slowdown > 0f)
+            offspringCount = Math.Max(1, (int)MathF.Round(offspringCount * (1f - slowdown)));
+
         _audio.PlayPredicted(ent.Comp.MitosisSound, ent, ent);
 
         List<EntityUid> slimes = [];
@@ -192,5 +200,52 @@ public partial class XenobiologySystem
         _mobGrowth.SetBaseName(newEntityUid, Loc.GetString(newBreed.BreedName));
 
         return new Entity<SlimeComponent>(newEntityUid, newSlime);
+    }
+
+    /// <summary>
+    /// Counts the number of slimes on the same grid as the given slime.
+    /// </summary>
+    public int GetLocalSlimeDensity(Entity<SlimeComponent> ent)
+    {
+        if (_net.IsClient)
+            return 0;
+
+        var gridId = Transform(ent).GridUid;
+        var count = 0;
+
+        var query = EntityQueryEnumerator<SlimeComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out _, out var xform))
+        {
+            if (uid == ent.Owner)
+                continue;
+
+            if (xform.GridUid == gridId)
+                count++;
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// Computes a breeding slowdown factor in the range [0, 1] based on local slime density.
+    /// 0 means no slowdown (breeding unaffected), approaching 1 means breeding is nearly halted.
+    /// The slowdown ramps up progressively between the slowdown-start threshold and the max cap.
+    /// </summary>
+    public float GetBreedingSlowdown(Entity<SlimeComponent> ent)
+    {
+        var max = _configuration.GetCVar(SimpleStationCCVars.XenobiologyMaxSlimesPerGrid);
+        var start = _configuration.GetCVar(SimpleStationCCVars.XenobiologyBreedingSlowdownStart);
+        var factor = _configuration.GetCVar(SimpleStationCCVars.XenobiologyBreedingSlowdownFactor);
+
+        if (max <= 0 || factor <= 0)
+            return 0f;
+
+        var density = GetLocalSlimeDensity(ent);
+        if (density <= start)
+            return 0f;
+
+        var range = Math.Max(1, max - start);
+        var raw = (density - start) / (float)range;
+        return Math.Clamp(raw * factor, 0f, 1f);
     }
 }

--- a/Content.Shared/ADT/Xenobiology/Systems/XenobiologySystem.Breeding.cs
+++ b/Content.Shared/ADT/Xenobiology/Systems/XenobiologySystem.Breeding.cs
@@ -11,6 +11,11 @@ using Content.Shared.Body;
 using Content.Shared.Body.Components;
 using Content.Shared.ADT.CCVar;
 using Content.Shared.Body.Systems;
+using Content.Shared.NPC.Systems;
+using Content.Shared.NPC.Components;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
 
 namespace Content.Shared.ADT.Xenobiology.Systems;
 
@@ -19,6 +24,8 @@ public partial class XenobiologySystem
     [Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
     [Dependency] private readonly BodySystem _body = default!;
     [Dependency] private readonly StomachSystem _stomach = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly NpcFactionSystem _factions = default!;
 
     private void SubscribeBreeding()
     {
@@ -178,9 +185,44 @@ public partial class XenobiologySystem
             }
         }
 
+        MakeMitosisFriends(ent, slimes);
+
         _containerSystem.EmptyContainer(ent.Comp.Stomach);
         RaiseLocalEvent(ent, new SlimeMitosisEvent(slimes));
         QueueDel(ent);
+    }
+
+    private void MakeMitosisFriends(Entity<SlimeComponent> ent, List<EntityUid> offspring)
+    {
+        if (_net.IsClient)
+            return;
+
+        var range = ent.Comp.FriendSightRange;
+        if (range <= 0f)
+            return;
+
+        var coords = Transform(ent).Coordinates;
+        var witnessed = new HashSet<EntityUid>();
+
+        foreach (var player in _lookup.GetEntitiesInRange<ActorComponent>(coords, range))
+        {
+            var playerUid = player.Owner;
+
+            if (ent.Comp.LatchedTarget is { } latchTarget && latchTarget == playerUid)
+                continue;
+
+            witnessed.Add(playerUid);
+        }
+
+        if (witnessed.Count == 0)
+            return;
+
+        _factions.IgnoreEntities(new Entity<FactionExceptionComponent?>(ent.Owner, default), witnessed);
+
+        foreach (var child in offspring)
+        {
+            _factions.IgnoreEntities(new Entity<FactionExceptionComponent?>(child, default), witnessed);
+        }
     }
 
     private Entity<SlimeComponent>? SpawnSlime(EntityUid parent, EntProtoId newEntityProto, ProtoId<BreedPrototype> selectedBreed)

--- a/Resources/Locale/en-US/ADT/xenobio/slime-scanner.ftl
+++ b/Resources/Locale/en-US/ADT/xenobio/slime-scanner.ftl
@@ -1,0 +1,12 @@
+slime-scanner-window-title = Slime Scanner
+slime-scanner-mutation-chance = Mutation chance:
+slime-scanner-extracts-produced = Extracts produced:
+slime-scanner-possible-mutations = Possible mutations:
+slime-scanner-no-mutations = No possible mutations.
+slime-scanner-extract-reagents = Reactive reagents:
+slime-scanner-no-data = No available data.
+slime-scanner-footer-text = Use on a slime or extract to view information.
+slime-scanner-unknown = Unknown
+slime-scanner-overcrowding-warning = [color=orange]Slime population: { $count }/{ $max }
+                                      Breeding slowed by { $pct }%[/color]
+slime-scanner-population-ok = Slime population: { $count }/{ $max }

--- a/Resources/Locale/ru-RU/ADT/xenobio/slime-scanner.ftl
+++ b/Resources/Locale/ru-RU/ADT/xenobio/slime-scanner.ftl
@@ -7,3 +7,6 @@ slime-scanner-extract-reagents = Реактивные реагенты:
 slime-scanner-no-data = Нет доступных данных.
 slime-scanner-footer-text = Используйте на слайме или экстракте для просмотра информации.
 slime-scanner-unknown = Неизвестно
+slime-scanner-overcrowding-warning = [color=orange]Популяция слаймов: { $count }/{ $max }
+                                      Размножение замедлено на { $pct }%[/color]
+slime-scanner-population-ok = Популяция слаймов: { $count }/{ $max }


### PR DESCRIPTION
## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
- add: Внедрена система популяционного контроля для слаймов. Начиная с 30-й особи, каждый новый слайм начинает оказывать угнетающее воздействие на популяцию, снижая скорость роста всех слаймов на 1,5% за каждую единицу свыше лимита. Данный эффект действует вплоть до достижения численности в 60 особей. При наступлении популяционного предела новые слаймы перестают появляться в результате митоза
- tweak: Усовершенствовано поведение слаймов в фазе митоза. Теперь при обнаружении живых игроков в радиусе 10 клеток все слаймы (как родительская особь, так и вновь появившиеся в результате митоза) переходят в дружелюбный режим по отношению к ним
