### PR TITLE
[ADD] Сцепка для каталки и мешка для трупов на квадроцикле

### DIFF
--- a/Content.Shared/ADT/Vehicle/Trailer/ADTTrailerComponent.cs
+++ b/Content.Shared/ADT/Vehicle/Trailer/ADTTrailerComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.ADT.Vehicle.Trailer;
+
+/// <summary>
+/// Маркер прицепа: каталка или мешок для трупов, цепляемый к сцепке транспорта.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ADTTrailerComponent : Component
+{
+}

--- a/Content.Shared/ADT/Vehicle/Trailer/ADTVehicleHitchComponent.cs
+++ b/Content.Shared/ADT/Vehicle/Trailer/ADTVehicleHitchComponent.cs
@@ -1,0 +1,46 @@
+using System.Numerics;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.ADT.Vehicle.Trailer;
+
+/// <summary>
+/// Компонент транспорта со сцепкой: создаёт дочернюю сущность-сцепку, к которой цепляются прицепы.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ADTVehicleHitchComponent : Component
+{
+    /// <summary>
+    /// Прототип создаваемой сцепки.
+    /// </summary>
+    [DataField]
+    public EntProtoId HitchPrototype = "ADTVehicleHitch";
+
+    /// <summary>
+    /// Смещение сцепки относительно транспорта.
+    /// </summary>
+    [DataField]
+    public Vector2 HitchOffset = new(0, 0.55f);
+
+    /// <summary>
+    /// Радиус поиска прицепа вокруг сцепки.
+    /// </summary>
+    [DataField]
+    public float AttachRange = 2.5f;
+
+    /// <summary>
+    /// Действие водителя: прицепить или отцепить прицеп.
+    /// </summary>
+    [DataField]
+    public EntProtoId ToggleAction = "ADTActionTrailerToggle";
+
+    /// <summary>
+    /// Созданная сцепка.
+    /// </summary>
+    public EntityUid? Hitch;
+
+    /// <summary>
+    /// Созданное действие прицепа.
+    /// </summary>
+    public EntityUid? ToggleActionEntity;
+}

--- a/Content.Shared/ADT/Vehicle/Trailer/ADTVehicleHitchStrapComponent.cs
+++ b/Content.Shared/ADT/Vehicle/Trailer/ADTVehicleHitchStrapComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.ADT.Vehicle.Trailer;
+
+/// <summary>
+/// Маркер сущности-сцепки транспорта.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ADTVehicleHitchStrapComponent : Component
+{
+}

