### PR TITLE
SpriteLayersTweaks | Теперь РПСки отображаются ПОВЕРХ бронежилетов.

### DIFF
--- a/Resources/Prototypes/Body/species_appearance.yml
+++ b/Resources/Prototypes/Body/species_appearance.yml
@@ -39,9 +39,9 @@
     - map: [ "shoes" ]
     - map: [ "ears" ]
     - map: [ "eyes" ]
-    - map: [ "belt" ]
     - map: [ "id" ]
-    - map: [ "outerClothing" ]
+    - map: [ "outerClothing" ] # ADT: Moved UNDER belt layer, because webbings renders UNDER Armor vests (this is NOT logic).
+    - map: [ "belt" ]
     - map: [ "back" ]
     - map: [ "neck" ]
     - map: [ "suitstorage" ]

--- a/Resources/Prototypes/Body/species_appearance.yml
+++ b/Resources/Prototypes/Body/species_appearance.yml
@@ -39,9 +39,12 @@
     - map: [ "shoes" ]
     - map: [ "ears" ]
     - map: [ "eyes" ]
+    #- map: [ "belt" ] # ADT-Tweak: Disabled layer from Wizards
     - map: [ "id" ]
-    - map: [ "outerClothing" ] # ADT: Moved UNDER belt layer, because webbings renders UNDER Armor vests (this is NOT logic).
-    - map: [ "belt" ]
+    # ADT-Tweak-Start
+    - map: [ "outerClothing" ]
+    - map: [ "belt" ]  # ADT: Moved ABOVE outer layer, because webbings renders UNDER Armor vests (this was NOT logic).
+    # ADT-Tweak-End
     - map: [ "back" ]
     - map: [ "neck" ]
     - map: [ "suitstorage" ]


### PR DESCRIPTION
## Описание PR
Сменил порядок слоёв на телах.
## Почему / Баланс
Изначальная оффовская идея была - убрать пипку от КПК под верхнюю одежду.
Но у них случился проёб, из-за чего всё, что находится на поясе, отображалось под куртками, скафами и т.д.

Пиком стал момент, когда РПСы начали лезть ПОД бронежилет, что не очень то логично.
## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
no media, no fun. Я это делаю в час ночи.

## Чейнджлог
:cl: CatBackG
- fix: Исправлен порядок отображения слоёв на персонажах. Теперь РПСы можно вновь надевать, не боясь за уродство.
