### PR TITLE
fix: Мини-паук больше не открывает двери, новакиды не получают яд от сварочного топлива

### DIFF
--- a/Resources/Prototypes/ADT/Body/Species/novakid.yml
+++ b/Resources/Prototypes/ADT/Body/Species/novakid.yml
@@ -24,10 +24,10 @@
       Appendix: OrganHumanAppendix
       Ears: OrganHumanEars
       Lungs: ADTOrganNovakidLungs
-      Heart: OrganHumanHeart
-      Stomach: OrganHumanStomach
-      Liver: OrganHumanLiver
-      Kidneys: OrganHumanKidneys
+      Heart: ADTOrganNovakidHeart
+      Stomach: ADTOrganNovakidStomach
+      Liver: ADTOrganNovakidLiver
+      Kidneys: ADTOrganNovakidKidneys
   - type: HumanoidProfile
     species: NovakidSpecies
   - type: Inventory
@@ -249,6 +249,26 @@
   components:
   - type: Metabolizer
     metabolizerTypes: [ Novakid ]
+
+# ADT-Tweak Start: внутренние органы новакида с типом метаболизатора Novakid
+# (раньше использовались человеческие органы, из-за чего условия MetabolizerTypeCondition
+# для Novakid не работали: новакиды получали яд от сварочного топлива и др. пиротехники)
+- type: entity
+  id: ADTOrganNovakidHeart
+  parent: [ OrganBaseHeart, OrganSpriteHumanInternal, ADTOrganNovakidMetabolizer ]
+
+- type: entity
+  id: ADTOrganNovakidStomach
+  parent: [ OrganBaseStomach, OrganSpriteHumanInternal, ADTOrganNovakidMetabolizer ]
+
+- type: entity
+  id: ADTOrganNovakidLiver
+  parent: [ OrganBaseLiver, OrganSpriteHumanInternal, ADTOrganNovakidMetabolizer ]
+
+- type: entity
+  id: ADTOrganNovakidKidneys
+  parent: [ OrganBaseKidneys, OrganSpriteHumanInternal, ADTOrganNovakidMetabolizer ]
+# ADT-Tweak End
 
 - type: entity
   id: ADTOrganNovakidVisual

--- a/Resources/Prototypes/ADT/Body/Species/novakid.yml
+++ b/Resources/Prototypes/ADT/Body/Species/novakid.yml
@@ -250,9 +250,6 @@
   - type: Metabolizer
     metabolizerTypes: [ Novakid ]
 
-# ADT-Tweak Start: внутренние органы новакида с типом метаболизатора Novakid
-# (раньше использовались человеческие органы, из-за чего условия MetabolizerTypeCondition
-# для Novakid не работали: новакиды получали яд от сварочного топлива и др. пиротехники)
 - type: entity
   id: ADTOrganNovakidHeart
   parent: [ OrganBaseHeart, OrganSpriteHumanInternal, ADTOrganNovakidMetabolizer ]
@@ -268,7 +265,6 @@
 - type: entity
   id: ADTOrganNovakidKidneys
   parent: [ OrganBaseKidneys, OrganSpriteHumanInternal, ADTOrganNovakidMetabolizer ]
-# ADT-Tweak End
 
 - type: entity
   id: ADTOrganNovakidVisual

--- a/Resources/Prototypes/ADT/Entities/Mobs/NPCs/spiders.yml
+++ b/Resources/Prototypes/ADT/Entities/Mobs/NPCs/spiders.yml
@@ -371,12 +371,9 @@
         - SmallMobMask
         layer:
         - SmallMobLayer
-  # ADT-Tweak Start: мини-паук проходит под дверями как мышь и не должен их триггерить
-  # (DoorBumpOpener убран из наследуемых тегов ADTMobBaseSpider)
   - type: Tag
     tags:
     - FootstepSound
-  # ADT-Tweak End
   - type: DamageStateVisuals
     states:
       Alive:

--- a/Resources/Prototypes/ADT/Entities/Mobs/NPCs/spiders.yml
+++ b/Resources/Prototypes/ADT/Entities/Mobs/NPCs/spiders.yml
@@ -371,6 +371,12 @@
         - SmallMobMask
         layer:
         - SmallMobLayer
+  # ADT-Tweak Start: мини-паук проходит под дверями как мышь и не должен их триггерить
+  # (DoorBumpOpener убран из наследуемых тегов ADTMobBaseSpider)
+  - type: Tag
+    tags:
+    - FootstepSound
+  # ADT-Tweak End
   - type: DamageStateVisuals
     states:
       Alive:


### PR DESCRIPTION
## Описание PR
Два фикса багов:
1. Мини-паук (little spider) больше не триггерит двери: двери не открываются и не выдают его местоположение, паучок проходит под ними как мышь.
2. Новакиды больше не получают ядовитый урон от сварочного топлива и других горючих веществ (термит, напалм и т.д.) - для них работает задуманная механика: утоление жажды и конверсия топлива в этанол.

## Почему / Баланс
1. Мини-паук наследовал тег DoorBumpOpener от базы пауков, из-за чего двери реагировали на него, хотя он проходит под ними (фикстура как у мыши). Мышь тег не имеет, поэтому двери на неё не реагируют.
2. Внутренние органы новакидов использовали человеческий тип метаболизатора, из-за чего условия иммунитета к яду (MetabolizerTypeCondition) для новакидов не срабатывали: яд действовал, а утоление жажды и конверсия в этанол не работали.

## Техническая информация
1. Resources/Prototypes/ADT/Entities/Mobs/NPCs/spiders.yml: у ADTMobMiniSpider тег DoorBumpOpener убран (тег переопределён, остаётся FootstepSound).
2. Resources/Prototypes/ADT/Body/Species/novakid.yml: добавлены ADTOrganNovakidHeart/Stomach/Liver/Kidneys с metabolizerTypes [Novakid] (по образцу ADTOrganNovakidLungs), InitialBody новакида использует их вместо человеческих органов.

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа

## Чейнджлог

:cl: ultradyper
- fix: Мини-паук больше не открывает двери, проходя под ними как мышь
- fix: Новакиды больше не получают ядовитый урон от сварочного топлива и других горючих веществ