--- a/Content.Shared/ADT/Vehicle/Trailer/SharedADTVehicleTrailerSystem.cs
+++ b/Content.Shared/ADT/Vehicle/Trailer/SharedADTVehicleTrailerSystem.cs
@@ -1,0 +1,242 @@
+using System.Linq;
+using System.Numerics;
+using Content.Shared.Actions;
+using Content.Shared.Actions.Components;
+using Content.Shared.Buckle;
+using Content.Shared.Buckle.Components;
+using Content.Shared.Containers;
+using Content.Shared.Foldable;
+using Content.Shared.Interaction;
+using Content.Shared.Popups;
+using Content.Shared.Vehicle.Components;
+using Robust.Shared.Containers;
+using Robust.Shared.Map;
+using Robust.Shared.Network;
+
+namespace Content.Shared.ADT.Vehicle.Trailer;
+
+/// <summary>
+/// Событие действия водителя: прицепить или отцепить прицеп от сцепки.
+/// </summary>
+public sealed partial class ADTTrailerToggleActionEvent : InstantActionEvent
+{
+}
+
+/// <summary>
+/// Сцепки транспорта и прицепы: создание сцепки, прицепление и отцепление каталоги/мешков для трупов.
+/// </summary>
+public sealed partial class SharedADTVehicleTrailerSystem : EntitySystem
+{
+    [Dependency] private readonly INetManager _netManager = default!;
+    [Dependency] private readonly SharedBuckleSystem _buckle = default!;
+    [Dependency] private readonly SharedActionsSystem _actions = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ADTVehicleHitchComponent, MapInitEvent>(OnHitchMapInit);
+        SubscribeLocalEvent<ADTVehicleHitchComponent, EntityTerminatingEvent>(OnVehicleTerminating);
+        SubscribeLocalEvent<ADTVehicleHitchComponent, StrappedEvent>(OnVehicleStrapped);
+        SubscribeLocalEvent<ADTVehicleHitchComponent, UnstrappedEvent>(OnVehicleUnstrapped);
+        SubscribeLocalEvent<ADTVehicleHitchComponent, ADTTrailerToggleActionEvent>(OnTrailerToggleAction);
+
+        SubscribeLocalEvent<ADTTrailerComponent, InteractHandEvent>(OnTrailerInteractHand);
+        SubscribeLocalEvent<ADTTrailerComponent, FoldedEvent>(OnTrailerFolded);
+        SubscribeLocalEvent<ADTTrailerComponent, EntityTerminatingEvent>(OnTrailerTerminating);
+    }
+
+    private void OnHitchMapInit(Entity<ADTVehicleHitchComponent> ent, ref MapInitEvent args)
+    {
+        if (!_netManager.IsServer || ent.Comp.Hitch != null)
+            return;
+
+        var hitch = Spawn(ent.Comp.HitchPrototype, Transform(ent).Coordinates);
+        if (!TryComp<ADTVehicleHitchStrapComponent>(hitch, out _))
+        {
+            Log.Error($"Failed to spawn hitch {ent.Comp.HitchPrototype} for {ToPrettyString(ent)}");
+            return;
+        }
+
+        ent.Comp.Hitch = hitch;
+        Dirty(ent);
+
+        _transform.SetCoordinates(hitch, new EntityCoordinates(ent.Owner, ent.Comp.HitchOffset));
+    }
+
+    private void OnVehicleTerminating(Entity<ADTVehicleHitchComponent> ent, ref EntityTerminatingEvent args)
+    {
+        if (ent.Comp.Hitch is not { } hitch)
+            return;
+
+        // Выкинуть прицепы на карту, иначе они удалятся вместе с транспортом:
+        // при Terminating транспорта ванильный Unbuckle пропускает PlaceNextTo
+        if (TryComp<StrapComponent>(hitch, out var strap))
+        {
+            foreach (var buckled in strap.BuckledEntities.ToArray())
+            {
+                var xform = Transform(buckled);
+                _transform.SetCoordinates(buckled, xform, _transform.ToCoordinates(_transform.ToMapCoordinates(xform.Coordinates)));
+                _buckle.Unbuckle(buckled, null);
+            }
+        }
+        // Хич - ребёнок транспорта, движок удалит его сам в RecursiveFlagEntityTermination
+    }
+
+    private void OnVehicleStrapped(Entity<ADTVehicleHitchComponent> ent, ref StrappedEvent args)
+    {
+        var rider = args.Buckle.Owner;
+        if (!TryComp<ActionsComponent>(rider, out var actions))
+            return;
+
+        _actions.AddAction(rider, ref ent.Comp.ToggleActionEntity, ent.Comp.ToggleAction, ent.Owner, actions);
+    }
+
+    private void OnVehicleUnstrapped(Entity<ADTVehicleHitchComponent> ent, ref UnstrappedEvent args)
+    {
+        _actions.RemoveProvidedActions(args.Buckle.Owner, ent.Owner);
+    }
+
+    private void OnTrailerToggleAction(Entity<ADTVehicleHitchComponent> ent, ref ADTTrailerToggleActionEvent args)
+    {
+        if (_netManager.IsClient)
+            return;
+
+        args.Handled = ToggleTrailer(ent, args.Performer);
+    }
+
+    private bool ToggleTrailer(Entity<ADTVehicleHitchComponent> ent, EntityUid user)
+    {
+        // Действие только для текущего водителя этого транспорта
+        if (!TryComp<RiderComponent>(user, out var rider) || rider.Vehicle != ent.Owner)
+            return false;
+
+        if (ent.Comp.Hitch is not { } hitch || !TryComp<StrapComponent>(hitch, out var strap))
+            return false;
+
+        if (strap.BuckledEntities.Count == 0)
+        {
+            if (!TryFindTrailer(ent, hitch, out var trailer) ||
+                !TryComp<BuckleComponent>(trailer, out var buckle) ||
+                !_buckle.TryBuckle(trailer, user, hitch, buckle))
+            {
+                return false;
+            }
+
+            _popup.PopupEntity(Loc.GetString("adt-trailer-attached"), ent.Owner, user);
+            return true;
+        }
+
+        var buckled = strap.BuckledEntities.First();
+        // Прямой Unbuckle: CanUnbuckle блокируется коллизией квадроцикла между водителем и сцепкой
+        _buckle.Unbuckle(buckled, null);
+
+        // Отодвинуть прицеп от сцепки за корму, чтобы отцепление было заметно
+        var away = _transform.GetWorldPosition(hitch) - _transform.GetWorldPosition(ent);
+        if (away == Vector2.Zero)
+            away = new Vector2(0, 1);
+        away = Vector2.Normalize(away);
+
+        _transform.SetWorldPosition(buckled, _transform.GetWorldPosition(hitch) + away * 0.8f);
+
+        _popup.PopupEntity(Loc.GetString("adt-trailer-unattached"), ent.Owner, user);
+        return true;
+    }
+
+    private void OnTrailerInteractHand(Entity<ADTTrailerComponent> ent, ref InteractHandEvent args)
+    {
+        if (args.Handled || !_netManager.IsServer)
+            return;
+
+        if (!TryComp<BuckleComponent>(ent, out var buckle) || buckle.BuckledTo != null)
+            return;
+
+        if (!TryFindHitch(ent.Owner, out var hitch))
+            return;
+
+        if (!_buckle.TryBuckle(ent.Owner, args.User, hitch, buckle))
+            return;
+
+        args.Handled = true;
+        _popup.PopupEntity(Loc.GetString("adt-trailer-attached"), ent.Owner, args.User);
+    }
+
+    private void OnTrailerFolded(Entity<ADTTrailerComponent> ent, ref FoldedEvent args)
+    {
+        if (!args.IsFolded || !_netManager.IsServer)
+            return;
+
+        if (!TryComp<BuckleComponent>(ent, out var buckle) || buckle.BuckledTo == null)
+            return;
+
+        _buckle.Unbuckle(ent.Owner, null);
+    }
+
+    private void OnTrailerTerminating(Entity<ADTTrailerComponent> ent, ref EntityTerminatingEvent args)
+    {
+        // Убрать прицеп из списка сцепки, чтобы не осталось мёртвого uid
+        if (TryComp<BuckleComponent>(ent, out var buckle) && buckle.BuckledTo != null)
+            _buckle.Unbuckle(ent.Owner, null);
+    }
+
+    private bool TryFindTrailer(Entity<ADTVehicleHitchComponent> ent, EntityUid hitch, out EntityUid trailer)
+    {
+        trailer = default;
+        var hitchPos = _transform.ToMapCoordinates(Transform(hitch).Coordinates);
+        var maxRangeSq = ent.Comp.AttachRange * ent.Comp.AttachRange;
+
+        var bestDist = maxRangeSq;
+        var query = EntityQueryEnumerator<ADTTrailerComponent, BuckleComponent, TransformComponent>();
+        while (query.MoveNext(out var candidate, out _, out var buckle, out var xform))
+        {
+            if (buckle.BuckledTo != null || _container.IsEntityInContainer(candidate))
+                continue;
+
+            if (xform.MapID != hitchPos.MapId)
+                continue;
+
+            var dist = (hitchPos.Position - _transform.ToMapCoordinates(xform.Coordinates).Position).LengthSquared();
+            if (dist > bestDist)
+                continue;
+
+            bestDist = dist;
+            trailer = candidate;
+        }
+
+        return trailer != default;
+    }
+
+    private bool TryFindHitch(EntityUid trailer, out EntityUid hitch)
+    {
+        hitch = default;
+        var trailerPos = _transform.ToMapCoordinates(Transform(trailer).Coordinates);
+
+        var bestDist = float.MaxValue;
+        var query = EntityQueryEnumerator<ADTVehicleHitchComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var comp, out var xform))
+        {
+            if (comp.Hitch is not { } hitchUid)
+                continue;
+
+            if (xform.MapID != trailerPos.MapId)
+                continue;
+
+            // Только свободная сцепка: один прицеп на одну сцепку
+            if (!TryComp<StrapComponent>(hitchUid, out var strap) || strap.BuckledEntities.Count != 0)
+                continue;
+
+            var range = comp.AttachRange;
+            var dist = (trailerPos.Position - _transform.ToMapCoordinates(xform.Coordinates).Position).LengthSquared();
+            if (dist > range * range || dist > bestDist)
+                continue;
+
+            bestDist = dist;
+            hitch = hitchUid;
+        }
+
+        return hitch != default;
+    }
+}

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
+using Content.Shared.ADT.Vehicle.Trailer;
 using Content.Shared.Alert;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Cuffs.Components;
