### PR TITLE
add: Сохранение расстановки кнопок способностей при смене тела

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -22,6 +22,7 @@ using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controllers;
 using Robust.Client.UserInterface.Controls;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Graphics.RSI;
 using Robust.Shared.Input;
 using Robust.Shared.Input.Binding;
@@ -53,6 +54,12 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
     private ActionButtonContainer? _container;
     private readonly List<EntityUid?> _actions = new();
+
+    /// <summary>
+    /// Manually placed action positions (action prototype id -> slot index), restored after actions are re-linked
+    /// (body change, polymorph, death/ghost). Kept for the duration of the round.
+    /// </summary>
+    private readonly Dictionary<string, int> _pinnedSlots = new();
     private readonly DragDropHelper<ActionButton> _menuDragHelper;
     private readonly TextureRect _dragShadow;
     private ActionsWindow? _window;
@@ -96,6 +103,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
     private void OnScreenUnload()
     {
+        _pinnedSlots.Clear();
         UnloadGui();
     }
 
@@ -258,6 +266,12 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
         if (_actions.Contains(action))
             return;
+
+        if (GetActionKey(actionId) is {} key && _pinnedSlots.TryGetValue(key, out var targetIndex))
+        {
+            _actions.Insert(Math.Min(targetIndex, _actions.Count), actionId);
+            return;
+        }
 
         _actions.Add(action);
     }
@@ -439,7 +453,12 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             if (_container?.TryGetButtonIndex(button, out position) ?? false)
             {
                 if (_actions.Count > position && position >= 0)
+                {
+                    if (_actions[position] is {} oldAction && GetActionKey(oldAction) is {} oldKey)
+                        _pinnedSlots.Remove(oldKey);
+
                     _actions.RemoveAt(position);
+                }
             }
         }
         else if (button.TryReplaceWith(actionId.Value, _actionsSystem) &&
@@ -454,6 +473,9 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             {
                 _actions[position] = actionId;
             }
+
+            if (GetActionKey(actionId.Value) is {} key)
+                _pinnedSlots[key] = position;
         }
 
         if (updateSlots)
@@ -770,6 +792,49 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             if (!_actions.Contains(action))
                 _actions.Add(action);
         }
+
+        ApplyPinnedSlots();
+    }
+
+    /// <summary>
+    /// Restores manually placed action positions after actions are re-linked. Actions that no longer exist
+    /// are ignored, new actions keep their default spots.
+    /// </summary>
+    private void ApplyPinnedSlots()
+    {
+        if (_pinnedSlots.Count == 0 || _actionsSystem == null)
+            return;
+
+        var byKey = new Dictionary<string, EntityUid>();
+        foreach (var (uid, _) in _actionsSystem.GetClientActions())
+        {
+            if (GetActionKey(uid) is {} key && !byKey.ContainsKey(key))
+                byKey[key] = uid;
+        }
+
+        foreach (var (key, targetIndex) in _pinnedSlots.OrderBy(x => x.Value))
+        {
+            if (!byKey.TryGetValue(key, out var actionId))
+                continue;
+
+            var currentIndex = _actions.IndexOf(actionId);
+            if (currentIndex == targetIndex)
+                continue;
+
+            if (currentIndex == -1)
+            {
+                _actions.Insert(Math.Min(targetIndex, _actions.Count), actionId);
+                continue;
+            }
+
+            _actions.RemoveAt(currentIndex);
+            _actions.Insert(Math.Min(targetIndex, _actions.Count), actionId);
+        }
+    }
+
+    private string? GetActionKey(EntityUid actionId)
+    {
+        return EntityManager.GetComponent<MetaDataComponent>(actionId).EntityPrototype?.ID;
     }
 
     /// <summary>

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -291,14 +291,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (actionId == SelectingTargetFor)
             StopTargeting();
 
-        // ADT-Tweak-Start
-        var removedIndex = _actions.IndexOf(actionId);
-        // ADT-Tweak-End
         _actions.RemoveAll(x => x == actionId);
-        // ADT-Tweak-Start
-        if (removedIndex >= 0)
-            ShiftPinnedSlots(removedIndex);
-        // ADT-Tweak-End
     }
 
     private void OnActionsUpdated()

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -55,11 +55,13 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
     private ActionButtonContainer? _container;
     private readonly List<EntityUid?> _actions = new();
 
+    // ADT-Tweak-Start
     /// <summary>
     /// Manually placed action positions (action prototype id -> slot index), restored after actions are re-linked
     /// (body change, polymorph, death/ghost). Kept for the duration of the round.
     /// </summary>
     private readonly Dictionary<string, int> _pinnedSlots = new();
+    // ADT-Tweak-End
     private readonly DragDropHelper<ActionButton> _menuDragHelper;
     private readonly TextureRect _dragShadow;
     private ActionsWindow? _window;
