### PR TITLE
feat: ИИ получил доступ к НаноМаксу

### DIFF
--- a/Content.Client/ADT/NanoChat/StationAiNanoChatBoundUserInterface.cs
+++ b/Content.Client/ADT/NanoChat/StationAiNanoChatBoundUserInterface.cs
@@ -1,0 +1,48 @@
+using Content.Client.ADT.CartridgeLoader.Cartridges;
+using Content.Shared.ADT.CartridgeLoader.Cartridges;
+using Content.Shared.ADT.NanoChat;
+using JetBrains.Annotations;
+using Robust.Client.UserInterface;
+
+namespace Content.Client.ADT.NanoChat;
+
+[UsedImplicitly]
+public sealed class StationAiNanoChatBoundUserInterface(EntityUid owner, Enum uiKey) : BoundUserInterface(owner, uiKey)
+{
+    private StationAiNanoChatWindow? _window;
+
+    protected override void Open()
+    {
+        base.Open();
+
+        _window = this.CreateWindow<StationAiNanoChatWindow>();
+        _window.Fragment.OnMessageSent += OnMessageSent;
+    }
+
+    private void OnMessageSent(NanoChatUiMessageType type, uint? number, string? content, string? job)
+    {
+        SendMessage(new StationAiNanoChatUiMessage(type, number, content, job));
+    }
+
+    protected override void UpdateState(BoundUserInterfaceState state)
+    {
+        base.UpdateState(state);
+
+        if (state is not NanoChatUiState nanoChatState || _window == null)
+            return;
+
+        _window.UpdateState(nanoChatState);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (_window == null)
+            return;
+
+        _window.Fragment.OnMessageSent -= OnMessageSent;
+        _window.Dispose();
+        _window = null;
+    }
+}

--- a/Content.Client/ADT/NanoChat/StationAiNanoChatBoundUserInterface.cs
+++ b/Content.Client/ADT/NanoChat/StationAiNanoChatBoundUserInterface.cs
@@ -36,13 +36,13 @@ public sealed class StationAiNanoChatBoundUserInterface(EntityUid owner, Enum ui
 
     protected override void Dispose(bool disposing)
     {
+        if (_window != null)
+        {
+            _window.Fragment.OnMessageSent -= OnMessageSent;
+            _window.Dispose();
+            _window = null;
+        }
+
         base.Dispose(disposing);
-
-        if (_window == null)
-            return;
-
-        _window.Fragment.OnMessageSent -= OnMessageSent;
-        _window.Dispose();
-        _window = null;
     }
 }

--- a/Content.Client/ADT/NanoChat/StationAiNanoChatWindow.cs
+++ b/Content.Client/ADT/NanoChat/StationAiNanoChatWindow.cs
@@ -1,0 +1,26 @@
+using System.Numerics;
+using Content.Client.ADT.CartridgeLoader.Cartridges;
+using Content.Shared.ADT.CartridgeLoader.Cartridges;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.CustomControls;
+
+namespace Content.Client.ADT.NanoChat;
+
+public sealed class StationAiNanoChatWindow : DefaultWindow
+{
+    public readonly NanoChatUiFragment Fragment;
+
+    public StationAiNanoChatWindow()
+    {
+        Title = Loc.GetString("station-ai-nanochat-window-title");
+        MinSize = new Vector2(600, 400);
+
+        Fragment = new NanoChatUiFragment();
+        Contents.AddChild(Fragment);
+    }
+
+    public void UpdateState(NanoChatUiState state)
+    {
+        Fragment.UpdateState(state);
+    }
+}

--- a/Content.Server/ADT/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/ADT/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.ADT.NanoChat;
 using Content.Shared.PDA;
 using Content.Shared.Radio;
 using Content.Shared.Radio.Components;
