### PR TITLE
DoorClick Space Station 13

### DIFF
--- a/Content.Client/ADT/Silicons/DoorClickSystem.cs
+++ b/Content.Client/ADT/Silicons/DoorClickSystem.cs
@@ -1,0 +1,53 @@
+using Content.Client.Examine;
+using Content.Shared.ADT.Silicons;
+using Content.Shared.Doors.Components;
+using Content.Shared.Input;
+using Content.Shared.Interaction;
+using Content.Shared.Silicons.Borgs.Components;
+using Content.Shared.Silicons.StationAi;
+using Robust.Client.Player;
+using Robust.Shared.Input.Binding;
+using static Robust.Shared.Input.Binding.PointerInputCmdHandler;
+
+namespace Content.Client.ADT.Silicons;
+public sealed class DoorClickSystem : EntitySystem
+{
+    [Dependency] private readonly IPlayerManager _player = default!;
+
+    public override void Initialize()
+    {
+        CommandBinds.Builder
+            .BindBefore(ContentKeyFunctions.ExamineEntity, new PointerInputCmdHandler(OnShiftClick, outsidePrediction: true), typeof(ExamineSystem))
+            .BindBefore(ContentKeyFunctions.TryPullObject, new PointerInputCmdHandler(OnCtrlClick, outsidePrediction: true), typeof(SharedInteractionSystem))
+            .BindBefore(ContentKeyFunctions.AltActivateItemInWorld, new PointerInputCmdHandler(OnAltClick, outsidePrediction: true), typeof(SharedInteractionSystem))
+            .Register<DoorClickSystem>();
+    }
+
+    public override void Shutdown()
+    {
+        CommandBinds.Unregister<DoorClickSystem>();
+        base.Shutdown();
+    }
+
+    private bool OnShiftClick(in PointerInputCmdArgs args) => TryDoorClick(args, DoorClickAction.EmergencyAccess);
+
+    private bool OnCtrlClick(in PointerInputCmdArgs args) => TryDoorClick(args, DoorClickAction.Bolt);
+
+    private bool OnAltClick(in PointerInputCmdArgs args) => TryDoorClick(args, DoorClickAction.Electrify);
+
+    private bool TryDoorClick(in PointerInputCmdArgs args, DoorClickAction action)
+    {
+        if (!args.EntityUid.IsValid() || !Exists(args.EntityUid))
+            return false;
+
+        if (_player.LocalEntity is not { } player ||
+            (!HasComp<StationAiHeldComponent>(player) && !HasComp<BorgChassisComponent>(player)))
+            return false;
+
+        if (!HasComp<DoorComponent>(args.EntityUid))
+            return false;
+
+        RaiseNetworkEvent(new DoorClickEvent(GetNetEntity(args.EntityUid), action));
+        return true;
+    }
+}

--- a/Content.Server/ADT/Silicons/DoorClickSystem.cs
+++ b/Content.Server/ADT/Silicons/DoorClickSystem.cs
@@ -1,0 +1,63 @@
+using Content.Shared.ADT.Silicons;
+using Content.Shared.Doors.Components;
+using Content.Shared.Electrocution;
+using Content.Shared.Interaction;
+using Content.Shared.Silicons.Borgs.Components;
+using Content.Shared.Silicons.StationAi;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Player;
+
+namespace Content.Server.ADT.Silicons;
+public sealed class DoorClickSystem : EntitySystem
+{
+    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+
+    public override void Initialize()
+    {
+        SubscribeNetworkEvent<DoorClickEvent>(OnDoorClick);
+    }
+
+    private void OnDoorClick(DoorClickEvent msg, EntitySessionEventArgs args)
+    {
+        if (args.SenderSession.AttachedEntity is not { } user ||
+            (!HasComp<StationAiHeldComponent>(user) && !HasComp<BorgChassisComponent>(user)))
+            return;
+
+        var target = GetEntity(msg.Target);
+        if (!TryComp<DoorComponent>(target, out var door) ||
+            !TryComp<StationAiWhitelistComponent>(target, out var whitelist) ||
+            !whitelist.Enabled ||
+            !_interaction.InRangeUnobstructed(user, target))
+        {
+            return;
+        }
+
+        switch (msg.Action)
+        {
+            case DoorClickAction.EmergencyAccess:
+                RaiseLocalEvent(target,
+                    new StationAiEmergencyAccessEvent
+                    {
+                        User = user,
+                        EmergencyAccess = !TryComp(target, out AirlockComponent? airlock) || !airlock.EmergencyAccess,
+                    });
+                break;
+            case DoorClickAction.Bolt:
+                RaiseLocalEvent(target,
+                    new StationAiBoltEvent
+                    {
+                        User = user,
+                        Bolted = !TryComp(target, out DoorBoltComponent? bolt) || !bolt.BoltsDown,
+                    });
+                break;
+            case DoorClickAction.Electrify:
+                RaiseLocalEvent(target,
+                    new StationAiElectrifiedEvent
+                    {
+                        User = user,
+                        Electrified = !TryComp(target, out ElectrifiedComponent? electrified) || !electrified.Enabled,
+                    });
+                break;
+        }
+    }
+}

--- a/Content.Shared/ADT/Silicons/DoorClickEvent.cs
+++ b/Content.Shared/ADT/Silicons/DoorClickEvent.cs
@@ -1,0 +1,26 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.ADT.Silicons;
+public enum DoorClickAction : byte
+{
+    /// <summary> Включить или выключить аварийный доступ </summary>
+    EmergencyAccess,
+    /// <summary> Поднять или опустить болты </summary>
+    Bolt,
+    /// <summary> Включить или выключить электрификацию</summary>
+    Electrify,
+}
+
+[Serializable, NetSerializable]
+public sealed class DoorClickEvent : EntityEventArgs
+{
+    public NetEntity Target;
+
+    public DoorClickAction Action;
+
+    public DoorClickEvent(NetEntity target, DoorClickAction action)
+    {
+        Target = target;
+        Action = action;
+    }
+}

--- a/Content.Shared/Silicons/StationAi/Systems/SharedStationAiSystem.Held.cs
+++ b/Content.Shared/Silicons/StationAi/Systems/SharedStationAiSystem.Held.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Actions.Events;
+using Content.Shared.Doors.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Popups;
@@ -178,6 +179,11 @@ public abstract partial class SharedStationAiSystem
         {
             return;
         }
+
+        // ADT Tweak start
+        if (HasComp<DoorComponent>(args.Target))
+            return;
+        // ADT Tweak end
 
         var user = args.User;
         


### PR DESCRIPTION
## Описание PR
Более удобное управление дверями за Боргов и ИИ.
ШИФТ + ЛКМ ставит шлюз на аварийный доступ
АЛЬТ + ЛКМ ставит шлюз на электризацию
КТРЛ + ЛКМ ставит шлюз на болты.
Обычное нажатие по шлюзу или Е, открывает шлюз.

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- remove: Интерактивное окно с выбором действие с дверью на Борге/ИИ, оно было заменено на быстродействие сочетании клавиш
- add: ШИФТ + ЛКМ ставит шлюз на аварийный доступ
- add: АЛЬТ + ЛКМ ставит шлюз на электризацию
- add: КТРЛ + ЛКМ ставит шлюз на болты
- tweak: Обычное нажатие по шлюзу или Е, открывает шлюз.
