### PR TITLE
add: Армейский РПС в меню снаряжения колизея

### DIFF
--- a/Content.Client/ADT/Thunderdome/ThunderdomeLoadoutEui.cs
+++ b/Content.Client/ADT/Thunderdome/ThunderdomeLoadoutEui.cs
@@ -16,9 +16,9 @@ public sealed partial class ThunderdomeLoadoutEui : BaseEui
     {
         _window = new ThunderdomeLoadoutWindow();
         _window.OnClose += () => SendMessage(new CloseEuiMessage());
-        _window.OnLoadoutConfirmed += weaponIdx =>
+        _window.OnLoadoutConfirmed += (weaponIdx, equipmentIdx) =>
         {
-            SendMessage(new ThunderdomeLoadoutSelectedMessage(weaponIdx));
+            SendMessage(new ThunderdomeLoadoutSelectedMessage(weaponIdx, equipmentIdx));
         };
 
         _window.OnLeaderboardRequested += () =>

--- a/Content.Client/ADT/Thunderdome/ThunderdomeLoadoutWindow.cs
+++ b/Content.Client/ADT/Thunderdome/ThunderdomeLoadoutWindow.cs
@@ -6,11 +6,14 @@ namespace Content.Client.ADT.Thunderdome;
 
 public sealed partial class ThunderdomeLoadoutWindow : ThunderdomeWindow
 {
-    public event Action<int>? OnLoadoutConfirmed;
+    public event Action<int, int>? OnLoadoutConfirmed;
     public event Action? OnLeaderboardRequested;
 
     private int _weaponSelection = -1;
     private ThunderdomeWeaponCard? _selectedCard;
+
+    private int _equipmentSelection = -1;
+    private ThunderdomeWeaponCard? _selectedEquipmentCard;
 
     private readonly Label _playerCountLabel;
     private readonly BoxContainer _categoriesContainer;
@@ -64,7 +67,7 @@ public sealed partial class ThunderdomeLoadoutWindow : ThunderdomeWindow
         _confirmButton.OnPressed += () =>
         {
             if (_weaponSelection >= 0)
-                OnLoadoutConfirmed?.Invoke(_weaponSelection);
+                OnLoadoutConfirmed?.Invoke(_weaponSelection, _equipmentSelection);
         };
         Contents.AddChild(_confirmButton);
 
@@ -84,12 +87,40 @@ public sealed partial class ThunderdomeLoadoutWindow : ThunderdomeWindow
         _categoriesContainer.RemoveAllChildren();
         _selectedCard = null;
         _weaponSelection = -1;
+        _selectedEquipmentCard = null;
+        _equipmentSelection = -1;
         _confirmButton.Disabled = true;
 
+        AddLoadoutGroup(state.Weapons, OnCardSelected);
+
+        if (state.Equipment.Count > 0)
+        {
+            var equipmentHeader = new Label
+            {
+                Text = Loc.GetString("thunderdome-loadout-equipment-header"),
+                StyleClasses = { "LabelHeading" },
+                Margin = new Thickness(4, 10, 0, 2),
+            };
+            _categoriesContainer.AddChild(equipmentHeader);
+
+            var equipmentSubtitle = new Label
+            {
+                Text = Loc.GetString("thunderdome-loadout-equipment-subtitle"),
+                StyleClasses = { "LabelSubText" },
+                Margin = new Thickness(4, 0, 0, 4),
+            };
+            _categoriesContainer.AddChild(equipmentSubtitle);
+
+            AddLoadoutGroup(state.Equipment, OnEquipmentCardSelected);
+        }
+    }
+
+    private void AddLoadoutGroup(List<ThunderdomeLoadoutOption> options, Action<ThunderdomeWeaponCard> onSelected)
+    {
         var categories = new List<(string Category, List<ThunderdomeLoadoutOption> Options)>();
         var categoryMap = new Dictionary<string, List<ThunderdomeLoadoutOption>>();
 
-        foreach (var option in state.Weapons)
+        foreach (var option in options)
         {
             if (!categoryMap.TryGetValue(option.Category, out var list))
             {
@@ -100,7 +131,7 @@ public sealed partial class ThunderdomeLoadoutWindow : ThunderdomeWindow
             list.Add(option);
         }
 
-        foreach (var (category, options) in categories)
+        foreach (var (category, categoryOptions) in categories)
         {
             var header = new Label
             {
@@ -110,10 +141,10 @@ public sealed partial class ThunderdomeLoadoutWindow : ThunderdomeWindow
             };
             _categoriesContainer.AddChild(header);
 
-            foreach (var option in options)
+            foreach (var option in categoryOptions)
             {
                 var card = new ThunderdomeWeaponCard(option.Index, option.Name, option.SpritePrototype, option.Description);
-                card.OnSelected += OnCardSelected;
+                card.OnSelected += onSelected;
                 _categoriesContainer.AddChild(card);
             }
         }
@@ -128,5 +159,14 @@ public sealed partial class ThunderdomeLoadoutWindow : ThunderdomeWindow
         card.SetSelected(true);
 
         _confirmButton.Disabled = false;
+    }
+
+    private void OnEquipmentCardSelected(ThunderdomeWeaponCard card)
+    {
+        _selectedEquipmentCard?.SetSelected(false);
+
+        _selectedEquipmentCard = card;
+        _equipmentSelection = card.WeaponIndex;
+        card.SetSelected(true);
     }
 }

--- a/Content.Server/ADT/Thunderdome/ThunderdomeLoadoutEui.cs
+++ b/Content.Server/ADT/Thunderdome/ThunderdomeLoadoutEui.cs
@@ -23,7 +23,7 @@ public sealed class ThunderdomeLoadoutEui : BaseEui
     public override EuiStateBase GetNewState()
     {
         if (!_entManager.TryGetComponent<ThunderdomeRuleComponent>(_ruleEntity, out var rule))
-            return new ThunderdomeLoadoutEuiState(new List<ThunderdomeLoadoutOption>(), 0);
+            return new ThunderdomeLoadoutEuiState(new List<ThunderdomeLoadoutOption>(), new List<ThunderdomeLoadoutOption>(), 0);
 
         return _thunderdomeSystem.GetLoadoutState(rule);
     }
@@ -35,7 +35,7 @@ public sealed class ThunderdomeLoadoutEui : BaseEui
         switch (msg)
         {
             case ThunderdomeLoadoutSelectedMessage selected:
-                _thunderdomeSystem.SpawnPlayer(_session, _ruleEntity, selected.WeaponIndex);
+                _thunderdomeSystem.SpawnPlayer(_session, _ruleEntity, selected.WeaponIndex, selected.EquipmentIndex);
                 Close();
                 break;
         }

--- a/Content.Server/ADT/Thunderdome/ThunderdomeRuleSystem.cs
+++ b/Content.Server/ADT/Thunderdome/ThunderdomeRuleSystem.cs
@@ -284,7 +284,7 @@ public sealed partial class ThunderdomeRuleSystem : EntitySystem
         GhostDomePlayer(ent, rule, playSound: false);
     }
 