+using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -137,32 +138,41 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     /// </summary>
     private void HandleNewChat(Entity<NanoChatCardComponent> card, NanoChatUiMessageEvent msg)
     {
-        if (msg.RecipientNumber == null || msg.Content == null || msg.RecipientNumber == card.Comp.Number)
+        NewChat(card, msg.RecipientNumber, msg.Content, msg.RecipientJob, msg.Actor);
+    }
+
+    /// <summary>
+    ///     Creates a new chat conversation on a card.
+    /// </summary>
+    [PublicAPI]
+    public void NewChat(Entity<NanoChatCardComponent> card, uint? recipientNumber, string? content, string? recipientJob, EntityUid actor)
+    {
+        if (recipientNumber == null || content == null || recipientNumber == card.Comp.Number)
             return;
 
-        var name = msg.Content;
+        var name = content;
         if (!string.IsNullOrWhiteSpace(name))
         {
             name = name.Trim();
         }
 
-        var jobTitle = msg.RecipientJob;
+        var jobTitle = recipientJob;
         if (!string.IsNullOrWhiteSpace(jobTitle))
         {
             jobTitle = jobTitle.Trim();
         }
 
         // Add new recipient
-        var recipient = new NanoChatRecipient(msg.RecipientNumber.Value,
+        var recipient = new NanoChatRecipient(recipientNumber.Value,
             name,
             jobTitle);
 
         // Initialize or update recipient
-        _nanoChat.SetRecipient((card, card.Comp), msg.RecipientNumber.Value, recipient);
+        _nanoChat.SetRecipient((card, card.Comp), recipientNumber.Value, recipient);
 
         _adminLogger.Add(LogType.Action,
             LogImpact.Low,
-            $"{ToPrettyString(msg.Actor):user} created new NanoChat conversation with #{msg.RecipientNumber:D4} ({name})");
+            $"{ToPrettyString(actor):user} created new NanoChat conversation with #{recipientNumber:D4} ({name})");
 
         var recipientEv = new NanoChatRecipientUpdatedEvent(card);
         RaiseLocalEvent(ref recipientEv);
@@ -174,16 +184,25 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     /// </summary>
     private void HandleSelectChat(Entity<NanoChatCardComponent> card, NanoChatUiMessageEvent msg)
     {
-        if (msg.RecipientNumber == null)
+        SelectChat(card, msg.RecipientNumber);
+    }
+
+    /// <summary>
+    ///     Selects a chat conversation on a card.
+    /// </summary>
+    [PublicAPI]
+    public void SelectChat(Entity<NanoChatCardComponent> card, uint? recipientNumber)
+    {
+        if (recipientNumber == null)
             return;
 
-        _nanoChat.SetCurrentChat((card, card.Comp), msg.RecipientNumber);
+        _nanoChat.SetCurrentChat((card, card.Comp), recipientNumber);
 
         // Clear unread flag when selecting chat
-        if (_nanoChat.GetRecipient((card, card.Comp), msg.RecipientNumber.Value) is { } recipient)
+        if (_nanoChat.GetRecipient((card, card.Comp), recipientNumber.Value) is { } recipient)
         {
             _nanoChat.SetRecipient((card, card.Comp),
-                msg.RecipientNumber.Value,
+                recipientNumber.Value,
                 recipient with { HasUnread = false });
         }
     }
@@ -193,6 +212,15 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     /// </summary>
     private void HandleCloseChat(Entity<NanoChatCardComponent> card)
     {
+        CloseChat(card);
+    }
+
+    /// <summary>
+    ///     Closes the current chat conversation on a card.
+    /// </summary>
+    [PublicAPI]
+    public void CloseChat(Entity<NanoChatCardComponent> card)
+    {
         _nanoChat.SetCurrentChat((card, card.Comp), null);
     }
 
@@ -201,18 +229,27 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     /// </summary>
     private void HandleDeleteChat(Entity<NanoChatCardComponent> card, NanoChatUiMessageEvent msg)
     {
-        if (msg.RecipientNumber == null || card.Comp.Number == null)
+        DeleteChat(card, msg.RecipientNumber, msg.Actor);
+    }
+
+    /// <summary>
+    ///     Deletes a chat conversation on a card.
+    /// </summary>
+    [PublicAPI]
+    public void DeleteChat(Entity<NanoChatCardComponent> card, uint? recipientNumber, EntityUid actor)
+    {
+        if (recipientNumber == null || card.Comp.Number == null)
             return;
 
         // Delete chat but keep the messages
-        var deleted = _nanoChat.TryDeleteChat((card, card.Comp), msg.RecipientNumber.Value, true);
+        var deleted = _nanoChat.TryDeleteChat((card, card.Comp), recipientNumber.Value, true);
 
         if (!deleted)
             return;
 
         _adminLogger.Add(LogType.Action,
             LogImpact.Low,
-            $"{ToPrettyString(msg.Actor):user} deleted NanoChat conversation with #{msg.RecipientNumber:D4}");
+            $"{ToPrettyString(actor):user} deleted NanoChat conversation with #{recipientNumber:D4}");
 
         UpdateUIForCard(card);
     }
@@ -222,11 +259,29 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     /// </summary>
     private void HandleToggleMute(Entity<NanoChatCardComponent> card)
     {
+        ToggleMute(card);
+    }
+
+    /// <summary>
+    ///     Toggles notification mute state on a card.
+    /// </summary>
+    [PublicAPI]
+    public void ToggleMute(Entity<NanoChatCardComponent> card)
+    {
         _nanoChat.SetNotificationsMuted((card, card.Comp), !_nanoChat.GetNotificationsMuted((card, card.Comp)));
         UpdateUIForCard(card);
     }
 
     private void HandleToggleListNumber(Entity<NanoChatCardComponent> card)
