### PR TITLE
fix: Диагностический визор показывает здоровье КПБ

### DIFF
--- a/Content.Client/Overlays/EntityHealthBarOverlay.cs
+++ b/Content.Client/Overlays/EntityHealthBarOverlay.cs
@@ -4,6 +4,7 @@ using Content.Client.UserInterface.Systems;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
 using Content.Shared.FixedPoint;
+using Content.Shared.Mech.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
@@ -32,6 +33,7 @@ public sealed class EntityHealthBarOverlay : Overlay
     private readonly SpriteSystem _spriteSystem;
     private readonly ProgressColorSystem _progressColor;
     private readonly DamageableSystem _damageable;
+    private readonly EntityQuery<MechComponent> _mechQuery;
 
 
     public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowFOV;
@@ -49,6 +51,7 @@ public sealed class EntityHealthBarOverlay : Overlay
         _spriteSystem = _entManager.System<SpriteSystem>();
         _progressColor = _entManager.System<ProgressColorSystem>();
         _damageable = _entManager.System<DamageableSystem>();
+        _mechQuery = _entManager.GetEntityQuery<MechComponent>();
     }
 
     protected override void Draw(in OverlayDrawArgs args)
@@ -93,8 +96,19 @@ public sealed class EntityHealthBarOverlay : Overlay
                 continue;
 
             // we are all progressing towards death every day
-            if (CalcProgress(uid, mobStateComponent, damageableComponent, mobThresholdsComponent) is not { } deathProgress)
+            // ADT-Tweak Start: у мехов полоска считается по Integrity/MaxIntegrity,
+            // их MobThresholds (Critical = 1000) не отражает реальное ХП (maxintegrity 170-500)
+            (float ratio, bool inCrit)? progress;
+            if (_mechQuery.TryGetComponent(uid, out var mech))
+                progress = mech.MaxIntegrity > 0
+                    ? (mech.Integrity.Float() / mech.MaxIntegrity.Float(), mech.Broken)
+                    : (1f, false);
+            else
+                progress = CalcProgress(uid, mobStateComponent, damageableComponent, mobThresholdsComponent);
+
+            if (progress is not { } deathProgress)
                 continue;
+            // ADT-Tweak End
 
             var worldPosition = _transform.GetWorldPosition(xform);
             var worldMatrix = Matrix3Helpers.CreateTranslation(worldPosition);

--- a/Content.Client/Overlays/EntityHealthBarOverlay.cs
+++ b/Content.Client/Overlays/EntityHealthBarOverlay.cs
@@ -4,7 +4,6 @@ using Content.Client.UserInterface.Systems;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
 using Content.Shared.FixedPoint;
-using Content.Shared.Mech.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
@@ -33,7 +32,6 @@ public sealed class EntityHealthBarOverlay : Overlay
     private readonly SpriteSystem _spriteSystem;
     private readonly ProgressColorSystem _progressColor;
     private readonly DamageableSystem _damageable;
-    private readonly EntityQuery<MechComponent> _mechQuery;
 
 
     public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowFOV;
@@ -51,7 +49,6 @@ public sealed class EntityHealthBarOverlay : Overlay
         _spriteSystem = _entManager.System<SpriteSystem>();
         _progressColor = _entManager.System<ProgressColorSystem>();
         _damageable = _entManager.System<DamageableSystem>();
-        _mechQuery = _entManager.GetEntityQuery<MechComponent>();
     }
 
     protected override void Draw(in OverlayDrawArgs args)
@@ -96,19 +93,8 @@ public sealed class EntityHealthBarOverlay : Overlay
                 continue;
 
             // we are all progressing towards death every day
-            // ADT-Tweak Start: у мехов полоска считается по Integrity/MaxIntegrity,
-            // их MobThresholds (Critical = 1000) не отражает реальное ХП (maxintegrity 170-500)
-            (float ratio, bool inCrit)? progress;
-            if (_mechQuery.TryGetComponent(uid, out var mech))
-                progress = mech.MaxIntegrity > 0
-                    ? (mech.Integrity.Float() / mech.MaxIntegrity.Float(), mech.Broken)
-                    : (1f, false);
-            else
-                progress = CalcProgress(uid, mobStateComponent, damageableComponent, mobThresholdsComponent);
-
-            if (progress is not { } deathProgress)
+            if (CalcProgress(uid, mobStateComponent, damageableComponent, mobThresholdsComponent) is not { } deathProgress)
                 continue;
-            // ADT-Tweak End
 
             var worldPosition = _transform.GetWorldPosition(xform);
             var worldMatrix = Matrix3Helpers.CreateTranslation(worldPosition);

--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/clothing/eyes/hud.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/clothing/eyes/hud.ftl
@@ -2,10 +2,8 @@ ent-ShowSecurityIcons = { "" }
     .desc = { "" }
 ent-ShowMedicalIcons = { "" }
     .desc = { "" }
-# ADT-Tweak-Start: из описания убраны экзокостюмы (мехи не поддерживаются визором)
 ent-ClothingEyesHudDiagnostic = диагностический визор
     .desc = Окуляр с индикатором на стекле, способный анализировать целостность и состояние роботов. Сделан из си-боргия.
-# ADT-Tweak-End
 ent-ClothingEyesHudMedical = медицинский визор
     .desc = Окуляр с индикатором на стекле, который сканирует гуманоидов в поле зрения и предоставляет точные данные о состоянии их здоровья.
 ent-ClothingEyesHudSecurity = визор охраны