-    public void SpawnPlayer(ICommonSession session, EntityUid ruleEntity, int weaponIdx)
+    public void SpawnPlayer(ICommonSession session, EntityUid ruleEntity, int weaponIdx, int equipmentIdx)
     {
         if (!TryComp<ThunderdomeRuleComponent>(ruleEntity, out var rule)
           || !rule.Active
@@ -304,7 +304,7 @@ public sealed partial class ThunderdomeRuleSystem : EntitySystem
 
         var mob = _stationSpawning.SpawnPlayerMob(spawnCoords.Value, null, profile, null);
         _stationSpawning.EquipStartingGear(mob, rule.Gear);
-        SpawnLoadoutItems(mob, weaponIdx, rule);
+        SpawnLoadoutItems(mob, weaponIdx, equipmentIdx, rule);
 
         // айди карта с сикеем игруна
         if (_idCard.TryFindIdCard(mob, out var idCard))
@@ -647,13 +647,19 @@ public sealed partial class ThunderdomeRuleSystem : EntitySystem
         EnsureComp<TimedDespawnComponent>(uid).Lifetime = lifetime;
     }
 
-    private void SpawnLoadoutItems(EntityUid mob, int weaponIdx, ThunderdomeRuleComponent rule)
+    private void SpawnLoadoutItems(EntityUid mob, int weaponIdx, int equipmentIdx, ThunderdomeRuleComponent rule)
     {
-        if (rule.WeaponLoadouts.Count == 0)
-            return;
+        if (rule.WeaponLoadouts.Count > 0)
+        {
+            weaponIdx = Math.Clamp(weaponIdx, 0, rule.WeaponLoadouts.Count - 1);
+            _stationSpawning.EquipStartingGear(mob, rule.WeaponLoadouts[weaponIdx].Gear);
+        }
 
-        weaponIdx = Math.Clamp(weaponIdx, 0, rule.WeaponLoadouts.Count - 1);
-        _stationSpawning.EquipStartingGear(mob, rule.WeaponLoadouts[weaponIdx].Gear);
+        if (equipmentIdx >= 0 && rule.EquipmentLoadouts.Count > 0)
+        {
+            equipmentIdx = Math.Clamp(equipmentIdx, 0, rule.EquipmentLoadouts.Count - 1);
+            _stationSpawning.EquipStartingGear(mob, rule.EquipmentLoadouts[equipmentIdx].Gear);
+        }
     }
 
     private EntityCoordinates? GetRandomSpawnPoint(ThunderdomeRuleComponent rule)
@@ -734,7 +740,21 @@ public sealed partial class ThunderdomeRuleSystem : EntitySystem
             });
         }
 
