### PR TITLE
add: Трайт Полиглот (дополнительный язык)

### DIFF
--- a/Content.Client/ADT/Language/UI/HumanoidProfileEditor.Languages.cs
+++ b/Content.Client/ADT/Language/UI/HumanoidProfileEditor.Languages.cs
@@ -22,7 +22,7 @@ public sealed partial class HumanoidProfileEditor
 
         LanguagesCountLabel.Text = Loc.GetString("humanoid-profile-editor-languages-count",
                                                 ("current", Profile.Languages.Count),
-                                                ("max", species.MaxLanguages));
+                                                ("max", species.MaxLanguages + Profile.LanguageSlotsBonus));
 
         var list = _prototypeManager.EnumeratePrototypes<LanguagePrototype>().Where(x => x.Roundstart).ToList();
         foreach (var item in species.UniqueLanguages)
@@ -63,7 +63,7 @@ public sealed partial class HumanoidProfileEditor
         };
         entry.SelectButton.Text = Loc.GetString(!Profile.Languages.Contains(proto) ? "language-lobby-add-button" : "language-lobby-remove-button");
         entry.SelectButton.ToolTip = null;
-        entry.SelectButton.Disabled = Profile.Languages.Count >= species.MaxLanguages && !Profile.Languages.Contains(proto);
+        entry.SelectButton.Disabled = Profile.Languages.Count >= species.MaxLanguages + Profile.LanguageSlotsBonus && !Profile.Languages.Contains(proto);
         entry.OnLanguageSelected += SelectLanguage;
         LanguagesList.AddChild(entry);
     }

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.Traits.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.Traits.cs
@@ -49,5 +49,6 @@ public sealed partial class HumanoidProfileEditor
 
         SetDirty();
         RefreshTraits();
+        RefreshLanguages(); // ADT-Tweak: лимит языков зависит от выбранных трайтов (Полиглот)
     }
 }

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -152,6 +152,16 @@ namespace Content.Shared.Preferences
         private HashSet<ProtoId<LanguagePrototype>> _languages = new();
 
         public IReadOnlySet<ProtoId<LanguagePrototype>> Languages => _languages;
+
+        /// <summary>
+        /// Трайт, дающий один дополнительный слот языка в редакторе персонажа.
+        /// </summary>
+        private static readonly ProtoId<TraitPrototype> PolyglotTraitId = "Polyglot";
+
+        /// <summary>
+        /// Бонус к лимиту языков от выбранных трайтов (трайт «Полиглот»).
+        /// </summary>
+        public int LanguageSlotsBonus => TraitPreferences.Contains(PolyglotTraitId) ? 1 : 0;
         // ADT Languages end
 
         /// <summary>
@@ -990,7 +1000,7 @@ namespace Content.Shared.Preferences
                 return new(this);
             if (_languages.Contains(language))
                 return new(this);
-            if (_languages.Count >= species.MaxLanguages)
+            if (_languages.Count >= species.MaxLanguages + LanguageSlotsBonus)
                 return new(this);
 
             HashSet<ProtoId<LanguagePrototype>> list = new(_languages);

--- a/Resources/Locale/en-US/ADT/traits/neutral.ftl
+++ b/Resources/Locale/en-US/ADT/traits/neutral.ftl
@@ -67,3 +67,6 @@ trait-voracious-desc = You eat faster than others, your metabolism is accelerate
 
 trait-drunk-tolerance-name = Alcohol Tolerance
 trait-drunk-tolerance-desc = You are less affected by alcohol, you need more to get drunk.
+
+trait-polyglot-name = Polyglot
+trait-polyglot-desc = You know one extra language: an additional language slot is available in the character editor.

--- a/Resources/Locale/ru-RU/ADT/traits/neutral.ftl
+++ b/Resources/Locale/ru-RU/ADT/traits/neutral.ftl
@@ -69,3 +69,6 @@ trait-drunk-tolerance-desc = Вы менее подвержены воздейс
 
 trait-invert-run-name = Инвертированный бег
 trait-invert-run-desc = Вы Pangaari? Нет? Не включайте.
+
+trait-polyglot-name = Полиглот
+trait-polyglot-desc = Вы знаете один дополнительный язык: в редакторе персонажа доступен ещё один слот языка.

--- a/Resources/Prototypes/ADT/Traits/languages.yml
+++ b/Resources/Prototypes/ADT/Traits/languages.yml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 ultradyper <ultradyper@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: trait
+  id: Polyglot
+  name: trait-polyglot-name
+  description: trait-polyglot-desc
+  category: LanguageTraits
+  cost: 1


### PR DESCRIPTION
## Описание PR
Новый трайт «Полиглот» в категории «Языки» за 1 очко: позволяет выбрать один дополнительный язык при создании персонажа.

## Почему / Баланс
Игроки, которым мало стандартного набора языков расы, могут вложить очко трайтов в знание дополнительного языка. Без трайта лимит языков не меняется.

## Техническая информация
- HumanoidCharacterProfile.LanguageSlotsBonus: бонус к лимиту языков от выбранных трайтов (сейчас Полиглот даёт +1).
- WithLanguage учитывает бонус при добавлении языка в профиль.
- Редактор персонажа: счётчик «Выбрано языков: N/M» и доступность кнопок языков считают максимум с учётом бонуса.
- При смене трайта языковая вкладка обновляется (правка ванили с маркером ADT-Tweak).
- Трайт Polyglot в готовой категории LanguageTraits (cost 1), без эффектов: выбранный в редакторе язык применяется при спавне из профиля автоматически.
- Локализация ru/en в neutral.ftl.

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
Скриншоты будут добавлены отдельным комментарием.

## Чейнджлог
:cl: ultradyper
- add: Добавлен трайт Полиглот, позволяющий выбрать один дополнительный язык при создании персонажа