@@ -47,9 +45,7 @@ ent-ClothingEyesEyepatchHudBeer = пивной монокуляр
     .desc = Пара солнцезащитных очков, оснащённых сканером реагентов, а также дающих понимание вязкости жидкости во время движения. Для настоящих патриотов.
 ent-ClothingEyesEyepatchHudBeerFlipped = пивной монокуляр
     .desc = { ent-ClothingEyesEyepatchHudBeer.desc }
-# ADT-Tweak-Start: из описания убраны экзокостюмы (мехи не поддерживаются визором)
 ent-ClothingEyesEyepatchHudDiag = диагностический моновизор
     .desc = Окуляр с индикатором на стекле, способный анализировать целостность и состояние роботов. Сделан из си-боргия.
-# ADT-Tweak-End
 ent-ClothingEyesEyepatchHudDiagFlipped = diagnostic hud eyepatch
     .desc = { ent-ClothingEyesEyepatchHudDiag.desc }

--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/clothing/eyes/hud.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/clothing/eyes/hud.ftl
@@ -2,8 +2,10 @@ ent-ShowSecurityIcons = { "" }
     .desc = { "" }
 ent-ShowMedicalIcons = { "" }
     .desc = { "" }
+# ADT-Tweak-Start: из описания убраны экзокостюмы (мехи не поддерживаются визором)
 ent-ClothingEyesHudDiagnostic = диагностический визор
-    .desc = Окуляр с индикатором на стекле, способный анализировать целостность и состояние роботов и экзокостюмов. Сделан из си-боргия.
+    .desc = Окуляр с индикатором на стекле, способный анализировать целостность и состояние роботов. Сделан из си-боргия.
+# ADT-Tweak-End
 ent-ClothingEyesHudMedical = медицинский визор
     .desc = Окуляр с индикатором на стекле, который сканирует гуманоидов в поле зрения и предоставляет точные данные о состоянии их здоровья.
 ent-ClothingEyesHudSecurity = визор охраны
@@ -45,7 +47,9 @@ ent-ClothingEyesEyepatchHudBeer = пивной монокуляр
     .desc = Пара солнцезащитных очков, оснащённых сканером реагентов, а также дающих понимание вязкости жидкости во время движения. Для настоящих патриотов.
 ent-ClothingEyesEyepatchHudBeerFlipped = пивной монокуляр
     .desc = { ent-ClothingEyesEyepatchHudBeer.desc }
+# ADT-Tweak-Start: из описания убраны экзокостюмы (мехи не поддерживаются визором)
 ent-ClothingEyesEyepatchHudDiag = диагностический моновизор
-    .desc = Окуляр с индикатором на стекле, способный анализировать целостность и состояние роботов и экзокостюмов. Сделан из си-боргия.
+    .desc = Окуляр с индикатором на стекле, способный анализировать целостность и состояние роботов. Сделан из си-боргия.
+# ADT-Tweak-End
 ent-ClothingEyesEyepatchHudDiagFlipped = diagnostic hud eyepatch
     .desc = { ent-ClothingEyesEyepatchHudDiag.desc }

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -39,6 +39,9 @@
     damageContainers:
     - Inorganic
     - Silicon
+    # ADT-Tweak Start: КПБ (IPC) видны в диагностическом визоре
+    - ADTSiliconDamageContainer
+    # ADT-Tweak End
   - type: ShowAccessReaderSettings
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -39,9 +39,9 @@
     damageContainers:
     - Inorganic
     - Silicon
-    # ADT-Tweak Start: КПБ (IPC) видны в диагностическом визоре
+    # ADT-Tweak-Start: КПБ (IPC) видны в диагностическом визоре
     - ADTSiliconDamageContainer
-    # ADT-Tweak End
+    # ADT-Tweak-End
   - type: ShowAccessReaderSettings
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -39,9 +39,8 @@
     damageContainers:
     - Inorganic
     - Silicon
-    # ADT-Tweak Start: КПБ (IPC) и мехи видны в диагностическом визоре
+    # ADT-Tweak Start: КПБ (IPC) видны в диагностическом визоре
     - ADTSiliconDamageContainer
-    - StructuralInorganic
     # ADT-Tweak End
   - type: ShowAccessReaderSettings
 

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -39,8 +39,9 @@
     damageContainers:
     - Inorganic
     - Silicon
-    # ADT-Tweak Start: КПБ (IPC) видны в диагностическом визоре
+    # ADT-Tweak Start: КПБ (IPC) и мехи видны в диагностическом визоре
     - ADTSiliconDamageContainer
+    - StructuralInorganic
     # ADT-Tweak End
   - type: ShowAccessReaderSettings
 


### PR DESCRIPTION
## Описание PR
Диагностический визор теперь показывает здоровье КПБ: над ними отображается полоска ХП, как медицинский визор показывает её над обычными людьми.

## Почему / Баланс
КПБ используют собственный контейнер урона (ADTSiliconDamageContainer), который не входил в список контейнеров диагностического визора, из-за чего их здоровье не отображалось.

## Техническая информация
В компонент `ShowHealthBars` диагностического визора (`ClothingEyesHudDiagnostic`) добавлен контейнер урона `ADTSiliconDamageContainer`. Повязка-визор наследует прототип, поэтому изменение покрывает оба предмета.

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа

## Чейнджлог

:cl: ultradyper
- fix: Диагностический визор теперь показывает здоровье КПБ