-        return new ThunderdomeLoadoutEuiState(weapons, rule.Players.Count);
+        var equipment = new List<ThunderdomeLoadoutOption>();
+        for (var i = 0; i < rule.EquipmentLoadouts.Count; i++)
+        {
+            var loadout = rule.EquipmentLoadouts[i];
+            equipment.Add(new ThunderdomeLoadoutOption
+            {
+                Index = i,
+                Name = Loc.GetString(loadout.Name),
+                Description = string.IsNullOrEmpty(loadout.Description) ? string.Empty : Loc.GetString(loadout.Description),
+                Category = Loc.GetString(loadout.Category),
+                SpritePrototype = loadout.Sprite,
+            });
+        }
+
+        return new ThunderdomeLoadoutEuiState(weapons, equipment, rule.Players.Count);
     }
 
     private void RefillAmmo(EntityUid killer)

--- a/Content.Shared/ADT/Thunderdome/ThunderdomeLoadoutEuiMessages.cs
+++ b/Content.Shared/ADT/Thunderdome/ThunderdomeLoadoutEuiMessages.cs
@@ -7,11 +7,13 @@ namespace Content.Shared.ADT.Thunderdome;
 public sealed partial class ThunderdomeLoadoutEuiState : EuiStateBase
 {
     public List<ThunderdomeLoadoutOption> Weapons { get; }
+    public List<ThunderdomeLoadoutOption> Equipment { get; }
     public int PlayerCount { get; }
 
-    public ThunderdomeLoadoutEuiState(List<ThunderdomeLoadoutOption> weapons, int playerCount)
+    public ThunderdomeLoadoutEuiState(List<ThunderdomeLoadoutOption> weapons, List<ThunderdomeLoadoutOption> equipment, int playerCount)
     {
         Weapons = weapons;
+        Equipment = equipment;
         PlayerCount = playerCount;
     }
 }
@@ -30,9 +32,11 @@ public sealed partial class ThunderdomeLoadoutOption
 public sealed partial class ThunderdomeLoadoutSelectedMessage : EuiMessageBase
 {
     public int WeaponIndex { get; }
+    public int EquipmentIndex { get; }
 
-    public ThunderdomeLoadoutSelectedMessage(int weaponIndex)
+    public ThunderdomeLoadoutSelectedMessage(int weaponIndex, int equipmentIndex)
     {
         WeaponIndex = weaponIndex;
+        EquipmentIndex = equipmentIndex;
     }
 }

--- a/Content.Shared/ADT/Thunderdome/ThunderdomeRuleComponent.cs
+++ b/Content.Shared/ADT/Thunderdome/ThunderdomeRuleComponent.cs
@@ -45,6 +45,9 @@ public sealed partial class ThunderdomeRuleComponent : Component
     public List<ThunderdomeWeaponLoadout> WeaponLoadouts = new();
 
     [DataField]
+    public List<ThunderdomeWeaponLoadout> EquipmentLoadouts = new();
+
+    [DataField]
     public TimeSpan CleanupInterval = TimeSpan.FromSeconds(25);
 
     [DataField]

