### PR TITLE
add: Клоуны лечатся банановым соком

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/juice.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/juice.yml
@@ -16,6 +16,22 @@
   physicalDesc: reagent-physical-desc-crisp
   flavor: banana
   color: "#FFE777"
+  # ADT-Tweak-Start: клоуны лечатся банановым соком (по аналогии с лечением дварфов алкоголем)
+  metabolisms:
+    Digestion:
+      effects:
+      - !type:SatiateThirst
+        factor: 3
+      - !type:EvenHealthChange
+        conditions:
+        - !type:ReagentCondition
+          reagent: JuiceBanana
+          min: 5
+        - !type:JobCondition
+          jobs: [ Clown ]
+        damage:
+          Brute: -0.5
+  # ADT-Tweak-End
 
 - type: reagent
   id: JuiceBerry


### PR DESCRIPTION
## Описание PR
Клоуны теперь лечатся от бананового сока: пока сок переваривается в желудке, клоун восстанавливает механический урон (по аналогии с тем, как дварфы лечатся от алкоголя).

## Почему / Баланс
Механика из SS13. Лечение слабое: -0.5 урона группы Brute за 1u сока (стакан ~30u = ~30 механики за ~минуту переваривания), минимум 5u в желудке. Работает только у игроков с работой Клоун и только при питье.

## Техническая информация
- Реагент JuiceBanana получил метаболизм Digestion с эффектом EvenHealthChange (группа Brute, -0.5) и условиями: ReagentCondition (JuiceBanana >= 5u) + JobCondition (jobs: Clown).
- SatiateThirst из BaseDrink сохранён в списке эффектов явно, чтобы не потерять утоление жажды при наследовании метаболизмов.
- C# не изменялся, использован готовый JobCondition (проверяет текущую работу сущности через mind).
- Правка ванильного файла с маркером ADT-Tweak, YAML Linter чистый.

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
Скриншоты добавлю отдельным комментарием.

## Чейнджлог
:cl: ultradyper
- add: Клоуны лечатся банановым соком
