### PR TITLE
feat: таракомоли надргызают случайный предмет одежды при атаке, а также небольшие фиксы тегов одежды

### DIFF
--- a/Content.Server/ADT/ClothesBite/ClothesBiteOnHitSystem.cs
+++ b/Content.Server/ADT/ClothesBite/ClothesBiteOnHitSystem.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using Content.Shared.ADT.ClothesBite;
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Systems;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.FixedPoint;
+using Content.Shared.Inventory;
+using Content.Shared.Nutrition;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Nutrition.EntitySystems;
+using Content.Shared.Weapons.Melee.Events;
+using Robust.Shared.Random;
+
+namespace Content.Server.ADT.ClothesBite;
+
+/// <summary>
+/// Lets an attacker (mothroach) feed off a struck mob's worn, digestible clothing.
+/// </summary>
+public sealed class ClothesBiteOnHitSystem : EntitySystem
+{
+    [Dependency] private readonly BodySystem _body = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly IngestionSystem _ingestion = default!;
+    [Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
+    [Dependency] private readonly StomachSystem _stomach = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ClothesBiteOnHitComponent, MeleeHitEvent>(OnMeleeHit);
+    }
+
+    private void OnMeleeHit(Entity<ClothesBiteOnHitComponent> ent, ref MeleeHitEvent args)
+    {
+        if (args.HitEntities.Count == 0)
+            return;
+
+        if (!_body.TryGetOrgansWithComponent<StomachComponent>(ent.Owner, out var stomachs))
+            return;
+
+        foreach (var target in args.HitEntities)
+        {
+            if (target == ent.Owner)
+                continue;
+
+            BiteWornClothing(ent, stomachs, target);
+        }
+    }
+
+    private void BiteWornClothing(Entity<ClothesBiteOnHitComponent> ent, List<Entity<StomachComponent>> stomachs, EntityUid target)
+    {
+        // Only actually-worn clothing, not pocket contents.
+        if (!_inventory.TryGetContainerSlotEnumerator(target, out var enumerator, SlotFlags.WITHOUT_POCKET))
+            return;
+
+        var edible = new List<EntityUid>();
+        while (enumerator.NextItem(out var item, out _))
+        {
+            if (CanBite(item, stomachs))
+                edible.Add(item);
+        }
+
+        if (edible.Count == 0)
+            return;
+
+        Bite(ent, stomachs, _random.Pick(edible));
+    }
+
+    private bool CanBite(EntityUid item, List<Entity<StomachComponent>> stomachs)
+    {
+        if (!TryComp<EdibleComponent>(item, out var edible))
+            return false;
+
+        if (!_solutionContainer.TryGetSolution(item, edible.Solution, out _, out var solution) || solution.Volume <= 0)
+            return false;
+
+        return _ingestion.IsDigestibleBy(item, stomachs, out _);
+    }
+
+    private void Bite(Entity<ClothesBiteOnHitComponent> ent, List<Entity<StomachComponent>> stomachs, EntityUid item)
+    {
+        if (!TryComp<EdibleComponent>(item, out var edible))
+            return;
+
+        if (!_solutionContainer.TryGetSolution(item, edible.Solution, out var soln, out var solution) || solution.Volume <= 0)
+            return;
+
+        Entity<StomachComponent>? stomach = null;
+        foreach (var candidate in stomachs)
+        {
+            if (_ingestion.IsDigestibleBy(item, candidate))
+            {
+                stomach = candidate;
+                break;
+            }
+        }
+
+        if (stomach == null)
+            return;
+
+        var amount = FixedPoint2.Min(ent.Comp.Amount, solution.Volume);
+        var split = _solutionContainer.SplitSolution(soln.Value, amount);
+        _stomach.TryTransferSolution(stomach.Value.Owner, split, stomach.Value.Comp);
+
+        // Drained dry: finish it off like a full eat (fires FullyEatenEvent, then deletes).
+        if (solution.Volume <= 0 && edible.DestroyOnEmpty)
+        {
+            var finishedEv = new FullyEatenEvent(ent.Owner);
+            RaiseLocalEvent(item, ref finishedEv);
+            QueueDel(item);
+        }
+    }
+}

