### PR TITLE
fix: вернуть молям возможность кушать комбезы

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
@@ -70,6 +70,8 @@
     slots: [underwearb, underweart]
   - type: Tag
     tags:
+      - ClothMade
+      - Recyclable
       - ADTJumpSuitSacrifice
       - WhitelistChameleon
   - type: HidesSlots


### PR DESCRIPTION
`ClothingUniformBase` при наследовании `UnsensoredClothingUniformBase` потерял теги `ClothMade` и `Recyclable`, из-за потери первого тега моли перестали иметь промпт на поедание комбезов

## Описание PR
Вернул возможность таракомолям и нианам есть комбезы путем добавления потеряных тегов

## Почему / Баланс
Таракомоли и Нианы должны иметь возможность есть комбезы, и имели ее, но потеряли

- [Баг-репорт](https://discord.com/channels/901772674865455115/1536804250217353276)

## Техническая информация
Изменен только прототип `ClothingUniformBase` , которому были добавлены теги `ClothMade` и `Recyclable`. 
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<img width="703" height="301" alt="image" src="https://github.com/user-attachments/assets/df718a31-62b1-4674-ba93-20f6b2177806" />

## Чейнджлог
:cl: FriendlyOneDev
- fix: Нианы и таракомоли теперь могут есть комбезы.
