### PR TITLE
fix: Шоковый ошейник теперь бьёт током носителя

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Objects/Devices/shock_collar.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Devices/shock_collar.yml
@@ -19,6 +19,7 @@
     - neck
   - type: SelfUnremovableClothing
   - type: ShockOnTrigger
+    targetContainer: true
     damage: 5
     duration: 3
   - type: TriggerOnSignal


### PR DESCRIPTION
## Описание PR
Исправлен шоковый ошейник (ADTClothingNeckShockCollar): при сигнале с пульта он бил током сам себя, а не носителя.

## Почему / Баланс
У ошейника в ShockOnTrigger не было `targetContainer: true`, из-за чего электрокуция применялась к самому предмету (у него нет StatusEffectsComponent/Damageable - эффект молча пропадал). У ванильного электропака (ClothingBackpackElectropack), по которому делался ошейник, этот флаг есть. Баланс не менялся: 5 урона Shock, 3 секунды стана - как задумано.

## Техническая информация
Добавлена одна строка в YAML-прототип. Механика: ShockOnTriggerSystem (Content.Shared/Trigger/Systems/ShockOnTriggerSystem.cs) при `targetContainer: true` переопределяет цель на владельца контейнера (носителя в слоте neck).

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
- [ ] Не требуется

## Чейнджлог

:cl: ultradyper
- fix: Шоковый ошейник теперь бьёт током носителя при сигнале с пульта
