### PR TITLE
tweak: Армейский РПС в стартовом снаряжении колизея

### DIFF
--- a/Content.Client/ADT/Thunderdome/ThunderdomeLoadoutEui.cs
+++ b/Content.Client/ADT/Thunderdome/ThunderdomeLoadoutEui.cs
@@ -16,9 +16,9 @@ public sealed partial class ThunderdomeLoadoutEui : BaseEui
     {
         _window = new ThunderdomeLoadoutWindow();
         _window.OnClose += () => SendMessage(new CloseEuiMessage());
-        _window.OnLoadoutConfirmed += (weaponIdx, equipmentIdx) =>
+        _window.OnLoadoutConfirmed += weaponIdx =>
         {
-            SendMessage(new ThunderdomeLoadoutSelectedMessage(weaponIdx, equipmentIdx));
+            SendMessage(new ThunderdomeLoadoutSelectedMessage(weaponIdx));
         };
 
         _window.OnLeaderboardRequested += () =>

--- a/Content.Client/ADT/Thunderdome/ThunderdomeLoadoutWindow.cs
+++ b/Content.Client/ADT/Thunderdome/ThunderdomeLoadoutWindow.cs
@@ -6,14 +6,11 @@ namespace Content.Client.ADT.Thunderdome;
 
 public sealed partial class ThunderdomeLoadoutWindow : ThunderdomeWindow
 {
-    public event Action<int, int>? OnLoadoutConfirmed;
+    public event Action<int>? OnLoadoutConfirmed;
     public event Action? OnLeaderboardRequested;
 
     private int _weaponSelection = -1;
     private ThunderdomeWeaponCard? _selectedCard;
-
-    private int _equipmentSelection = -1;
-    private ThunderdomeWeaponCard? _selectedEquipmentCard;
 
     private readonly Label _playerCountLabel;
     private readonly BoxContainer _categoriesContainer;
@@ -67,7 +64,7 @@ public sealed partial class ThunderdomeLoadoutWindow : ThunderdomeWindow
         _confirmButton.OnPressed += () =>
         {
             if (_weaponSelection >= 0)
-                OnLoadoutConfirmed?.Invoke(_weaponSelection, _equipmentSelection);
+                OnLoadoutConfirmed?.Invoke(_weaponSelection);
         };
         Contents.AddChild(_confirmButton);
 
@@ -87,40 +84,12 @@ public sealed partial class ThunderdomeLoadoutWindow : ThunderdomeWindow
         _categoriesContainer.RemoveAllChildren();
         _selectedCard = null;
         _weaponSelection = -1;
-        _selectedEquipmentCard = null;
-        _equipmentSelection = -1;
         _confirmButton.Disabled = true;
 
-        AddLoadoutGroup(state.Weapons, OnCardSelected);
-
-        if (state.Equipment.Count > 0)
-        {
-            var equipmentHeader = new Label
-            {
-                Text = Loc.GetString("thunderdome-loadout-equipment-header"),
-                StyleClasses = { "LabelHeading" },
-                Margin = new Thickness(4, 10, 0, 2),
-            };
-            _categoriesContainer.AddChild(equipmentHeader);
-
-            var equipmentSubtitle = new Label
-            {
-                Text = Loc.GetString("thunderdome-loadout-equipment-subtitle"),
-                StyleClasses = { "LabelSubText" },
-                Margin = new Thickness(4, 0, 0, 4),
-            };
-            _categoriesContainer.AddChild(equipmentSubtitle);
-
-            AddLoadoutGroup(state.Equipment, OnEquipmentCardSelected);
-        }
-    }
-
-    private void AddLoadoutGroup(List<ThunderdomeLoadoutOption> options, Action<ThunderdomeWeaponCard> onSelected)
-    {
         var categories = new List<(string Category, List<ThunderdomeLoadoutOption> Options)>();
         var categoryMap = new Dictionary<string, List<ThunderdomeLoadoutOption>>();
 
-        foreach (var option in options)
+        foreach (var option in state.Weapons)
         {
             if (!categoryMap.TryGetValue(option.Category, out var list))
             {
@@ -131,7 +100,7 @@ public sealed partial class ThunderdomeLoadoutWindow : ThunderdomeWindow
             list.Add(option);
         }
 
-        foreach (var (category, categoryOptions) in categories)
+        foreach (var (category, options) in categories)
         {
             var header = new Label
             {
@@ -141,10 +110,10 @@ public sealed partial class ThunderdomeLoadoutWindow : ThunderdomeWindow
             };
             _categoriesContainer.AddChild(header);
 
-            foreach (var option in categoryOptions)
+            foreach (var option in options)
             {
                 var card = new ThunderdomeWeaponCard(option.Index, option.Name, option.SpritePrototype, option.Description);
-                card.OnSelected += onSelected;
+                card.OnSelected += OnCardSelected;
                 _categoriesContainer.AddChild(card);
             }
         }
@@ -159,14 +128,5 @@ public sealed partial class ThunderdomeLoadoutWindow : ThunderdomeWindow
         card.SetSelected(true);
 
         _confirmButton.Disabled = false;
-    }
-
-    private void OnEquipmentCardSelected(ThunderdomeWeaponCard card)
-    {
-        _selectedEquipmentCard?.SetSelected(false);
-
-        _selectedEquipmentCard = card;
-        _equipmentSelection = card.WeaponIndex;
-        card.SetSelected(true);
     }
 }

--- a/Content.Server/ADT/Thunderdome/ThunderdomeLoadoutEui.cs
+++ b/Content.Server/ADT/Thunderdome/ThunderdomeLoadoutEui.cs
@@ -23,7 +23,7 @@ public sealed class ThunderdomeLoadoutEui : BaseEui
     public override EuiStateBase GetNewState()
     {
         if (!_entManager.TryGetComponent<ThunderdomeRuleComponent>(_ruleEntity, out var rule))
-            return new ThunderdomeLoadoutEuiState(new List<ThunderdomeLoadoutOption>(), new List<ThunderdomeLoadoutOption>(), 0);
+            return new ThunderdomeLoadoutEuiState(new List<ThunderdomeLoadoutOption>(), 0);
 
         return _thunderdomeSystem.GetLoadoutState(rule);
     }
@@ -35,7 +35,7 @@ public sealed class ThunderdomeLoadoutEui : BaseEui
         switch (msg)
         {
             case ThunderdomeLoadoutSelectedMessage selected:
-                _thunderdomeSystem.SpawnPlayer(_session, _ruleEntity, selected.WeaponIndex, selected.EquipmentIndex);
+                _thunderdomeSystem.SpawnPlayer(_session, _ruleEntity, selected.WeaponIndex);
                 Close();
                 break;
         }

--- a/Content.Server/ADT/Thunderdome/ThunderdomeRuleSystem.cs
+++ b/Content.Server/ADT/Thunderdome/ThunderdomeRuleSystem.cs
@@ -284,7 +284,7 @@ public sealed partial class ThunderdomeRuleSystem : EntitySystem
         GhostDomePlayer(ent, rule, playSound: false);
     }
 
