### PR TITLE
fix: дрифт и осмотр опьянения не срабатывают при кровопотере (#3137)

### DIFF
--- a/Content.Shared/ADT/DrunkDrift/DrunkDriftSystem.cs
+++ b/Content.Shared/ADT/DrunkDrift/DrunkDriftSystem.cs
@@ -29,7 +29,8 @@ public sealed partial class DrunkDriftSystem : EntitySystem
 
     private void OnDrunkApplied(Entity<StatusEffectComponent> ent, ref StatusEffectAppliedEvent args)
     {
-        if (!HasComp<DrunkStatusEffectComponent>(ent.Owner))
+        // Bloodloss and woozy effects also carry DrunkStatusEffect - wobble only from alcohol.
+        if (MetaData(ent.Owner).EntityPrototype?.ID != SharedDrunkSystem.Drunk.Id)
             return;
 
         if (_timing.ApplyingState)
@@ -41,14 +42,14 @@ public sealed partial class DrunkDriftSystem : EntitySystem
 
     private void OnDrunkRemoved(Entity<StatusEffectComponent> ent, ref StatusEffectRemovedEvent args)
     {
-        if (!HasComp<DrunkStatusEffectComponent>(ent.Owner))
+        if (MetaData(ent.Owner).EntityPrototype?.ID != SharedDrunkSystem.Drunk.Id)
             return;
 
         if (_timing.ApplyingState)
             return;
 
         // Keep the marker while any drunkenness effect remains.
-        if (_statusEffects.HasEffectComp<DrunkStatusEffectComponent>(args.Target))
+        if (_statusEffects.HasStatusEffect(args.Target, SharedDrunkSystem.Drunk))
         {
             if (TryComp<ADTDrunkDriftComponent>(args.Target, out var comp))
                 UpdateVisuals(args.Target, comp);
@@ -62,7 +63,7 @@ public sealed partial class DrunkDriftSystem : EntitySystem
     private void UpdateVisuals(EntityUid uid, ADTDrunkDriftComponent comp)
     {
         var active = false;
-        if (_statusEffects.TryGetMaxTime<DrunkStatusEffectComponent>(uid, out var time))
+        if (_statusEffects.TryGetTime(uid, SharedDrunkSystem.Drunk, out var time))
         {
             var remaining = time.EndEffectTime - _timing.CurTime;
             active = remaining == null


### PR DESCRIPTION
## Описание PR
Исправлен баг из #3137: при кровопотере у игрока включались дрифт движения и осмотр "пьян", хотя алкоголя он не пил.

## Почему / Баланс
Ванильный статус-эффект кровопотери (StatusEffectBloodloss) использует компонент DrunkStatusEffect (размытие экрана при кровопотере - ванильное поведение), а система шатания фильтровала эффекты по наличию этого компонента. Теперь она ориентируется только на прототип опьянения StatusEffectDrunk.

## Техническая информация
- DrunkDriftSystem фильтрует эффекты по прототипу (EntityPrototype.ID == StatusEffectDrunk) в OnDrunkApplied/OnDrunkRemoved.
- UpdateVisuals считает остаток опьянения через TryGetTime по прототипу, а не TryGetMaxTime по компоненту.
- OnDrunkRemoved проверяет оставшееся опьянение через HasStatusEffect по прототипу.
- Размытие экрана при кровопотере (ванильный DrunkOverlay) не тронуто.
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
Не требуется.

## Чейнджлог

:cl: ultradyper
- fix: Дрифт и осмотр опьянения больше не срабатывают при кровопотере