@@ -103,6 +105,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
     private void OnScreenUnload()
     {
+        // ADT-Tweak: сброс ручных позиций кнопок способностей при выгрузке экрана
         _pinnedSlots.Clear();
         UnloadGui();
     }
@@ -267,11 +270,13 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (_actions.Contains(action))
             return;
 
+        // ADT-Tweak-Start
         if (GetActionKey(actionId) is {} key && _pinnedSlots.TryGetValue(key, out var targetIndex))
         {
             _actions.Insert(Math.Min(targetIndex, _actions.Count), actionId);
             return;
         }
+        // ADT-Tweak-End
 
         _actions.Add(action);
     }
@@ -453,12 +458,14 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             if (_container?.TryGetButtonIndex(button, out position) ?? false)
             {
                 if (_actions.Count > position && position >= 0)
+                // ADT-Tweak-Start
                 {
                     if (_actions[position] is {} oldAction && GetActionKey(oldAction) is {} oldKey)
                         _pinnedSlots.Remove(oldKey);
 
                     _actions.RemoveAt(position);
                 }
+                // ADT-Tweak-End
             }
         }
         else if (button.TryReplaceWith(actionId.Value, _actionsSystem) &&
@@ -474,8 +481,10 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
                 _actions[position] = actionId;
             }
 
+            // ADT-Tweak-Start
             if (GetActionKey(actionId.Value) is {} key)
                 _pinnedSlots[key] = position;
+            // ADT-Tweak-End
         }
 
         if (updateSlots)
@@ -793,6 +802,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
                 _actions.Add(action);
         }
 
+        // ADT-Tweak-Start
         ApplyPinnedSlots();
     }
 
@@ -836,6 +846,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
     {
         return EntityManager.GetComponent<MetaDataComponent>(actionId).EntityPrototype?.ID;
     }
+    // ADT-Tweak-End
 
     /// <summary>
     /// If currently targeting with this slot, stops targeting.

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -105,8 +105,10 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
     private void OnScreenUnload()
     {
-        // ADT-Tweak: сброс ручных позиций кнопок способностей при выгрузке экрана
+        // ADT-Tweak-Start
+        // Сброс ручных позиций кнопок способностей при выгрузке экрана.
         _pinnedSlots.Clear();
+        // ADT-Tweak-End
         UnloadGui();
     }
 
@@ -289,7 +291,14 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (actionId == SelectingTargetFor)
             StopTargeting();
 
+        // ADT-Tweak-Start
+        var removedIndex = _actions.IndexOf(actionId);
+        // ADT-Tweak-End
         _actions.RemoveAll(x => x == actionId);
+        // ADT-Tweak-Start
+        if (removedIndex >= 0)
+            ShiftPinnedSlots(removedIndex);
+        // ADT-Tweak-End
     }
 
     private void OnActionsUpdated()
@@ -464,6 +473,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
                         _pinnedSlots.Remove(oldKey);
 
                     _actions.RemoveAt(position);
+                    ShiftPinnedSlots(position);
                 }
                 // ADT-Tweak-End
             }
@@ -845,6 +855,16 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
     private string? GetActionKey(EntityUid actionId)
     {
         return EntityManager.GetComponent<MetaDataComponent>(actionId).EntityPrototype?.ID;
+    }
+
+    /// <summary>
+    /// Shifts pinned slot indexes after an action was removed from the list.
+    /// </summary>
+    private void ShiftPinnedSlots(int removedIndex)
+    {
+        var keysToShift = _pinnedSlots.Where(x => x.Value > removedIndex).Select(x => x.Key).ToList();
+        foreach (var key in keysToShift)
+            _pinnedSlots[key]--;
     }
     // ADT-Tweak-End
 


### PR DESCRIPTION
## Описание PR
Расстановка кнопок способностей на панели действий теперь сохраняется при смене тела: полиморф (например, превращение в призрака у еретика на пути пепла), смерть и возвращение в тело. Раньше ручная расстановка сбрасывалась при каждой перелинковке действий.

## Почему / Баланс
Смена тела полностью сбрасывала расстановку кнопок способностей, приходилось восстанавливать её вручную. Изменение чисто клиентское, на баланс не влияет. Расстановка сохраняется в течение раунда (сбрасывается при новом раунде и реконнекте).

## Техническая информация
Клиентский кэш расстановки в ActionUIController (Content.Client/UserInterface/Systems/Actions/ActionUIController.cs): словарь id прототипа действия -> индекс слота. Обновляется при перетаскивании кнопок и очистке слота (ПКМ), применяется при перелинковке действий (смена тела): LoadDefaultActions + OnActionAdded. Очищается при выходе из игрового экрана (новый раунд/лобби). Серверная часть и сетевые протоколы не затронуты.

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
Скрины игрового теста добавлю отдельным комментарием.

## Чейнджлог

:cl: ultradyper
- add: Расстановка кнопок способностей больше не сбрасывается при смене тела