### PR TITLE
HolsterTweaks | Плечевые кобуры можно надеть в слот шеи.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -112,9 +112,11 @@
     sprite: Clothing/Belt/holster.rsi
   - type: Clothing
     sprite: Clothing/Belt/holster.rsi
+    # ADT-Tweak-Start
     slots:
     - belt
     - neck
+    # ADT-Tweak-End
   - type: Storage
     grid:
     - 0,0,3,1
@@ -129,9 +131,11 @@
     sprite: Clothing/Belt/syndieholster.rsi
   - type: Clothing
     sprite: Clothing/Belt/syndieholster.rsi
+    # ADT-Tweak-Start
     slots:
     - belt
     - neck
+    # ADT-Tweak-End
   - type: Storage
     maxItemSize: Huge
     grid:

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -112,6 +112,9 @@
     sprite: Clothing/Belt/holster.rsi
   - type: Clothing
     sprite: Clothing/Belt/holster.rsi
+    slots:
+    - belt
+    - neck
   - type: Storage
     grid:
     - 0,0,3,1
@@ -126,6 +129,9 @@
     sprite: Clothing/Belt/syndieholster.rsi
   - type: Clothing
     sprite: Clothing/Belt/syndieholster.rsi
+    slots:
+    - belt
+    - neck
   - type: Storage
     maxItemSize: Huge
     grid:


### PR DESCRIPTION
## Описание PR
Дал возможность надевать плечевые кобуры в слот шеи.

## Почему / Баланс
Ну... Чисто в теории:
- +дополнительные слоты для вещей, ведь слот пояса освободится. 
(правда куда в таком случае девать бодикамеры - неясно.)

Ссылка на предложение:
- [Предложение](https://discord.com/channels/901772674865455115/1532787140654661692)

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
No media?

## Чейнджлог

:cl: CatBackG
- tweak: Теперь плечевые кобуры можно надеть в слот шеи.


