### PR TITLE
Право выбора в хранилище скафандров

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -299,6 +299,16 @@
         tableId: FillResearchDirectorHardsuit
   - type: AccessReader
     access: [ [ "ResearchDirector" ] ]
+  #ADT-Tweak-Start
+  - type: UserInterface
+    interfaces:
+      enum.SuitStorageUiKey.Key:
+        type: SuitStorageBoundUserInterface
+  - type: SuitStorage
+    options:
+    - ADTClothingModsuitBackMinerva
+    - ClothingOuterHardsuitRd
+  #ADT-Tweak-End
 
 #HOS's hardsuit
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -293,13 +293,17 @@
   parent: SuitStorageBase
   suffix: Research Director
   components:
+  #ADT-Tweak-Start
+  # - type: EntityTableContainerFill
+  #   containers:
+  #    entity_storage: !type:NestedSelector
+  #     tableId: FillResearchDirectorHardsuit
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:NestedSelector
-        tableId: FillResearchDirectorHardsuit
-  - type: AccessReader
-    access: [ [ "ResearchDirector" ] ]
-  #ADT-Tweak-Start
+      entity_storage: !type:AllSelector
+        children:
+        - id: OxygenTankFilled
+        - id: ClothingMaskBreath
   - type: UserInterface
     interfaces:
       enum.SuitStorageUiKey.Key:
@@ -309,6 +313,8 @@
     - ADTClothingModsuitBackMinerva
     - ClothingOuterHardsuitRd
   #ADT-Tweak-End
+  - type: AccessReader
+    access: [ [ "ResearchDirector" ] ]
 
 #HOS's hardsuit
 - type: entity


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
В хранилище мода НРа добавлен выбор между модом и скафандром.

## Почему / Баланс
[Баг-репорт](https://discord.com/channels/901772674865455115/1536265544351744082)

## Техническая информация
- [ ] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [ ] PR закончен и требует просмотра изменений.

## Медиа
Ноу Медиа

## Чейнджлог
- fix: Возможности выбора снаряжения в хранилище скафандров НРа.