--- a/Content.Server/ADT/ClothesBite/ClothesBiteOnHitSystem.cs
+++ b/Content.Server/ADT/ClothesBite/ClothesBiteOnHitSystem.cs
@@ -35,7 +35,7 @@ public sealed class ClothesBiteOnHitSystem : EntitySystem
 
     private void OnMeleeHit(Entity<ClothesBiteOnHitComponent> ent, ref MeleeHitEvent args)
     {
-        if (args.HitEntities.Count == 0)
+        if (!args.IsHit || args.HitEntities.Count == 0)
             return;
 
         if (!_body.TryGetOrgansWithComponent<StomachComponent>(ent.Owner, out var stomachs))

--- a/Content.Shared/ADT/ClothesBite/ClothesBiteOnHitComponent.cs
+++ b/Content.Shared/ADT/ClothesBite/ClothesBiteOnHitComponent.cs
@@ -1,0 +1,18 @@
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared.ADT.ClothesBite;
+
+/// <summary>
+/// When this entity melee-attacks a mob that wears clothing it can digest, it draws <see cref="Amount"/>
+/// from one such garment's food solution (chosen at random) into its stomach, as if it had taken a bite.
+/// Used by mothroaches so they can feed off worn clothing by attacking.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ClothesBiteOnHitComponent : Component
+{
+    /// <summary>
+    /// How much of the garment's food solution is drawn per attack.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 Amount = FixedPoint2.New(2);
+}

--- a/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Entities/Clothing/Uniforms/jumpsuit_tsf.yml
+++ b/Resources/Prototypes/ADT/ADTGlobalEvents/ShipBattle/Entities/Clothing/Uniforms/jumpsuit_tsf.yml
@@ -16,7 +16,7 @@
   # - type: StationLimitedNetwork
   # ADT-Tweak End
   - type: Tag
-    tags: [] # ignore "WhitelistChameleon" tag
+    tags: [ ClothMade, Recyclable ]
 
 #Command
 

--- a/Resources/Prototypes/ADT/Entities/Clothing/Uniforms/Jumpsuits.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/Uniforms/Jumpsuits.yml
@@ -1324,6 +1324,7 @@
     tags:
     - ClownSuit
     - WhitelistChameleon
+    - ClothMade
 
 # Бармен
 

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpsuits.yml
@@ -55,11 +55,6 @@
       - state: equipped-INNERCLOTHING
         color: "#b3b3b3"
       - state: trinkets-equipped-INNERCLOTHING
-### Start ADT Tweak
-  - type: Tag
-    tags:
-      - ADTJumpSuitSacrifice
-### End ADT Tweak
 
 # Black Jumpsuit
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -204,6 +204,7 @@
     tags:
     - ClownSuit
     - WhitelistChameleon
+    - ClothMade
 
 - type: entity
   parent: ClothingUniformJumpsuitClown

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -691,7 +691,9 @@
     growth: 0.05
     maxGrowth: 2
     #ADT-Tweak-End-Port-Goob-EatToGrowSystem
+  #ADT-Tweak-Start
   - type: ClothesBiteOnHit
+  #ADT-Tweak-End
 
 # Note that the mallard duck is actually a male drake mallard, with the brown duck being the female variant of the same species, however ss14 lacks sex specific textures
 # The white duck is more akin to a pekin or call duck.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -691,6 +691,7 @@
     growth: 0.05
     maxGrowth: 2
     #ADT-Tweak-End-Port-Goob-EatToGrowSystem
+  - type: ClothesBiteOnHit
 
 # Note that the mallard duck is actually a male drake mallard, with the brown duck being the female variant of the same species, however ss14 lacks sex specific textures
 # The white duck is more akin to a pekin or call duck.


### PR DESCRIPTION
## Описание PR
Таракомоли надгрызают случайный предмет одежды на мобе при атаке. Также, небольшие фиксы тегов одежды, которые в некоторых местах потеряли тег `ClothMade`

## Почему / Баланс
Почему - `¯\_(ツ)_/¯`
Мне кажется это интересной и забавной механикой. 

Баланс: 
Комбезы, униформы, зимние куртки 30 унций - 15 ударов
Плащи 20 унций - 10 ударов
Обувь, шапки, маски, перчатки, носки, трусы, т.д. 10 унций - 5 ударов

- [Предложение](https://discord.com/channels/901772674865455115/1537834317756235936)

## Техническая информация
Добавлен новый компонент `ClothesBiteOnHit`, и механика поедания одетой одежды моба. Одежда "поедается" перемещая 2 унции `Fiber` из одежды, в живот таракомоли. При каждом ударе, одежда, которая надгрызается, выбирается случайно.

**Поедается только та одежда, которая может поедаться. Вся броня, термалы, т.д. поедаться не может. У них нет тега `ClothMade`**
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
- [ДС](https://discord.com/channels/901772674865455115/1537834317756235936/1537834317756235936)

## Чейнджлог

:cl: FriendlyOne
- add: Таракомоли теперь надргрызают одежду, когда атакуют моба
- fix: Исправлена невозможность есть серый, асиковый комбез, и несколько других комбезов

