### PR TITLE
remove: Удалён нерабочий трайт аллергии (Allergic)

### DIFF
--- a/Resources/Locale/ru-RU/ADT/traits/disabilities.ftl
+++ b/Resources/Locale/ru-RU/ADT/traits/disabilities.ftl
@@ -25,8 +25,6 @@ trait-soft-hands-desc = Ваши руки слишком слабы, чтобы 
 trait-unadapted-to-space-name = Несовместимость с космосом
 trait-unadapted-to-space-desc = Из-за особого строения ваше тело не подготовлено к нагрузкам от космического вакуума, потому вы испытываете колоссальные перегрузки при контакте с ним.
 
-trait-allergic-name = Аллергик
-trait-allergic-desc = У вас есть аллергия.
 
 trait-highlightsensitivity-name = Высокая светочувствительность
 trait-highlightsensitivity-desc = Вы гораздо более чувствительны к свету, чем большинство шейдкинов.

--- a/Resources/Locale/ru-RU/ADT/traits/disabilities.ftl
+++ b/Resources/Locale/ru-RU/ADT/traits/disabilities.ftl
@@ -25,10 +25,8 @@ trait-soft-hands-desc = Ваши руки слишком слабы, чтобы 
 trait-unadapted-to-space-name = Несовместимость с космосом
 trait-unadapted-to-space-desc = Из-за особого строения ваше тело не подготовлено к нагрузкам от космического вакуума, потому вы испытываете колоссальные перегрузки при контакте с ним.
 
-# ADT-Tweak: ключи закомментированы по ревью (PR #3087), не удалены.
-#trait-allergic-name = Аллергик
-#trait-allergic-desc = У вас есть аллергия.
-
+# trait-allergic-name = Аллергик
+# trait-allergic-desc = У вас есть аллергия.
 
 trait-highlightsensitivity-name = Высокая светочувствительность
 trait-highlightsensitivity-desc = Вы гораздо более чувствительны к свету, чем большинство шейдкинов.

--- a/Resources/Locale/ru-RU/ADT/traits/disabilities.ftl
+++ b/Resources/Locale/ru-RU/ADT/traits/disabilities.ftl
@@ -25,6 +25,10 @@ trait-soft-hands-desc = Ваши руки слишком слабы, чтобы 
 trait-unadapted-to-space-name = Несовместимость с космосом
 trait-unadapted-to-space-desc = Из-за особого строения ваше тело не подготовлено к нагрузкам от космического вакуума, потому вы испытываете колоссальные перегрузки при контакте с ним.
 
+# ADT-Tweak: ключи закомментированы по ревью (PR #3087), не удалены.
+#trait-allergic-name = Аллергик
+#trait-allergic-desc = У вас есть аллергия.
+
 
 trait-highlightsensitivity-name = Высокая светочувствительность
 trait-highlightsensitivity-desc = Вы гораздо более чувствительны к свету, чем большинство шейдкинов.

--- a/Resources/Prototypes/ADT/Traits/disabilities.yml
+++ b/Resources/Prototypes/ADT/Traits/disabilities.yml
@@ -119,3 +119,19 @@
   speciesBlacklist:
   - NovakidSpecies
 
+# ADT-Tweak: трайт Allergic закомментирован по ревью (PR #3087), не удалён.
+# Система аллергии не работала, трайт давал очко ни за что.
+#- type: trait
+#  id: Allergic
+#  name: trait-allergic-name
+#  description: trait-allergic-desc
+#  category: Disabilities
+#  components:
+#    - type: Allergic
+#  cost: -1
+#  quirk: true
+#  speciesBlacklist:
+#  - NovakidSpecies
+#  - Diona
+#  - SlimePerson
+#  - IPC

--- a/Resources/Prototypes/ADT/Traits/disabilities.yml
+++ b/Resources/Prototypes/ADT/Traits/disabilities.yml
@@ -119,17 +119,3 @@
   speciesBlacklist:
   - NovakidSpecies
 
-- type: trait
-  id: Allergic
-  name: trait-allergic-name
-  description: trait-allergic-desc
-  category: Disabilities
-  components:
-    - type: Allergic
-  cost: -1
-  quirk: true
-  speciesBlacklist:
-  - NovakidSpecies
-  - Diona
-  - SlimePerson
-  - IPC

--- a/Resources/Prototypes/ADT/Traits/disabilities.yml
+++ b/Resources/Prototypes/ADT/Traits/disabilities.yml
@@ -119,7 +119,6 @@
   speciesBlacklist:
   - NovakidSpecies
 
-# ADT-Tweak: трайт Allergic закомментирован по ревью (PR #3087), не удалён.
 # Система аллергии не работала, трайт давал очко ни за что.
 #- type: trait
 #  id: Allergic


### PR DESCRIPTION
## Описание PR
Удалён трайт «Аллергик» (Allergic) из категории Disabilities.

## Почему / Баланс
Трайт давал игрокам очко персонажа (cost -1) ни за что: система аллергии не работает, реакции на реагенты не срабатывают. Убран до починки системы.

## Техническая информация
Удалено определение трайта из `Resources/Prototypes/ADT/Traits/disabilities.yml` и его локализация (`trait-allergic-name`, `trait-allergic-desc`). Система аллергии и связанные прототипы (реакции, лечение) не тронуты.

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
Не требуется.

## Чейнджлог

:cl: ultradyper
- remove: Удалён нерабочий трайт аллергии.