+    {
+        ToggleListNumber(card);
+    }
+
+    /// <summary>
+    ///     Toggles card number visibility in the station directory.
+    /// </summary>
+    [PublicAPI]
+    public void ToggleListNumber(Entity<NanoChatCardComponent> card)
     {
         _nanoChat.SetListNumber((card, card.Comp), !_nanoChat.GetListNumber((card, card.Comp)));
         UpdateUIForAllCards();
@@ -239,13 +294,25 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
         Entity<NanoChatCardComponent> card,
         NanoChatUiMessageEvent msg)
     {
-        if (msg.RecipientNumber == null || msg.Content == null || card.Comp.Number == null)
+        SendMessage(cartridge, card, msg.RecipientNumber, msg.Content, cartridge.Comp.RadioChannel);
+    }
+
+    /// <summary>
+    ///     Sends a NanoChat message from a card, attempting delivery through the radio channel.
+    /// </summary>
+    [PublicAPI]
+    public void SendMessage(EntityUid sender,
+        Entity<NanoChatCardComponent> card,
+        uint? recipientNumber,
+        string? content,
+        ProtoId<RadioChannelPrototype> channelId)
+    {
+        if (recipientNumber == null || content == null || card.Comp.Number == null)
             return;
 
-        if (!EnsureRecipientExists(card, msg.RecipientNumber.Value))
+        if (!EnsureRecipientExists(card, recipientNumber.Value))
             return;
 
-        var content = msg.Content;
         if (!string.IsNullOrWhiteSpace(content))
         {
             content = FormattedMessage.EscapeText(content.Trim());
@@ -261,18 +328,18 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
         );
 
         // Attempt delivery
-        var (deliveryFailed, recipients) = AttemptMessageDeliveryInternal(cartridge, msg.RecipientNumber.Value, cartridge.Comp.RadioChannel);
+        var (deliveryFailed, recipients) = AttemptMessageDeliveryInternal(sender, recipientNumber.Value, channelId);
 
         // Update delivery status
         message = message with { DeliveryFailed = deliveryFailed };
 
         // Store message in sender's outbox under recipient's number
-        _nanoChat.AddMessage((card, card.Comp), msg.RecipientNumber.Value, message);
+        _nanoChat.AddMessage((card, card.Comp), recipientNumber.Value, message);
 
         // Log message attempt
         var recipientsText = recipients.Count > 0
             ? string.Join(", ", recipients.Select(r => ToPrettyString(r)))
-            : $"#{msg.RecipientNumber:D4}";
+            : $"#{recipientNumber:D4}";
 
         _adminLogger.Add(LogType.Chat,
             LogImpact.Low,
@@ -308,6 +375,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     /// <param name="recipientNumber">The recipient's number</param>
     /// <param name="channelId">The radio channel used for delivery</param>
     /// <returns>Tuple containing delivery status and recipients if found.</returns>
+    [PublicAPI]
     public (bool failed, List<Entity<NanoChatCardComponent>> recipient) AttemptMessageDeliveryInternal(
         EntityUid sender,
         uint recipientNumber,
@@ -433,6 +501,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     /// <param name="sender">The sender's card entity</param>
     /// <param name="recipient">The recipient's card entity</param>
     /// <param name="message">The <see cref="NanoChatMessage" /> to deliver</param>
+    [PublicAPI]
     public void DeliverMessageToRecipient(Entity<NanoChatCardComponent> sender,
         Entity<NanoChatCardComponent> recipient,
         NanoChatMessage message)
@@ -509,7 +578,8 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     /// <summary>
     ///     Updates the UI for all PDAs containing a NanoChat cartridge.
     /// </summary>
-    private void UpdateUIForAllCards()
+    [PublicAPI]
+    public void UpdateUIForAllCards()
     {
         // Find any PDA containing this card and update its UI
         var query = EntityQueryEnumerator<NanoChatCartridgeComponent, CartridgeComponent>();
@@ -523,6 +593,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     /// <summary>
     ///     Gets the <see cref="NanoChatRecipient" /> for a given NanoChat number.
     /// </summary>
+    [PublicAPI]
     public NanoChatRecipient? GetCardInfo(uint number)
     {
         // Find card with this number to get its info
@@ -583,6 +654,16 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
                 if (nanoChatCard.ListNumber && nanoChatCard.Number is uint nanoChatNumber && idCardComponent.FullName is string fullName && _station.GetOwningStation(entityId) == station)
                 {
                     contacts.Add(new NanoChatRecipient(nanoChatNumber, fullName));
+                }
+            }
+
+            // Cards held by a station AI are visible in the directory as well
+            var aiQuery = AllEntityQuery<NanoChatCardComponent, StationAiNanoChatComponent>();
+            while (aiQuery.MoveNext(out var entityId, out var nanoChatCard, out _))
+            {
+                if (nanoChatCard.ListNumber && nanoChatCard.Number is uint nanoChatNumber && _station.GetOwningStation(entityId) == station)
+                {
+                    contacts.Add(new NanoChatRecipient(nanoChatNumber, Name(entityId)));
                 }
             }
             contacts.Sort((contactA, contactB) => string.CompareOrdinal(contactA.Name, contactB.Name));

--- a/Content.Server/ADT/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/ADT/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Server.ADT.NanoChat;
 using Content.Server.Administration.Logs;
 using Content.Server.CartridgeLoader;
 using Content.Server.Power.Components;
@@ -10,6 +11,7 @@ using Content.Shared.Database;
 using Content.Shared.ADT.CartridgeLoader.Cartridges;
 using Content.Shared.ADT.NanoChat;
 using Content.Shared.PDA;
+using Content.Shared.Radio;
 using Content.Shared.Radio.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
@@ -259,7 +261,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
         );
 
         // Attempt delivery
-        var (deliveryFailed, recipients) = AttemptMessageDelivery(cartridge, msg.RecipientNumber.Value);
+        var (deliveryFailed, recipients) = AttemptMessageDeliveryInternal(cartridge, msg.RecipientNumber.Value, cartridge.Comp.RadioChannel);
 
         // Update delivery status
         message = message with { DeliveryFailed = deliveryFailed };
@@ -300,17 +302,19 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     }
 
     /// <summary>
-    ///     Attempts to deliver a message to recipients.
+    ///     Attempts to deliver a message to recipients, including cards held by a station AI.
     /// </summary>
-    /// <param name="sender">The sending cartridge entity</param>
+    /// <param name="sender">The sending entity (cartridge or station AI)</param>
     /// <param name="recipientNumber">The recipient's number</param>
+    /// <param name="channelId">The radio channel used for delivery</param>
     /// <returns>Tuple containing delivery status and recipients if found.</returns>
-    private (bool failed, List<Entity<NanoChatCardComponent>> recipient) AttemptMessageDelivery(
-        Entity<NanoChatCartridgeComponent> sender,
-        uint recipientNumber)
+    public (bool failed, List<Entity<NanoChatCardComponent>> recipient) AttemptMessageDeliveryInternal(
+        EntityUid sender,
+        uint recipientNumber,
+        ProtoId<RadioChannelPrototype> channelId)
     {
         // First verify we can send from this device
-        var channel = _prototype.Index(sender.Comp.RadioChannel);
+        var channel = _prototype.Index(channelId);
         var sendAttemptEvent = new RadioSendAttemptEvent(channel, sender);
         RaiseLocalEvent(ref sendAttemptEvent);
         if (sendAttemptEvent.Cancelled)
@@ -331,11 +335,14 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
         if (foundRecipients.Count == 0)
             return (true, foundRecipients);
 
+        var senderStation = _station.GetOwningStation(sender);
+
         // Now check if any of these cards can receive
         var deliverableRecipients = new List<Entity<NanoChatCardComponent>>();
         foreach (var recipient in foundRecipients)
         {
             // Find any cartridges that have this card
+            var foundCartridge = false;
             var cartridgeQuery = EntityQueryEnumerator<NanoChatCartridgeComponent, ActiveRadioComponent>();
             while (cartridgeQuery.MoveNext(out var receiverUid, out var receiverCart, out _))
             {
@@ -344,7 +351,6 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
 
                 // Check if devices are on same station/map
                 var recipientStation = _station.GetOwningStation(receiverUid);
-                var senderStation = _station.GetOwningStation(sender);
 
                 // Both entities must be on a station
                 if (recipientStation == null || senderStation == null)
@@ -366,8 +372,38 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
 
                 // Found valid cartridge that can receive
                 deliverableRecipients.Add(recipient);
+                foundCartridge = true;
                 break; // Only need one valid cartridge per card
             }
+
+            if (foundCartridge)
+                continue;
+
+            // Cards held by a station AI (e.g. in a core) can receive without a cartridge
+            if (!HasComp<StationAiNanoChatComponent>(recipient.Owner))
+                continue;
+
+            var aiRecipientStation = _station.GetOwningStation(recipient.Owner);
+
+            // Both entities must be on a station
+            if (aiRecipientStation == null || senderStation == null)
+                continue;
+
+            // Must be on same map/station unless long range allowed
+            if (!channel.LongRange && aiRecipientStation != senderStation)
+                continue;
+
+            // Needs telecomms
+            if (!HasActiveServer(senderStation.Value) || !HasActiveServer(aiRecipientStation.Value))
+                continue;
+
+            // Check if recipient can receive
+            var aiReceiveAttemptEv = new RadioReceiveAttemptEvent(channel, sender, recipient.Owner);
+            RaiseLocalEvent(ref aiReceiveAttemptEv);
+            if (aiReceiveAttemptEv.Cancelled)
+                continue;
+
+            deliverableRecipients.Add(recipient);
         }
 
         return (deliverableRecipients.Count == 0, deliverableRecipients);
@@ -397,7 +433,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     /// <param name="sender">The sender's card entity</param>
     /// <param name="recipient">The recipient's card entity</param>
     /// <param name="message">The <see cref="NanoChatMessage" /> to deliver</param>
-    private void DeliverMessageToRecipient(Entity<NanoChatCardComponent> sender,
+    public void DeliverMessageToRecipient(Entity<NanoChatCardComponent> sender,
         Entity<NanoChatCardComponent> recipient,
         NanoChatMessage message)
     {
@@ -487,7 +523,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     /// <summary>
     ///     Gets the <see cref="NanoChatRecipient" /> for a given NanoChat number.
     /// </summary>
-    private NanoChatRecipient? GetCardInfo(uint number)
+    public NanoChatRecipient? GetCardInfo(uint number)
     {
         // Find card with this number to get its info
         var query = EntityQueryEnumerator<NanoChatCardComponent>();
@@ -503,6 +539,11 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
             {
                 jobTitle = idCard.LocalizedJobTitle;
                 name = idCard.FullName ?? name;
+            }
+            else if (HasComp<StationAiNanoChatComponent>(uid))
+            {
+                name = Name(uid);
+                jobTitle = Loc.GetString("job-name-station-ai");
             }
 
             return new NanoChatRecipient(number, name, jobTitle);

--- a/Content.Server/ADT/NanoChat/StationAiNanoChatComponent.cs
+++ b/Content.Server/ADT/NanoChat/StationAiNanoChatComponent.cs
@@ -1,0 +1,27 @@
+using Content.Shared.Radio;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.ADT.NanoChat;
+
+/// <summary>
+///     Added to a station AI while it is held in a core (via the AiHeld prototype).
+///     Marks its NanoChat card as deliverable without a PDA cartridge and grants the NanoChat action.
+/// </summary>
+[RegisterComponent]
+public sealed partial class StationAiNanoChatComponent : Component
+{
+    /// <summary>
+    ///     The action that opens the NanoChat UI.
+    /// </summary>
+    [DataField("NanoChat")]
+    public EntProtoId Action = "ActionStationAiNanoChat";
+
+    [DataField, AutoNetworkedField]
+    public EntityUid? ActionEntity;
+
+    /// <summary>
+    ///     The <see cref="RadioChannelPrototype" /> required to send or receive messages.
+    /// </summary>
+    [DataField]
+    public ProtoId<RadioChannelPrototype> RadioChannel = "Common";
+}

--- a/Content.Server/ADT/NanoChat/StationAiNanoChatComponent.cs
+++ b/Content.Server/ADT/NanoChat/StationAiNanoChatComponent.cs
@@ -13,10 +13,10 @@ public sealed partial class StationAiNanoChatComponent : Component
     /// <summary>
     ///     The action that opens the NanoChat UI.
     /// </summary>
-    [DataField("NanoChat")]
+    [DataField]
     public EntProtoId Action = "ActionStationAiNanoChat";
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public EntityUid? ActionEntity;
 
     /// <summary>

--- a/Content.Server/ADT/NanoChat/StationAiNanoChatSystem.cs
+++ b/Content.Server/ADT/NanoChat/StationAiNanoChatSystem.cs
@@ -1,18 +1,11 @@
-using System.Linq;
 using Content.Server.ADT.CartridgeLoader.Cartridges;
-using Content.Server.Administration.Logs;
 using Content.Server.Actions;
 using Content.Server.Station.Systems;
 using Content.Shared.Access.Components;
 using Content.Shared.ADT.CartridgeLoader.Cartridges;
 using Content.Shared.ADT.NanoChat;
-using Content.Shared.Database;
-using Content.Shared.Radio;
-using Content.Shared.Radio.Components;
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;
-using Robust.Shared.Timing;
-using Robust.Shared.Utility;
 
 namespace Content.Server.ADT.NanoChat;
 
@@ -21,10 +14,7 @@ public sealed class StationAiNanoChatSystem : EntitySystem
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
     [Dependency] private readonly ActionsSystem _action = default!;
     [Dependency] private readonly StationSystem _station = default!;
-    [Dependency] private readonly SharedNanoChatSystem _nanoChat = default!;
     [Dependency] private readonly NanoChatCartridgeSystem _nanoChatCartridge = default!;
-    [Dependency] private readonly IAdminLogManager _adminLogger = default!;
-    [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
     {
@@ -90,144 +80,29 @@ public sealed class StationAiNanoChatSystem : EntitySystem
         switch (msg.Type)
         {
             case NanoChatUiMessageType.NewChat:
-                HandleNewChat(card, msg);
+                _nanoChatCartridge.NewChat(card, msg.RecipientNumber, msg.Content, msg.RecipientJob, msg.Actor);
                 break;
             case NanoChatUiMessageType.SelectChat:
-                HandleSelectChat(card, msg);
+                _nanoChatCartridge.SelectChat(card, msg.RecipientNumber);
                 break;
             case NanoChatUiMessageType.CloseChat:
-                HandleCloseChat(card);
+                _nanoChatCartridge.CloseChat(card);
                 break;
             case NanoChatUiMessageType.ToggleMute:
-                HandleToggleMute(card);
+                _nanoChatCartridge.ToggleMute(card);
                 break;
             case NanoChatUiMessageType.DeleteChat:
-                HandleDeleteChat(card, msg);
+                _nanoChatCartridge.DeleteChat(card, msg.RecipientNumber, msg.Actor);
                 break;
             case NanoChatUiMessageType.SendMessage:
-                HandleSendMessage(ent, card, msg);
+                _nanoChatCartridge.SendMessage(ent.Owner, card, msg.RecipientNumber, msg.Content, ent.Comp.RadioChannel);
                 break;
             case NanoChatUiMessageType.ToggleListNumber:
-                HandleToggleListNumber(card);
+                _nanoChatCartridge.ToggleListNumber(card);
                 break;
         }
 
         UpdateUi(ent);
-    }
-
-    private void HandleNewChat(Entity<NanoChatCardComponent> card, StationAiNanoChatUiMessage msg)
-    {
-        if (msg.RecipientNumber == null || msg.Content == null || msg.RecipientNumber == card.Comp.Number)
-            return;
-
-        var name = msg.Content.Trim();
-        var jobTitle = string.IsNullOrWhiteSpace(msg.RecipientJob) ? null : msg.RecipientJob.Trim();
-
-        _nanoChat.SetRecipient((card, card.Comp), msg.RecipientNumber.Value, new NanoChatRecipient(msg.RecipientNumber.Value, name, jobTitle));
-
-        _adminLogger.Add(LogType.Action,
-            LogImpact.Low,
-            $"{ToPrettyString(msg.Actor):user} created new NanoChat conversation with #{msg.RecipientNumber:D4} ({name})");
-
-        var recipientEv = new NanoChatRecipientUpdatedEvent(card);
-        RaiseLocalEvent(ref recipientEv);
-    }
-
-    private void HandleSelectChat(Entity<NanoChatCardComponent> card, StationAiNanoChatUiMessage msg)
-    {
-        if (msg.RecipientNumber == null)
-            return;
-
-        _nanoChat.SetCurrentChat((card, card.Comp), msg.RecipientNumber);
-
-        if (_nanoChat.GetRecipient((card, card.Comp), msg.RecipientNumber.Value) is { } recipient)
-        {
-            _nanoChat.SetRecipient((card, card.Comp),
-                msg.RecipientNumber.Value,
-                recipient with { HasUnread = false });
-        }
-    }
-
-    private void HandleCloseChat(Entity<NanoChatCardComponent> card)
-    {
-        _nanoChat.SetCurrentChat((card, card.Comp), null);
-    }
-
-    private void HandleDeleteChat(Entity<NanoChatCardComponent> card, StationAiNanoChatUiMessage msg)
-    {
-        if (msg.RecipientNumber == null)
-            return;
-
-        var deleted = _nanoChat.TryDeleteChat((card, card.Comp), msg.RecipientNumber.Value, true);
-
-        if (!deleted)
-            return;
-
-        _adminLogger.Add(LogType.Action,
-            LogImpact.Low,
-            $"{ToPrettyString(msg.Actor):user} deleted NanoChat conversation with #{msg.RecipientNumber:D4}");
-    }
-
-    private void HandleToggleMute(Entity<NanoChatCardComponent> card)
-    {
-        _nanoChat.SetNotificationsMuted((card, card.Comp), !_nanoChat.GetNotificationsMuted((card, card.Comp)));
-    }
-
-    private void HandleToggleListNumber(Entity<NanoChatCardComponent> card)
-    {
-        _nanoChat.SetListNumber((card, card.Comp), !_nanoChat.GetListNumber((card, card.Comp)));
-    }
-
-    private void HandleSendMessage(Entity<StationAiNanoChatComponent> ent,
-        Entity<NanoChatCardComponent> card,
-        StationAiNanoChatUiMessage msg)
-    {
-        if (msg.RecipientNumber == null || msg.Content == null || card.Comp.Number == null)
-            return;
-
-        if (!_nanoChat.EnsureRecipientExists((card, card.Comp), msg.RecipientNumber.Value,
-                _nanoChatCartridge.GetCardInfo(msg.RecipientNumber.Value)))
-            return;
-
-        var content = msg.Content;
-        if (!string.IsNullOrWhiteSpace(content))
-        {
-            content = FormattedMessage.EscapeText(content.Trim());
-            if (content.Length > NanoChatMessage.MaxContentLength)
-                content = content[..NanoChatMessage.MaxContentLength];
-        }
-
-        var message = new NanoChatMessage(
-            _timing.CurTime,
-            content,
-            (uint)card.Comp.Number
-        );
-
-        var (deliveryFailed, recipients) = _nanoChatCartridge.AttemptMessageDeliveryInternal(
-            ent.Owner, msg.RecipientNumber.Value, ent.Comp.RadioChannel);
-
-        message = message with { DeliveryFailed = deliveryFailed };
-
-        _nanoChat.AddMessage((card, card.Comp), msg.RecipientNumber.Value, message);
-
-        var recipientsText = recipients.Count > 0
-            ? string.Join(", ", recipients.Select(r => ToPrettyString(r)))
-            : $"#{msg.RecipientNumber:D4}";
-
-        _adminLogger.Add(LogType.Chat,
-            LogImpact.Low,
-            $"{ToPrettyString(card):user} sent NanoChat message to {recipientsText}: {content}{(deliveryFailed ? " [DELIVERY FAILED]" : "")}");
-
-        var msgEv = new NanoChatMessageReceivedEvent(card);
-        RaiseLocalEvent(ref msgEv);
-
-        if (deliveryFailed)
-            return;
-
-        foreach (var recipient in recipients)
-        {
-            _nanoChatCartridge.DeliverMessageToRecipient(card, recipient, message);
-        }
     }
 
     private void UpdateUi(Entity<StationAiNanoChatComponent> ent)

--- a/Content.Server/ADT/NanoChat/StationAiNanoChatSystem.cs
+++ b/Content.Server/ADT/NanoChat/StationAiNanoChatSystem.cs
@@ -1,0 +1,267 @@
+using System.Linq;
+using Content.Server.ADT.CartridgeLoader.Cartridges;
+using Content.Server.Administration.Logs;
+using Content.Server.Actions;
+using Content.Server.Station.Systems;
+using Content.Shared.Access.Components;
+using Content.Shared.ADT.CartridgeLoader.Cartridges;
+using Content.Shared.ADT.NanoChat;
+using Content.Shared.Database;
+using Content.Shared.Radio;
+using Content.Shared.Radio.Components;
+using Robust.Server.GameObjects;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Content.Server.ADT.NanoChat;
+
+public sealed class StationAiNanoChatSystem : EntitySystem
+{
+    [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
+    [Dependency] private readonly ActionsSystem _action = default!;
+    [Dependency] private readonly StationSystem _station = default!;
+    [Dependency] private readonly SharedNanoChatSystem _nanoChat = default!;
+    [Dependency] private readonly NanoChatCartridgeSystem _nanoChatCartridge = default!;
+    [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<StationAiNanoChatComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<StationAiNanoChatComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<StationAiNanoChatComponent, StationAiNanoChatActionEvent>(OnAction);
+        SubscribeLocalEvent<StationAiNanoChatComponent, BoundUIOpenedEvent>(OnUiOpened);
+        SubscribeLocalEvent<NanoChatCardComponent, NanoChatMessageReceivedEvent>(OnCardMessageReceived);
+
+        Subs.BuiEvents<StationAiNanoChatComponent>(StationAiNanoChatUiKey.Key, subs =>
+        {
+            subs.Event<StationAiNanoChatUiMessage>(OnMessage);
+        });
+    }
+
+    private void OnUiOpened(Entity<StationAiNanoChatComponent> ent, ref BoundUIOpenedEvent args)
+    {
+        if (!StationAiNanoChatUiKey.Key.Equals(args.UiKey))
+            return;
+
+        UpdateUi(ent);
+    }
+
+    private void OnCardMessageReceived(Entity<NanoChatCardComponent> ent, ref NanoChatMessageReceivedEvent args)
+    {
+        if (!HasComp<StationAiNanoChatComponent>(ent.Owner))
+            return;
+
+        UpdateUi((ent.Owner, Comp<StationAiNanoChatComponent>(ent.Owner)));
+    }
+
+    private void OnMapInit(EntityUid uid, StationAiNanoChatComponent component, MapInitEvent args)
+    {
+        _action.AddAction(uid, ref component.ActionEntity, component.Action);
+    }
+
+    private void OnShutdown(EntityUid uid, StationAiNanoChatComponent component, ComponentShutdown args)
+    {
+        _action.RemoveAction(uid, component.ActionEntity);
+    }
+
+    private void OnAction(EntityUid uid, StationAiNanoChatComponent comp, StationAiNanoChatActionEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (!TryComp<ActorComponent>(uid, out var actor))
+            return;
+
+        _uiSystem.TryOpenUi(uid, StationAiNanoChatUiKey.Key, actor.Owner);
+        args.Handled = true;
+    }
+
+    private void OnMessage(Entity<StationAiNanoChatComponent> ent, ref StationAiNanoChatUiMessage msg)
+    {
+        if (!TryComp<NanoChatCardComponent>(ent.Owner, out var cardComp))
+            return;
+
+        var card = new Entity<NanoChatCardComponent>(ent.Owner, cardComp);
+
+        switch (msg.Type)
+        {
+            case NanoChatUiMessageType.NewChat:
+                HandleNewChat(card, msg);
+                break;
+            case NanoChatUiMessageType.SelectChat:
+                HandleSelectChat(card, msg);
+                break;
+            case NanoChatUiMessageType.CloseChat:
+                HandleCloseChat(card);
+                break;
+            case NanoChatUiMessageType.ToggleMute:
+                HandleToggleMute(card);
+                break;
+            case NanoChatUiMessageType.DeleteChat:
+                HandleDeleteChat(card, msg);
+                break;
+            case NanoChatUiMessageType.SendMessage:
+                HandleSendMessage(ent, card, msg);
+                break;
+            case NanoChatUiMessageType.ToggleListNumber:
+                HandleToggleListNumber(card);
+                break;
+        }
+
+        UpdateUi(ent);
+    }
+
+    private void HandleNewChat(Entity<NanoChatCardComponent> card, StationAiNanoChatUiMessage msg)
+    {
+        if (msg.RecipientNumber == null || msg.Content == null || msg.RecipientNumber == card.Comp.Number)
+            return;
+
+        var name = msg.Content.Trim();
+        var jobTitle = string.IsNullOrWhiteSpace(msg.RecipientJob) ? null : msg.RecipientJob.Trim();
+
+        _nanoChat.SetRecipient((card, card.Comp), msg.RecipientNumber.Value, new NanoChatRecipient(msg.RecipientNumber.Value, name, jobTitle));
+
+        _adminLogger.Add(LogType.Action,
+            LogImpact.Low,
+            $"{ToPrettyString(msg.Actor):user} created new NanoChat conversation with #{msg.RecipientNumber:D4} ({name})");
+
+        var recipientEv = new NanoChatRecipientUpdatedEvent(card);
+        RaiseLocalEvent(ref recipientEv);
+    }
+
+    private void HandleSelectChat(Entity<NanoChatCardComponent> card, StationAiNanoChatUiMessage msg)
+    {
+        if (msg.RecipientNumber == null)
+            return;
+
+        _nanoChat.SetCurrentChat((card, card.Comp), msg.RecipientNumber);
+
+        if (_nanoChat.GetRecipient((card, card.Comp), msg.RecipientNumber.Value) is { } recipient)
+        {
+            _nanoChat.SetRecipient((card, card.Comp),
+                msg.RecipientNumber.Value,
+                recipient with { HasUnread = false });
+        }
+    }
+
+    private void HandleCloseChat(Entity<NanoChatCardComponent> card)
+    {
+        _nanoChat.SetCurrentChat((card, card.Comp), null);
+    }
+
+    private void HandleDeleteChat(Entity<NanoChatCardComponent> card, StationAiNanoChatUiMessage msg)
+    {
+        if (msg.RecipientNumber == null)
+            return;
+
+        var deleted = _nanoChat.TryDeleteChat((card, card.Comp), msg.RecipientNumber.Value, true);
+
+        if (!deleted)
+            return;
+
+        _adminLogger.Add(LogType.Action,
+            LogImpact.Low,
+            $"{ToPrettyString(msg.Actor):user} deleted NanoChat conversation with #{msg.RecipientNumber:D4}");
+    }
+
+    private void HandleToggleMute(Entity<NanoChatCardComponent> card)
+    {
+        _nanoChat.SetNotificationsMuted((card, card.Comp), !_nanoChat.GetNotificationsMuted((card, card.Comp)));
+    }
+
+    private void HandleToggleListNumber(Entity<NanoChatCardComponent> card)
+    {
+        _nanoChat.SetListNumber((card, card.Comp), !_nanoChat.GetListNumber((card, card.Comp)));
+    }
+
+    private void HandleSendMessage(Entity<StationAiNanoChatComponent> ent,
+        Entity<NanoChatCardComponent> card,
+        StationAiNanoChatUiMessage msg)
+    {
+        if (msg.RecipientNumber == null || msg.Content == null || card.Comp.Number == null)
+            return;
+
+        if (!_nanoChat.EnsureRecipientExists((card, card.Comp), msg.RecipientNumber.Value,
+                _nanoChatCartridge.GetCardInfo(msg.RecipientNumber.Value)))
+            return;
+
+        var content = msg.Content;
+        if (!string.IsNullOrWhiteSpace(content))
+        {
+            content = FormattedMessage.EscapeText(content.Trim());
+            if (content.Length > NanoChatMessage.MaxContentLength)
+                content = content[..NanoChatMessage.MaxContentLength];
+        }
+
+        var message = new NanoChatMessage(
+            _timing.CurTime,
+            content,
+            (uint)card.Comp.Number
+        );
+
+        var (deliveryFailed, recipients) = _nanoChatCartridge.AttemptMessageDeliveryInternal(
+            ent.Owner, msg.RecipientNumber.Value, ent.Comp.RadioChannel);
+
+        message = message with { DeliveryFailed = deliveryFailed };
+
+        _nanoChat.AddMessage((card, card.Comp), msg.RecipientNumber.Value, message);
+
+        var recipientsText = recipients.Count > 0
+            ? string.Join(", ", recipients.Select(r => ToPrettyString(r)))
+            : $"#{msg.RecipientNumber:D4}";
+
+        _adminLogger.Add(LogType.Chat,
+            LogImpact.Low,
+            $"{ToPrettyString(card):user} sent NanoChat message to {recipientsText}: {content}{(deliveryFailed ? " [DELIVERY FAILED]" : "")}");
+
+        var msgEv = new NanoChatMessageReceivedEvent(card);
+        RaiseLocalEvent(ref msgEv);
+
+        if (deliveryFailed)
+            return;
+
+        foreach (var recipient in recipients)
+        {
+            _nanoChatCartridge.DeliverMessageToRecipient(card, recipient, message);
+        }
+    }
+
+    private void UpdateUi(Entity<StationAiNanoChatComponent> ent)
+    {
+        if (!TryComp<NanoChatCardComponent>(ent.Owner, out var card))
+            return;
+
+        List<NanoChatRecipient>? contacts = null;
+        if (_station.GetOwningStation(ent.Owner) is { } station)
+        {
+            contacts = new List<NanoChatRecipient>();
+
+            var query = AllEntityQuery<NanoChatCardComponent, IdCardComponent>();
+            while (query.MoveNext(out var entityId, out var nanoChatCard, out var idCardComponent))
+            {
+                if (nanoChatCard.ListNumber && nanoChatCard.Number is uint nanoChatNumber &&
+                    idCardComponent.FullName is string fullName &&
+                    _station.GetOwningStation(entityId) == station)
+                {
+                    contacts.Add(new NanoChatRecipient(nanoChatNumber, fullName));
+                }
+            }
+            contacts.Sort((contactA, contactB) => string.CompareOrdinal(contactA.Name, contactB.Name));
+        }
+
+        var state = new NanoChatUiState(card.Recipients,
+            card.Messages,
+            contacts,
+            card.CurrentChat,
+            card.Number ?? 0,
+            card.MaxRecipients,
+            card.NotificationsMuted,
+            card.ListNumber);
+
+        _uiSystem.SetUiState(ent.Owner, StationAiNanoChatUiKey.Key, state);
+    }
+}

--- a/Content.Shared/ADT/NanoChat/SharedStationAiNanoChatSystem.cs
+++ b/Content.Shared/ADT/NanoChat/SharedStationAiNanoChatSystem.cs
@@ -1,0 +1,38 @@
+using Content.Shared.Actions;
+using Content.Shared.ADT.CartridgeLoader.Cartridges;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.ADT.NanoChat;
+
+[Serializable, NetSerializable]
+public enum StationAiNanoChatUiKey : byte
+{
+    Key
+}
+
+public sealed partial class StationAiNanoChatActionEvent : InstantActionEvent
+{
+}
+
+[Serializable, NetSerializable]
+public sealed class StationAiNanoChatUiMessage : BoundUserInterfaceMessage
+{
+    public readonly NanoChatUiMessageType Type;
+
+    public readonly uint? RecipientNumber;
+
+    public readonly string? Content;
+
+    public readonly string? RecipientJob;
+
+    public StationAiNanoChatUiMessage(NanoChatUiMessageType type,
+        uint? recipientNumber = null,
+        string? content = null,
+        string? recipientJob = null)
+    {
+        Type = type;
+        RecipientNumber = recipientNumber;
+        Content = content;
+        RecipientJob = recipientJob;
+    }
+}

--- a/Resources/Locale/ru-RU/ADT/silicons/station-ai.ftl
+++ b/Resources/Locale/ru-RU/ADT/silicons/station-ai.ftl
@@ -21,3 +21,6 @@ ent-ActionStationAiAtmosphericAlerts = Интерфейс атмосферной
     .desc = Просмотр интерфейса атмосферной сигнализации.
 ent-ActionStationAiInfo = Просмотреть информацию
     .desc = Просмотрите общую информацию о станции.
+ent-ActionStationAiNanoChat = НаноМакс
+    .desc = Открыть мессенджер НаноМакс.
+station-ai-nanochat-window-title = НаноМакс

--- a/Resources/Prototypes/ADT/Actions/station_ai.yml
+++ b/Resources/Prototypes/ADT/Actions/station_ai.yml
@@ -101,3 +101,14 @@
     priority: -9
   - type: InstantAction
     event: !type:ToggleRemoteDevicesScreenEvent
+
+- type: entity
+  id: ActionStationAiNanoChat
+  components:
+  - type: Action
+    icon: {sprite: ADT/Misc/program_icons.rsi, state: nanochat}
+    iconOn: {sprite: ADT/Misc/program_icons.rsi, state: nanochat}
+    keywords: [ "AI", "console", "interface" ]
+    priority: -4
+  - type: InstantAction
+    event: !type:StationAiNanoChatActionEvent

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -76,6 +76,8 @@
         type: AtmosAlertsComputerBoundUserInterface
       enum.StationAiInfoUiKey.Key:
         type: StationAiInfoBoundUserInterface
+      enum.StationAiNanoChatUiKey.Key:
+        type: StationAiNanoChatBoundUserInterface
     # ADT End
   - type: IntrinsicUI
     uis:
@@ -94,6 +96,7 @@
         toggleAction: ADTActionOpenRemoteDevicesMenu
   - type: AtmosAlertsComputer
   - type: StationAiInfo
+  - type: StationAiNanoChat
   - type: CrewManifestViewer
     ownerKey: enum.StationAiInfoUiKey.Key
     # ADT End
@@ -538,6 +541,7 @@
   - type: CollectiveMindRank
     rankName: collective-mind-sai-rank
   - type: StationAiBrain
+  - type: NanoChatCard
   # ADT-Tweak-End
   - type: StartingMindRole
     mindRole: "MindRoleSiliconBrain"


### PR DESCRIPTION
## Описание PR

Станционный ИИ теперь может пользоваться мессенджером НаноМакс: собственный номер, контакты и переписка с экипажем, как у обычного члена экипажа.

## Почему / Баланс

Раньше ИИ был ограничен голосовыми радиочастотами и не мог приватно написать конкретному члену экипажа. НаноМакс даёт ИИ полноценный текстовый канал: предупреждения, жалобы начальству и координация без шума в общем канале.

## Техническая информация

- Карта НаноМакс (NanoChatCardComponent) добавлена на StationAiBrain, номер выдаётся автоматически при инициализации (стабилен в ядре и интелликарте).
- Компонент StationAiNanoChatComponent добавляется через AiHeld: даёт действие "НаноМакс" и помечает карту ИИ как доставляемую без КПК-картриджа (только пока ИИ в ядре).
- В NanoChatCartridgeSystem вынесен публичный AttemptMessageDeliveryInternal, добавлена ветка для карт ИИ с теми же проверками (станция, телекоммуникации, канал). GetCardInfo отдаёт имя и должность ИИ для контактов экипажа.
- UI переиспользует клиентский NanoChatUiFragment в собственном окне, новые XAML не добавлялись.
- Проверки: сборка DebugOpt/Release без ошибок, YAML-линтер чист, юнит-тесты 381 passed, протестировано на тестовом сервере.

## Медиа

## Чейнджлог

:cl: ultradyper, Fineter75
- add: ИИ получил доступ к НаноМаксу: собственный номер и переписка с экипажем