### PR TITLE
Маленький шприц: варианты дозы 1/3/5

### DIFF
--- a/Resources/Prototypes/ADT/Chemistry/injector_modes.yml
+++ b/Resources/Prototypes/ADT/Chemistry/injector_modes.yml
@@ -1,0 +1,23 @@
+- type: injectorMode
+  parent: [ BaseHyposprayMode, BaseInjectMode ]
+  id: ADTSlowMedipenInjectMode
+  mobTime: 6
+  popupUserAttempt: adt-injector-component-medipen-stiff-user
+  popupTargetAttempt: adt-injector-component-medipen-stiff-target
+
+- type: injectorMode
+  abstract: true
+  parent: BaseSyringeMode
+  id: ADTSmallSyringeMode
+  transferAmounts:
+  - 1
+  - 3
+  - 5
+
+- type: injectorMode
+  parent: [ ADTSmallSyringeMode, BaseInjectMode ]
+  id: ADTSmallSyringeInjectMode
+
+- type: injectorMode
+  parent: [ ADTSmallSyringeMode, BaseDrawMode ]
+  id: ADTSmallSyringeDrawMode

--- a/Resources/Prototypes/ADT/Entities/Objects/Specific/Chemistry/chemistry.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Specific/Chemistry/chemistry.yml
@@ -26,9 +26,10 @@
     solution: injector
   - type: Injector
     restrainedMultiplier: 2 # ADT-Tweak(P4A) Ускорение Шприцов на койках и каталках
-    activeModeProtoId: SyringeInjectMode
+    activeModeProtoId: ADTSmallSyringeDrawMode
     allowedModes:
-    - SyringeInjectMode
+    - ADTSmallSyringeDrawMode
+    - ADTSmallSyringeInjectMode
   - type: Appearance
   - type: ExaminableSolution
     solution: injector


### PR DESCRIPTION
## Описание PR
Маленький шприц (`ADTSmallSyringe`, 5u max) ранее использовал общий `BaseSyringeMode` с дозами 5/10/15. На 5u шприце варианты 10u/15u бесполезны (выкачать больше 5u нельзя). Сделан отдельный `ADTSmallSyringeMode` с дозами 1/3/5.

## Почему / Баланс
Обычные шприцы (15u, cryostasis, bluespace, dropper) не затронуты - у каждого свой режим. Малый шприц получает честные дозы под свой объём.

## Техническая информация
- Создан `ADTSmallSyringeMode` (parent: `BaseSyringeMode`, transferAmounts: 1/3/5) + Inject/Draw наследники в `Resources/Prototypes/ADT/Chemistry/injector_modes.yml`.
- В `ADTSmallSyringe` заменены `activeModeProtoId` и `allowedModes` на новые режимы.
- Вербы выбора дозы берутся из `activeMode.TransferAmounts` (`InjectorSystem.AddVerbs`), отображаются в контекстном меню по ПКМ.

- [x] Изменения протестированы локально
- [x] PR завершён

## Медиа
Не нужно.

## Чейнджлог
:cl: ultradyper
- tweak: Маленький шприц теперь предлагает дозы 1/3/5 вместо 5/10/15