### PR TITLE
fix Bubblegum

### DIFF
--- a/Content.Server/ADT/Bubblegum/Abilities/Charge/BubblegumChargeSystem.cs
+++ b/Content.Server/ADT/Bubblegum/Abilities/Charge/BubblegumChargeSystem.cs
@@ -316,8 +316,6 @@ public sealed class BubblegumChargeSystem : EntitySystem
 
     private bool TrySmashStructure(EntityUid user, BubblegumActiveChargeComponent component, EntityUid target)
     {
-        if (HasComp<MobStateComponent>(target))
-            return false;
 
         var smash = new DamageSpecifier();
         smash.DamageDict.Add("Blunt", component.SmashBlunt);
@@ -330,6 +328,9 @@ public sealed class BubblegumChargeSystem : EntitySystem
     private bool IsSmashableStructure(EntityUid uid)
     {
         if (HasComp<ItemComponent>(uid))
+            return false;
+
+        if (HasComp<MobStateComponent>(uid))
             return false;
 
         if (!HasComp<DamageableComponent>(uid))

--- a/Content.Server/ADT/Bubblegum/Abilities/Charge/BubblegumChargeSystem.cs
+++ b/Content.Server/ADT/Bubblegum/Abilities/Charge/BubblegumChargeSystem.cs
@@ -316,6 +316,9 @@ public sealed class BubblegumChargeSystem : EntitySystem
 
     private bool TrySmashStructure(EntityUid user, BubblegumActiveChargeComponent component, EntityUid target)
     {
+        if (HasComp<MobStateComponent>(target))
+            return false;
+
         var smash = new DamageSpecifier();
         smash.DamageDict.Add("Blunt", component.SmashBlunt);
         smash.DamageDict.Add("Structural", component.SmashStructural);

--- a/Content.Server/ADT/Bubblegum/Abilities/Charge/BubblegumChargeSystem.cs
+++ b/Content.Server/ADT/Bubblegum/Abilities/Charge/BubblegumChargeSystem.cs
@@ -316,7 +316,6 @@ public sealed class BubblegumChargeSystem : EntitySystem
 
     private bool TrySmashStructure(EntityUid user, BubblegumActiveChargeComponent component, EntityUid target)
     {
-
         var smash = new DamageSpecifier();
         smash.DamageDict.Add("Blunt", component.SmashBlunt);
         smash.DamageDict.Add("Structural", component.SmashStructural);


### PR DESCRIPTION
## Описание PR
Бубля не наносит урон рывками по игрокам, и не наносит структурный.

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- fix: Бубльгум больше не наносит сумасшедший урон попадая рывком по цели
