### PR TITLE
fix: Вылет клиента в режиме совместимости из-за шейдера ПНВ

### DIFF
--- a/Resources/Textures/ADT/Shaders/night_vision_device.swsl
+++ b/Resources/Textures/ADT/Shaders/night_vision_device.swsl
@@ -13,7 +13,7 @@ uniform highp float ScanlineDark;
 
 void fragment()
 {
-    const vec3 NV_COLOR = vec3(0.4, 0.85, 0.4);
+    const highp vec3 NV_COLOR = vec3(0.4, 0.85, 0.4);
     COLOR = zTextureSpec(SCREEN_TEXTURE, Pos);
 
     highp float Y = dot(COLOR.rgb, vec3(0.2126, 0.7152, 0.0722));


### PR DESCRIPTION
## Описание PR
Исправлен вылет клиента в режиме совместимости: шейдер ПНВ (night_vision_device.swsl) не компилировался из-за объявления `const vec3 NV_COLOR` без квалификатора точности. Добавлен `highp`.

## Почему / Баланс
Регрессия от #3128: в GLES2 (режим совместимости) у float нет точности по умолчанию, компилятор падает с «No precision specified for (float)». На обычном OpenGL шейдер компилировался, поэтому баг проявлялся только в режиме совместимости: клиент не запускался вообще.

## Техническая информация
- Изменение в одну строку: `const vec3 NV_COLOR` -> `const highp vec3 NV_COLOR` (по конвенции SS14 все числовые типы в SWSL обязаны иметь квалификатор точности highp/lowp/mediump).
- Проверено: сканирование всех .swsl в репо на объявления без квалификаторов (нарушитель был один), игровой тест в режиме совместимости пройден.

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
Не требуется: фикс вылета, визуальных изменений нет.

## Чейнджлог
:cl: ultradyper
- fix: Исправлен вылет клиента в режиме совместимости из-за шейдера ПНВ
