### PR TITLE
fix chat poitiong

### DIFF
--- a/Content.Client/ADT/UserInterface/RichText/BaseTextureTag.cs
+++ b/Content.Client/ADT/UserInterface/RichText/BaseTextureTag.cs
@@ -32,16 +32,17 @@ public abstract class BaseTextureTag
         return true;
     }
 
-    protected static bool TryDrawIconEntity(NetEntity netEntity, long spriteSize, long scaleValue, Vector2 offset, [NotNullWhen(true)] out Control? control)
+    protected static bool TryDrawIconEntity(NetEntity netEntity, long scaleValue, Vector2 offset, [NotNullWhen(true)] out Control? control)
     {
         control = null;
         var spriteView = new StaticSpriteView()
         {
             OverrideDirection = Direction.South,
-            Stretch = StaticSpriteView.StretchMode.None,
+            Stretch = StaticSpriteView.StretchMode.Fill,
             Offset = offset,
             SpriteOffset = true,
             RectClipContent = false,
+            SetSize = new Vector2(32, 32),
         };
 
         spriteView.SetEntity(netEntity);

--- a/Content.Client/ADT/UserInterface/RichText/EntityTextureTag.cs
+++ b/Content.Client/ADT/UserInterface/RichText/EntityTextureTag.cs
@@ -19,11 +19,6 @@ public sealed class EntityTextureTag : BaseTextureTag, IMarkupTagHandler
         if (!node.Attributes.TryGetValue("id", out var idParameter) || !MarkupHelpers.TryGetLong(idParameter, out var id))
             return false;
 
-        if (!node.Attributes.TryGetValue("size", out var size) || !MarkupHelpers.TryGetLong(size, out var sizeValue))
-        {
-            sizeValue = 32;
-        }
-
         if (!node.Attributes.TryGetValue("scale", out var scale) || !MarkupHelpers.TryGetLong(scale, out var scaleValue))
         {
             scaleValue = 2;
@@ -35,7 +30,7 @@ public sealed class EntityTextureTag : BaseTextureTag, IMarkupTagHandler
         if (!node.Attributes.TryGetValue("offsetY", out var yParameter) || !MarkupHelpers.TryGetLong(yParameter, out var y))
             y = 0;
 
-        if (!TryDrawIconEntity(new NetEntity((int) id), sizeValue.Value, scaleValue.Value, new Vector2((float) x, (float) y), out var texture))
+        if (!TryDrawIconEntity(new NetEntity((int) id), scaleValue.Value, new Vector2((float) x, (float) y), out var texture))
             return false;
 
         control = texture;


### PR DESCRIPTION
## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<img width="472" height="185" alt="image" src="https://github.com/user-attachments/assets/c134177f-55aa-4d9c-88c2-1fdafd43f526" />

## Чейнджлог
:cl: CrimeMoot
- fix: При указании на объект, чат больше не разрывает из-за большой модельки. Теперь все указание имеют фиксированный размер
