### PR TITLE
fix clown boots

### DIFF
--- a/Content.Client/ADT/Movement/Systems/WaddleAnimationSystem.cs
+++ b/Content.Client/ADT/Movement/Systems/WaddleAnimationSystem.cs
@@ -149,6 +149,6 @@ public sealed class WaddleAnimationSystem : SharedWaddleAnimationSystem
 
     private void OnComponentShutdown(Entity<WaddleAnimationComponent> entity, ref ComponentShutdown args)
     {
-        _animation.Stop(entity.Owner, entity.Comp.KeyName);
+        StopWaddling(entity);
     }
 }

--- a/Content.Shared/ADT/Movement/Components/WaddleAnimationComponent.cs
+++ b/Content.Shared/ADT/Movement/Components/WaddleAnimationComponent.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.ADT.Movement.Components;
@@ -26,7 +27,7 @@ public sealed class StoppedWaddlingEvent(NetEntity entity) : EntityEventArgs
 /// <summary>
 /// Defines something as having a waddle animation when it moves.
 /// </summary>
-[RegisterComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class WaddleAnimationComponent : Component
 {
     /// <summary>

--- a/Content.Shared/ADT/Movement/Systems/SharedWaddleAnimationSystem.cs
+++ b/Content.Shared/ADT/Movement/Systems/SharedWaddleAnimationSystem.cs
@@ -64,10 +64,18 @@ public abstract class SharedWaddleAnimationSystem : EntitySystem
         if (!TryComp<InputMoverComponent>(entity.Owner, out var moverComponent))
             return;
 
-        if ((moverComponent.HeldMoveButtons & MoveButtons.AnyDirection) != MoveButtons.None)
-        {
-            RaiseNetworkEvent(new StartedWaddlingEvent(GetNetEntity(entity.Owner)));
-        }
+        if ((moverComponent.HeldMoveButtons & MoveButtons.AnyDirection) == MoveButtons.None)
+            return;
+
+        if (entity.Comp.IsCurrentlyWaddling)
+            return;
+
+        if (!CanWaddle(entity.Owner))
+            return;
+
+        entity.Comp.IsCurrentlyWaddling = true;
+
+        RaiseNetworkEvent(new StartedWaddlingEvent(GetNetEntity(entity.Owner)));
     }
 
     private void OnMovementInput(Entity<WaddleAnimationComponent> entity, ref MoveInputEvent args)

--- a/Content.Shared/ADT/Movement/Systems/SharedWaddleAnimationSystem.cs
+++ b/Content.Shared/ADT/Movement/Systems/SharedWaddleAnimationSystem.cs
@@ -64,7 +64,7 @@ public abstract class SharedWaddleAnimationSystem : EntitySystem
         if (!TryComp<InputMoverComponent>(entity.Owner, out var moverComponent))
             return;
 
-        if ((moverComponent.HeldMoveButtons & MoveButtons.AnyDirection) == MoveButtons.AnyDirection)
+        if ((moverComponent.HeldMoveButtons & MoveButtons.AnyDirection) != MoveButtons.None)
         {
             RaiseNetworkEvent(new StartedWaddlingEvent(GetNetEntity(entity.Owner)));
         }


### PR DESCRIPTION
## Описание PR
Поторопился забыл синхронизировать

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- fix: Теперь глупая походка у клоунских ботинков показывается не только у владельца, но и у других.