### PR TITLE
fix: КПБ не могут быть еретиком, бригмедик без лишнего магазина, карманы бронежилету бригмедика

### DIFF
--- a/Resources/Prototypes/ADT/GameRules/roundstart.yml
+++ b/Resources/Prototypes/ADT/GameRules/roundstart.yml
@@ -34,6 +34,9 @@
     - prefRoles: [ Heretic ]
       max: 4
       playerRatio: 15
+      blacklist:
+        components:
+        - MobIpc
       lateJoinAdditional: true
       mindComponents:
       - type: HereticRole
@@ -51,6 +54,9 @@
     - prefRoles: [ Heretic ]
       max: 1
       playerRatio: 15
+      blacklist:
+        components:
+        - MobIpc
       lateJoinAdditional: true
       mindComponents:
       - type: HereticRole
@@ -193,6 +199,9 @@
     - prefRoles: [ Heretic ]
       max: 2
       playerRatio: 15
+      blacklist:
+        components:
+        - MobIpc
       lateJoinAdditional: true
       mindComponents:
       - type: HereticRole
@@ -210,6 +219,9 @@
     - prefRoles: [ Heretic ]
       max: 3
       playerRatio: 15
+      blacklist:
+        components:
+        - MobIpc
       lateJoinAdditional: true
       mindComponents:
       - type: HereticRole

--- a/Resources/Prototypes/ADT/Roles/Antags/heretic.yml
+++ b/Resources/Prototypes/ADT/Roles/Antags/heretic.yml
@@ -7,4 +7,8 @@
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 270000 #75 hrs
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - IPC
   guides: [ Heretics ]

--- a/Resources/Prototypes/ADT/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/ADT/Roles/Jobs/Security/brigmedic.yml
@@ -44,7 +44,7 @@
   storage:
     back:
     - Flash
-    - MagazinePistol
+    # - MagazinePistol: магазин идёт в комплекте с МК-58 из ваучера РВИ
 
 - type: chameleonOutfit
   id: BrigmedicChameleonOutfit

--- a/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/vests.yml
@@ -24,6 +24,20 @@
       sprite: Corvax/Clothing/OuterClothing/Vests/armor_sec_med.rsi
     - type: Clothing
       sprite: Corvax/Clothing/OuterClothing/Vests/armor_sec_med.rsi
+    # ADT-Tweak-Start: описание жилета обещает карманы для мелочёвки, Storage не было
+    - type: Storage
+      grid:
+      - 0,0,2,1
+      maxItemSize: Small
+    - type: ContainerContainer
+      containers:
+        storagebase: !type:Container
+          ents: []
+    - type: UserInterface
+      interfaces:
+        enum.StorageUiKey.Key:
+          type: StorageBoundUserInterface
+    # ADT-Tweak-End
 
 - type: entity
   parent: [ClothingOuterBase, BadgeOnClothing] #ADT-Tweak

--- a/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/vests.yml
@@ -33,6 +33,10 @@
       containers:
         storagebase: !type:Container
           ents: []
+        badge: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
     - type: UserInterface
       interfaces:
         enum.StorageUiKey.Key:

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -39,7 +39,6 @@
     damageContainers:
     - Silicon
   - type: BorgSwitchableSubtype
-  - type: IgnoreUIRange
   - type: ShowElectrocutionHUD
   - type: StationAiVision
   # ADT-Tweak end


### PR DESCRIPTION
## Описание PR
Четыре багфикса:
1. КПБ (раса IPC) больше не могут быть еретиками: в требования антага добавлен запрет по виду, а во все правила еретика - блэклист компонента КПБ. В редакторе персонажа у КПБ на еретике теперь замок.
2. Бригмедик больше не получает раундстартом магазин МК-58 в сумке: магазин выдаётся только в комплекте с МК-58 через ваучер РВИ, при выборе лазерного пистолета лишнего магазина нет.
3. Бронежилет бригмедика получил карманы для мелочёвки, как и обещает описание.
4. Сумки закрываются у борга при отходе на 2 тайла: убрана IgnoreUIRange, которая отключала проверку дальности для всех окон, включая сумки. Удалённое взаимодействие с электроникой (APC, шлюзы, консоли) не затронуто - оно работает через прямую видимость.

## Почему / Баланс
1. Еретик не сочетается с КПБ, выглядело как баг.
2. Лишний магазин бесполезен при выборе лазерного пистолета и захламляет сумку.
3. Описание обещало карманы, а их не было.
4. Борг мог открыть сумку, отойти на любое расстояние и перекладывать предметы, сумка не закрывалась.

## Техническая информация
- `heretic.yml`: requirements антага дополнены `SpeciesRequirement` (inverted, species: IPC) - замок в редакторе и отсев кандидатов на сервере.
- `roundstart.yml`: во все 4 определения еретика (Heretic, HereticSoloGameRule, HereticDuoGameRule, HereticTripleGameRule) добавлен `blacklist: components: [MobIpc]` - страховка на уровне сущности, не зависит от cvar ролевых таймеров.
- `brigmedic.yml`: `MagazinePistol` закомментирован в `BrigmedicGear` (storage.back); комплект МК-58 из ваучера уже включает магазин.
- `vests.yml` (Corvax): `ClothingOuterVestArmorMedSec` добавлены `Storage` (grid 0,0,2,1, maxItemSize Small), `ContainerContainer` storagebase и `UserInterface` StorageBoundUserInterface (паттерн ClothingOuterStorageBase), с маркерами ADT-Tweak.
- `borg_chassis.yml`: у `BorgChassisSelectable` убрана `IgnoreUIRange` (добавлена в #2807 для удалённой электроники, но отключала проверку дальности для всех окон, включая сумки). Удалённое взаимодействие с электроникой работает через `InRangeOverrideEvent` и прямую видимость и не зависит от `IgnoreUIRange`.

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
Скриншоты добавлю отдельным комментарием.

## Чейнджлог
:cl: ultradyper
- fix: КПБ больше не могут быть еретиками
- fix: Бригмедик больше не получает лишний магазин МК-58 при выборе оружия через РВИ
- fix: Бронежилет бригмедика теперь имеет карманы, как и обещает описание
- fix: Сумки закрываются у борга при отходе на 2 тайла