--- a/Resources/Locale/ru-RU/ADT/thunderdome.ftl
+++ b/Resources/Locale/ru-RU/ADT/thunderdome.ftl
@@ -6,9 +6,12 @@ thunderdome-ghost-button-default = Колизей (0)
 thunderdome-loadout-title = Экипировка колизея
 thunderdome-loadout-players = Людей в колизее: {$count}
 thunderdome-loadout-subtitle = Выберите своё основное оружие
+thunderdome-loadout-equipment-header = Экипировка
+thunderdome-loadout-equipment-subtitle = Необязательно, можно выбрать дополнительно
 thunderdome-loadout-confirm = Войти в колизей
 
 # Weapon categories
+thunderdome-category-equipment = Разгрузка
 thunderdome-category-shotguns = Дробовики
 thunderdome-category-smgs = Пистолеты-пулемёты
 thunderdome-category-rifles = Винтовки
@@ -58,6 +61,7 @@ thunderdome-join = {$player} зашёл в колизей!
 thunderdome-leave = {$player} вышел с колизея.
 thunderdome-leave-01 = {$user} пропадает. Кажется, он устал от бойни.
 
+thunderdome-desc-armyrps = Армейский разгрузочный пояс с вместительными подсумками. Пустой, заполняй патронами
 thunderdome-desc-capo = Капоэйра + микроинъектор и инъектор гиперзина + 2 автоинъектора
 thunderdome-desc-mosin = Кардешёв-Мосина + 3 магазина + ушанка + ВОДКА
 thunderdome-desc-cqc = Руководство по CQC + микроинъектор
@@ -74,6 +78,7 @@ thunderdome-desc-deckard = Револьвер Декард + 3 спидлоад�
 thunderdome-desc-sabre = Сабля капитана + энергетический щит + микроинъектор и инъектор гиперзина
 thunderdome-desc-enforcer = Силовик + 1 коробка дроби, 1 коробка пули
 
+thunderdome-loadout-armyrps = Армейский РПС
 thunderdome-loadout-capo = Капоэйра
 thunderdome-loadout-mosin = Кардешёв-Мосина
 thunderdome-loadout-cqc = CQC

--- a/Resources/Prototypes/ADT/Thunderdome/thunderdome_gear.yml
+++ b/Resources/Prototypes/ADT/Thunderdome/thunderdome_gear.yml
@@ -255,3 +255,8 @@
     back:
       - BoxLethalshot
       - BoxShotgunSlug
+
+- type: startingGear
+  id: ThunderdomeArmyRPS
+  equipment:
+    belt: ADTClothingRPSUSSP

--- a/Resources/Prototypes/ADT/Thunderdome/thunderdome_rule.yml
+++ b/Resources/Prototypes/ADT/Thunderdome/thunderdome_rule.yml
@@ -131,6 +131,12 @@
           description: thunderdome-desc-enforcer
           category: thunderdome-category-shotguns
           sprite: WeaponShotgunEnforcer
+      equipmentLoadouts:
+        - gear: ThunderdomeArmyRPS
+          name: thunderdome-loadout-armyrps
+          description: thunderdome-desc-armyrps
+          category: thunderdome-category-equipment
+          sprite: ADTClothingRPSUSSP
     - type: LoadMapRule
       mapPath: /Maps/Nonstations/dm01-entryway.yml
     - type: RuleGrids


### PR DESCRIPTION
## Описание PR
В меню снаряжения колизея добавлена секция «Экипировка» с позицией «Армейский РПС» (разгрузочный пояс RPS USSP). Экипировка выбирается отдельно от оружия и выдаётся на пояс при заходе на арену, рюкзак игрока не затрагивается.

## Почему / Баланс
Игроки могут взять в колизей дополнительную разгрузку под патроны, не теряя выбор основного оружия. Выбор экипировки необязательный.

## Техническая информация
В ThunderdomeRuleComponent добавлен список equipmentLoadouts (переиспользует существующий формат лодаутов). Меню выбора снаряжения колизея получило секцию экипировки с независимым выбором, при спавне выбранная экипировка выдаётся через EquipStartingGear. Добавлен startingGear ThunderdomeArmyRPS (belt: ADTClothingRPSUSSP), новых спрайтов нет.

Проверки: DebugOpt и Release собираются без ошибок, YAML Linter чистый, Content.Tests 380/380, тестовый сервер запущен на этой сборке без ошибок.
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
Скриншоты будут добавлены отдельным комментарием.

## Чейнджлог
:cl:
- add: В меню снаряжения колизея появилась экипировка «Армейский РПС»
