### PR TITLE
fix: копирование описание персонажа при клонировании

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -90,8 +90,8 @@
   - BlockWriting
   - Hushed
   - Touchy
-  - CharacterFlavor # ADT: флавор (описание персонажа), копируется при клонировании
-  # ADT-fix-clone-end
+  - CharacterFlavor
+  
 
 # for job-specific traits etc.
 - type: cloningSettings

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -91,7 +91,7 @@
   - Hushed
   - Touchy
   - CharacterFlavor
-  
+  # ADT-fix-clone-end
 
 # for job-specific traits etc.
 - type: cloningSettings

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -90,6 +90,7 @@
   - BlockWriting
   - Hushed
   - Touchy
+  - CharacterFlavor # ADT: флавор (описание персонажа), копируется при клонировании
   # ADT-fix-clone-end
 
 # for job-specific traits etc.


### PR DESCRIPTION
## Описание PR
У клона (в том числе у парадокс-клона) отсутствовало описание оригинала. ADT-фича «флавор» хранится в `CharacterFlavorComponent`, который не входил в список компонентов, копируемых при клонировании.

## Почему / Баланс
При клонировании копируются только компоненты из списков в `clone.yml`. В ванили за описание отвечал `DetailExaminable`, но ADT заменил его на `CharacterFlavorComponent` (StationSpawningSystem) и забыл добавить компонент в настройки клонирования. В результате клон выглядел как оригинал, но без его описания.

## Техническая информация
Добавлен `CharacterFlavor` в список компонентов `Body` настроек клонирования. `CopyComp` корректно копирует строковые поля `FlavorText` и `HeadshotUrl`; при отсутствии компонента у оригинала он удаляется с клона.

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
-

## Чейнджлог
:cl: ultradyper
- fix: Клоны теперь копируют описание персонажа оригинала