### PR TITLE
tweak: Вернуть нианам метаболизм молей

### DIFF
--- a/Resources/Prototypes/Body/Species/moth.yml
+++ b/Resources/Prototypes/Body/Species/moth.yml
@@ -326,7 +326,7 @@
   id: OrganMothLungs
 
 - type: entity
-  parent: [OrganBaseHeart, OrganMothInternal, OrganAnimalMetabolizer]
+  parent: [OrganBaseHeart, OrganMothInternal, OrganMothMetabolizer]
   id: OrganMothHeart
 
 - type: entity


### PR DESCRIPTION
## Описание PR
Вернул нианам метаболизм молей, раньше был животный

## Почему / Баланс
В лоре молей ничего нет о том, что моли плохо воспринимают теобромин. Они не могут есть фаст фуд и мясо, напитков тут вообще ничего не касается. 

В добавок, полиморфин не превращал нианов в таракомолей

- [Баг-репорт](https://discord.com/channels/901772674865455115/1537743808614109214)
- [Предложение](https://discord.com/channels/901772674865455115/1532343162637652069)

## Техническая информация
Заменил `OrganAnimalMetabolizer` на `OrganMothMetabolizer`

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
No media

## Чейнджлог
:cl: FriendlyOne
- tweak: Изменен метаболизм у Ниан с животного, на мольский