-    public void SpawnPlayer(ICommonSession session, EntityUid ruleEntity, int weaponIdx, int equipmentIdx)
+    public void SpawnPlayer(ICommonSession session, EntityUid ruleEntity, int weaponIdx)
     {
         if (!TryComp<ThunderdomeRuleComponent>(ruleEntity, out var rule)
           || !rule.Active
@@ -304,7 +304,7 @@ public sealed partial class ThunderdomeRuleSystem : EntitySystem
 
         var mob = _stationSpawning.SpawnPlayerMob(spawnCoords.Value, null, profile, null);
         _stationSpawning.EquipStartingGear(mob, rule.Gear);
-        SpawnLoadoutItems(mob, weaponIdx, equipmentIdx, rule);
+        SpawnLoadoutItems(mob, weaponIdx, rule);
 
         // айди карта с сикеем игруна
         if (_idCard.TryFindIdCard(mob, out var idCard))
@@ -647,19 +647,13 @@ public sealed partial class ThunderdomeRuleSystem : EntitySystem
         EnsureComp<TimedDespawnComponent>(uid).Lifetime = lifetime;
     }
 
-    private void SpawnLoadoutItems(EntityUid mob, int weaponIdx, int equipmentIdx, ThunderdomeRuleComponent rule)
+    private void SpawnLoadoutItems(EntityUid mob, int weaponIdx, ThunderdomeRuleComponent rule)
     {
-        if (rule.WeaponLoadouts.Count > 0)
-        {
-            weaponIdx = Math.Clamp(weaponIdx, 0, rule.WeaponLoadouts.Count - 1);
-            _stationSpawning.EquipStartingGear(mob, rule.WeaponLoadouts[weaponIdx].Gear);
-        }
+        if (rule.WeaponLoadouts.Count == 0)
+            return;
 
-        if (equipmentIdx >= 0 && rule.EquipmentLoadouts.Count > 0)
-        {
-            equipmentIdx = Math.Clamp(equipmentIdx, 0, rule.EquipmentLoadouts.Count - 1);
-            _stationSpawning.EquipStartingGear(mob, rule.EquipmentLoadouts[equipmentIdx].Gear);
-        }
+        weaponIdx = Math.Clamp(weaponIdx, 0, rule.WeaponLoadouts.Count - 1);
+        _stationSpawning.EquipStartingGear(mob, rule.WeaponLoadouts[weaponIdx].Gear);
     }
 
     private EntityCoordinates? GetRandomSpawnPoint(ThunderdomeRuleComponent rule)
@@ -740,21 +734,7 @@ public sealed partial class ThunderdomeRuleSystem : EntitySystem
             });
         }
 