@@ -141,6 +142,10 @@ public abstract partial class SharedBuckleSystem
         if (HasComp<RiderComponent>(buckle.Owner) && HasComp<VehicleComponent>(strapUid))
             return;
         // ADT Vehicles end
+        // ADT-Tweak-Start: прицепы (каталка, мешок для трупов) не должны отцепляться от сцепки транспорта
+        if (HasComp<ADTTrailerComponent>(buckle.Owner) && HasComp<ADTVehicleHitchStrapComponent>(strapUid))
+            return;
+        // ADT-Tweak-End
 
         var delta = (xform.LocalPosition - strapComp.BuckleOffset).LengthSquared();
         if (delta > 1e-5)

--- a/Resources/Locale/en-US/ADT/prototypes/Entities/Objects/Vehicles/vehicles.ftl
+++ b/Resources/Locale/en-US/ADT/prototypes/Entities/Objects/Vehicles/vehicles.ftl
@@ -1,0 +1,8 @@
+ent-ADTVehicleATVMedic = medical ATV
+    .desc = An ATV with a hitch for carrying rollerbeds and body bags.
+
+ent-ADTActionTrailerToggle = Trailer
+    .desc = Attach or detach a trailer from the ATV hitch.
+
+adt-trailer-attached = The trailer is attached to the ATV.
+adt-trailer-unattached = The trailer is detached from the ATV.

