### PR TITLE
fix: языки сверх лимита остаются после снятия черты Полиглот

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.Traits.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.Traits.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using Content.Client.ADT.Traits.UI;
+using Content.Shared.ADT.Language;
 using Content.Shared.Preferences;
 using Content.Shared.Traits;
 using Robust.Shared.Prototypes;
@@ -47,8 +49,31 @@ public sealed partial class HumanoidProfileEditor
             Profile = Profile.WithTraitPreference(trait.Id, _prototypeManager);
         }
 
+        TrimLanguages();
+
         SetDirty();
         RefreshTraits();
         RefreshLanguages(); // ADT-Tweak: лимит языков зависит от выбранных трайтов (Полиглот)
     }
+
+    // ADT-Tweak-Start: при снятии Полиглота убрать языки сверх нового лимита
+    private void TrimLanguages()
+    {
+        if (Profile is null)
+            return;
+        var species = _prototypeManager.Index(Profile.Species);
+        var required = new HashSet<ProtoId<LanguagePrototype>>(species.DefaultLanguages);
+        required.UnionWith(species.UniqueLanguages);
+        var max = species.MaxLanguages + Profile.LanguageSlotsBonus;
+
+        foreach (var lang in Profile.Languages.ToList())
+        {
+            if (Profile.Languages.Count <= max)
+                break;
+            if (required.Contains(lang))
+                continue;
+            Profile = Profile.WithoutLanguage(lang);
+        }
+    }
+    // ADT-Tweak-End
 }

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.Traits.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.Traits.cs
@@ -56,11 +56,12 @@ public sealed partial class HumanoidProfileEditor
         RefreshLanguages(); // ADT-Tweak: лимит языков зависит от выбранных трайтов (Полиглот)
     }
 
-    // ADT-Tweak-Start: при снятии Полиглота убрать языки сверх нового лимита
+    // ADT-Tweak-Start
     private void TrimLanguages()
     {
         if (Profile is null)
             return;
+
         var species = _prototypeManager.Index(Profile.Species);
         var required = new HashSet<ProtoId<LanguagePrototype>>(species.DefaultLanguages);
         required.UnionWith(species.UniqueLanguages);
@@ -70,8 +71,10 @@ public sealed partial class HumanoidProfileEditor
         {
             if (Profile.Languages.Count <= max)
                 break;
+    
             if (required.Contains(lang))
                 continue;
+    
             Profile = Profile.WithoutLanguage(lang);
         }
     }

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -839,6 +839,23 @@ namespace Content.Shared.Preferences
                 _languages.Remove(lang);
             }
 
+            // ADT-Tweak-Start: снять лишние языки сверх лимита (черта Полиглот снята, хакерский профиль)
+            var maxLanguages = speciesPrototype.MaxLanguages + LanguageSlotsBonus;
+            if (_languages.Count > maxLanguages)
+            {
+                var required = new HashSet<ProtoId<LanguagePrototype>>(speciesPrototype.DefaultLanguages);
+                required.UnionWith(speciesPrototype.UniqueLanguages);
+                foreach (var lang in _languages.ToList())
+                {
+                    if (_languages.Count <= maxLanguages)
+                        break;
+                    if (required.Contains(lang))
+                        continue;
+                    _languages.Remove(lang);
+                }
+            }
+            // ADT-Tweak-End
+
             GetQuirkPoints();
             // ADT end
         }

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -839,7 +839,7 @@ namespace Content.Shared.Preferences
                 _languages.Remove(lang);
             }
 
-            // ADT-Tweak-Start: снять лишние языки сверх лимита (черта Полиглот снята, хакерский профиль)
+            // ADT-Tweak-Start
             var maxLanguages = speciesPrototype.MaxLanguages + LanguageSlotsBonus;
             if (_languages.Count > maxLanguages)
             {
@@ -849,8 +849,10 @@ namespace Content.Shared.Preferences
                 {
                     if (_languages.Count <= maxLanguages)
                         break;
+
                     if (required.Contains(lang))
                         continue;
+
                     _languages.Remove(lang);
                 }
             }


### PR DESCRIPTION
## Описание PR

Черта Полиглот даёт +1 слот языка. Лимит языков (`MaxLanguages + LanguageSlotsBonus`) проверялся только в `WithLanguage` при добавлении. Если снять черту после выбора языков сверх базового лимита, лишние языки оставались в профиле и персонаж знал их в раунде.

## Почему / Баланс

Баг-фикс. Плюс серверная валидация лимита в `EnsureValid` - профиль со 100 языками из модифицированного клиента теперь обрезается.

## Техническая информация

- `HumanoidCharacterProfile.EnsureValid` (Shared): после удаления невалидных языков обрезает `_languages` до `MaxLanguages + LanguageSlotsBonus`, сохраняя обязательные языки вида (DefaultLanguages + UniqueLanguages). `LanguageSlotsBonus` на этом моменте корректен, т.к. трайты валидируются выше в том же методе.
- `HumanoidProfileEditor.OnTraitsSelectionChanged` (Client): при изменении черт срезает лишние языки из профиля через `WithoutLanguage`, игрок сразу видит результат в редакторе.

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа

Отсутствует.

## Чейнджлог

:cl: ultradyper
- fix: Исправлен баг, когда языки сверх лимита оставались после снятия черты Полиглот