-        var equipment = new List<ThunderdomeLoadoutOption>();
-        for (var i = 0; i < rule.EquipmentLoadouts.Count; i++)
-        {
-            var loadout = rule.EquipmentLoadouts[i];
-            equipment.Add(new ThunderdomeLoadoutOption
-            {
-                Index = i,
-                Name = Loc.GetString(loadout.Name),
-                Description = string.IsNullOrEmpty(loadout.Description) ? string.Empty : Loc.GetString(loadout.Description),
-                Category = Loc.GetString(loadout.Category),
-                SpritePrototype = loadout.Sprite,
-            });
-        }
-
-        return new ThunderdomeLoadoutEuiState(weapons, equipment, rule.Players.Count);
+        return new ThunderdomeLoadoutEuiState(weapons, rule.Players.Count);
     }
 
     private void RefillAmmo(EntityUid killer)

--- a/Content.Shared/ADT/Thunderdome/ThunderdomeLoadoutEuiMessages.cs
+++ b/Content.Shared/ADT/Thunderdome/ThunderdomeLoadoutEuiMessages.cs
@@ -7,13 +7,11 @@ namespace Content.Shared.ADT.Thunderdome;
 public sealed partial class ThunderdomeLoadoutEuiState : EuiStateBase
 {
     public List<ThunderdomeLoadoutOption> Weapons { get; }
-    public List<ThunderdomeLoadoutOption> Equipment { get; }
     public int PlayerCount { get; }
 
-    public ThunderdomeLoadoutEuiState(List<ThunderdomeLoadoutOption> weapons, List<ThunderdomeLoadoutOption> equipment, int playerCount)
+    public ThunderdomeLoadoutEuiState(List<ThunderdomeLoadoutOption> weapons, int playerCount)
     {
         Weapons = weapons;
-        Equipment = equipment;
         PlayerCount = playerCount;
     }
 }
@@ -32,11 +30,9 @@ public sealed partial class ThunderdomeLoadoutOption
 public sealed partial class ThunderdomeLoadoutSelectedMessage : EuiMessageBase
 {
     public int WeaponIndex { get; }
-    public int EquipmentIndex { get; }
 
-    public ThunderdomeLoadoutSelectedMessage(int weaponIndex, int equipmentIndex)
+    public ThunderdomeLoadoutSelectedMessage(int weaponIndex)
     {
         WeaponIndex = weaponIndex;
-        EquipmentIndex = equipmentIndex;
     }
 }

--- a/Content.Shared/ADT/Thunderdome/ThunderdomeRuleComponent.cs
+++ b/Content.Shared/ADT/Thunderdome/ThunderdomeRuleComponent.cs
@@ -45,9 +45,6 @@ public sealed partial class ThunderdomeRuleComponent : Component
     public List<ThunderdomeWeaponLoadout> WeaponLoadouts = new();
 
     [DataField]
-    public List<ThunderdomeWeaponLoadout> EquipmentLoadouts = new();
-
-    [DataField]
     public TimeSpan CleanupInterval = TimeSpan.FromSeconds(25);
 
     [DataField]

--- a/Resources/Locale/ru-RU/ADT/thunderdome.ftl
+++ b/Resources/Locale/ru-RU/ADT/thunderdome.ftl
@@ -6,12 +6,9 @@ thunderdome-ghost-button-default = Колизей (0)
 thunderdome-loadout-title = Экипировка колизея
 thunderdome-loadout-players = Людей в колизее: {$count}
 thunderdome-loadout-subtitle = Выберите своё основное оружие