--- a/Resources/Locale/ru-RU/ADT/prototypes/Entities/Objects/Vehicles/vehicles.ftl
+++ b/Resources/Locale/ru-RU/ADT/prototypes/Entities/Objects/Vehicles/vehicles.ftl
@@ -44,7 +44,7 @@ vehicle-folded-ejected = Вас вытолкнули из { $vehicle }, пото
 ent-ADTVehicleATVMedic = медицинский квадроцикл
     .desc = Квадроцикл со сцепкой для перевозки каталок и мешков для трупов.
 
-ent-ADTActionTrailerToggle = Прицеп
+ent-ADTActionTrailerToggle = прицеп
     .desc = Прицепить или отцепить прицеп от сцепки квадроцикла.
 
 adt-trailer-attached = Прицеп закреплён на сцепке.

--- a/Resources/Locale/ru-RU/ADT/prototypes/Entities/Objects/Vehicles/vehicles.ftl
+++ b/Resources/Locale/ru-RU/ADT/prototypes/Entities/Objects/Vehicles/vehicles.ftl
@@ -40,3 +40,12 @@ vehicle-use-key = Вы используете { $keys } чтобы запуст�
 vehicle-folded-cannot-buckle = Нельзя сесть на сложенное транспортное средство { $vehicle }.
 vehicle-hands-occupied = Руки заняты, чтобы сесть на { $vehicle }.
 vehicle-folded-ejected = Вас вытолкнули из { $vehicle }, потому что его сложили!
+
+ent-ADTVehicleATVMedic = медицинский квадроцикл
+    .desc = Квадроцикл со сцепкой для перевозки каталок и мешков для трупов.
+
+ent-ADTActionTrailerToggle = Прицеп
+    .desc = Прицепить или отцепить прицеп от сцепки квадроцикла.
+
+adt-trailer-attached = Прицеп закреплён на сцепке.
+adt-trailer-unattached = Прицеп отцеплён от сцепки.

--- a/Resources/Prototypes/ADT/Entities/Markers/Spawners/vehicles.yml
+++ b/Resources/Prototypes/ADT/Entities/Markers/Spawners/vehicles.yml
@@ -95,3 +95,12 @@
   - type: ConditionalSpawner
     prototypes:
       - ADTVehicleLavabike
+
+- type: entity
+  name: Medical ATV Spawner
+  id: ADTSpawnVehicleATVMedic
+  parent: ADTSpawnVehicleATV
+  components:
+  - type: ConditionalSpawner
+    prototypes:
+      - ADTVehicleATVMedic

--- a/Resources/Prototypes/ADT/Entities/Objects/Vehicles/actions.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Vehicles/actions.yml
@@ -9,3 +9,12 @@
     icon: { sprite: Objects/Fun/bikehorn.rsi, state: icon } 
   - type: InstantAction
     event: !type:HonkActionEvent