-thunderdome-loadout-equipment-header = Экипировка
-thunderdome-loadout-equipment-subtitle = Необязательно, можно выбрать дополнительно
 thunderdome-loadout-confirm = Войти в колизей
 
 # Weapon categories
-thunderdome-category-equipment = Разгрузка
 thunderdome-category-shotguns = Дробовики
 thunderdome-category-smgs = Пистолеты-пулемёты
 thunderdome-category-rifles = Винтовки
@@ -61,7 +58,6 @@ thunderdome-join = {$player} зашёл в колизей!
 thunderdome-leave = {$player} вышел с колизея.
 thunderdome-leave-01 = {$user} пропадает. Кажется, он устал от бойни.
 
-thunderdome-desc-armyrps = Армейский разгрузочный пояс с вместительными подсумками. Пустой, заполняй патронами
 thunderdome-desc-capo = Капоэйра + микроинъектор и инъектор гиперзина + 2 автоинъектора
 thunderdome-desc-mosin = Кардешёв-Мосина + 3 магазина + ушанка + ВОДКА
 thunderdome-desc-cqc = Руководство по CQC + микроинъектор
@@ -78,7 +74,6 @@ thunderdome-desc-deckard = Револьвер Декард + 3 спидлоад�
 thunderdome-desc-sabre = Сабля капитана + энергетический щит + микроинъектор и инъектор гиперзина
 thunderdome-desc-enforcer = Силовик + 1 коробка дроби, 1 коробка пули
 
-thunderdome-loadout-armyrps = Армейский РПС
 thunderdome-loadout-capo = Капоэйра
 thunderdome-loadout-mosin = Кардешёв-Мосина
 thunderdome-loadout-cqc = CQC

--- a/Resources/Prototypes/ADT/Thunderdome/thunderdome_gear.yml
+++ b/Resources/Prototypes/ADT/Thunderdome/thunderdome_gear.yml
@@ -11,6 +11,7 @@
     id: PassengerIDCard
     pocket1: WeaponPistolMk58
     pocket2: MagazinePistol
+    belt: ADTClothingRPSUSSP
   storage:
     back:
       - MedkitCombatFilled

--- a/Resources/Prototypes/ADT/Thunderdome/thunderdome_gear.yml
+++ b/Resources/Prototypes/ADT/Thunderdome/thunderdome_gear.yml
@@ -255,8 +255,3 @@
     back:
       - BoxLethalshot
       - BoxShotgunSlug
-
-- type: startingGear
-  id: ThunderdomeArmyRPS
-  equipment:
-    belt: ADTClothingRPSUSSP

--- a/Resources/Prototypes/ADT/Thunderdome/thunderdome_rule.yml
+++ b/Resources/Prototypes/ADT/Thunderdome/thunderdome_rule.yml
@@ -131,12 +131,6 @@
           description: thunderdome-desc-enforcer
           category: thunderdome-category-shotguns
           sprite: WeaponShotgunEnforcer
-      equipmentLoadouts:
-        - gear: ThunderdomeArmyRPS
-          name: thunderdome-loadout-armyrps
-          description: thunderdome-desc-armyrps
-          category: thunderdome-category-equipment
-          sprite: ADTClothingRPSUSSP
     - type: LoadMapRule
       mapPath: /Maps/Nonstations/dm01-entryway.yml
     - type: RuleGrids


### PR DESCRIPTION
## Описание PR
Убран выбор экипировки из меню снаряжения колизея. Армейский РПС теперь выдаётся всем бойцам в стартовом снаряжении (пояс).

## Почему / Баланс
Выбор экипировки отдельной секцией в меню был избыточен: РПС можно выдавать прямо в гире, без изменения кода. РПС не мешает: его можно не использовать или выбросить.

## Техническая информация
Откат системы выбора экипировки из меню колизея (ThunderdomeLoadoutEui, ThunderdomeLoadoutWindow, ThunderdomeRuleSystem, ThunderdomeRuleComponent, ThunderdomeLoadoutEuiMessages, локализация, equipmentLoadouts в правиле). РПС (ADTClothingRPSUSSP) добавлен в общий базовый гир ThunderdomeBaseGear в слот пояса, его получают все бойцы.

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог

:cl: ultradyper
- tweak: Армейский РПС теперь выдаётся всем бойцам колизея в стартовом снаряжении.