+
+- type: entity
+  id: ADTActionTrailerToggle
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Action
+    icon: { sprite: Structures/Furniture/rollerbeds.rsi, state: rollerbed }
+  - type: InstantAction
+    event: !type:ADTTrailerToggleActionEvent

--- a/Resources/Prototypes/ADT/Entities/Objects/Vehicles/buckleable.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Vehicles/buckleable.yml
@@ -282,6 +282,7 @@
           components:
             - Storage
     sprite: Objects/Vehicles/atv.rsi
+  - type: ADTVehicleHitch
 
 - type: entity
   id: ADTVehicleSyndicateSegway
@@ -481,3 +482,7 @@
   components:
     - type: Foldable
       folded: true
+
+- type: entity
+  parent: ADTVehicleATV
+  id: ADTVehicleATVMedic

--- a/Resources/Prototypes/ADT/Entities/Objects/Vehicles/trailer.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Vehicles/trailer.yml
@@ -6,6 +6,7 @@
   - type: Physics
     bodyType: KinematicController
     bodyStatus: OnGround
+    canCollide: false
   - type: Strap
     buckleOnInteractHand: false
     position: None

--- a/Resources/Prototypes/ADT/Entities/Objects/Vehicles/trailer.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Vehicles/trailer.yml
@@ -1,0 +1,14 @@
+- type: entity
+  id: ADTVehicleHitch
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: ADTVehicleHitchStrap
+  - type: Physics
+    bodyType: KinematicController
+    bodyStatus: OnGround
+  - type: Strap
+    buckleOnInteractHand: false
+    position: None
+    whitelist:
+      components:
+      - ADTTrailer

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
@@ -87,6 +87,11 @@
           True: {visible: false}
           False: {visible: true}
   - type: Pullable
+  # ADT-Tweak-Start: мешок для трупов цепляется к сцепке квадроцикла
+  - type: Buckle
+    range: 3
+  - type: ADTTrailer
+  # ADT-Tweak-End
   - type: AntiRottingContainer
   - type: ContainerContainer
     containers:

--- a/Resources/Prototypes/Entities/Structures/Furniture/rollerbeds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/rollerbeds.yml
@@ -64,6 +64,11 @@
       rotation: -90
       buckleOffset: "0,0.15"
       buckleOnInteractHand: False
+    # ADT-Tweak-Start: каталка цепляется к сцепке квадроцикла
+    - type: Buckle
+      range: 3
+    - type: ADTTrailer
+    # ADT-Tweak-End
     - type: Appearance
     - type: GenericVisualizer
       visuals:


### PR DESCRIPTION
## Описание PR

Квадроцикл (ADTVehicleATV и медицинский ADTVehicleATVMedic) получил сцепку (ADTVehicleHitch) для перевозки каталок (RollerBed) и мешков для трупов (BodyBag). Водитель может прицепить/отцепить прицеп действием "Прицеп" (сидя за рулём) или вручную, подойдя к прицепу. При удалении транспорта прицеп остаётся на месте.

## Почему / Баланс

Медикам нужен способ быстро вывозить раненых/трупы с места происшествия, не таская каталку в руках. Сцепка работает только с каталками и мешками (whitelist), другие предметы цеплять нельзя. Баланс не задет: обычные предметы не трогаются.

## Техническая информация

- Новая система `SharedADTVehicleTrailerSystem` (Content.Shared/ADT/Vehicle/Trailer/): при MapInit транспорта спавнит дочернюю сущность-сцепку (KinematicController, следует за квадроциклом как водитель), прицепление/отцепление через Buckle (хич - Strap с whitelist ADTTrailer), действие водителя (ADTActionTrailerToggle) добавляется при посадке и снимается при слезании.
- При отцеплении прицеп отодвигается за корму; при удалении/сворачивании транспорта прицепы выкидываются на карту (не удаляются вместе с ним).
- Каталке (rollerbeds.yml) и мешку (morgue.yml) добавлены Buckle range 3 + ADTTrailer (ADT-Tweak маркеры); в SharedBuckleSystem.Buckle.cs - пропуск деактивации прицепов на сцепке (ADT-Tweak маркеры).
- Локализация ru + en в ADT-папках.

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
Под пром

## Чейнджлог

:cl: ultradyper
- add: Квадроцикл получил сцепку для перевозки каталок и мешков для трупов
