### PR TITLE
fix: моли теперь могут есть одежду из стильномата и пара других мелких фиксов одежки

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Clothing/Neck/facescarfs.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/Neck/facescarfs.yml
@@ -11,9 +11,6 @@
     slots: [mask, neck]
   - type: IdentityBlocker
     coverage: MOUTH
-  - type: Tag
-    tags:
-    - WhitelistChameleon
 
 - type: entity
   parent: ADTClothingNeckFacescarfBlack

--- a/Resources/Prototypes/ADT/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/OuterClothing/coats.yml
@@ -36,7 +36,7 @@
 
 #толстовки-топки от Празата
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: ADTClothingOuterStorageClothBase
   id: ADTClothingOuterWhiteSweatshirtTop
   name: white sweatshirt-top
   description: white sweatshirt-top
@@ -49,7 +49,7 @@
     price: 65
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: ADTClothingOuterStorageClothBase
   id: ADTClothingOuterGraySweatshirtTop
   name: gray sweatshirt-top
   description: gray sweatshirt-top
@@ -62,7 +62,26 @@
     price: 65
 
 - type: entity
+  abstract: true
   parent: ClothingOuterStorageBase
+  id: ADTClothingOuterStorageClothBase
+  components:
+  - type: Edible
+    requiresSpecialDigestion: true
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 30
+        reagents:
+        - ReagentId: Fiber
+          Quantity: 30
+  - type: Tag
+    tags:
+    - ClothMade
+    - WhitelistChameleon
+
+- type: entity
+  parent: ADTClothingOuterStorageClothBase
   id: ADTClothingOuterBlackSweatshirtTop
   name: black sweatshirt-top
   description: black sweatshirt-top
@@ -323,7 +342,7 @@
 
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: ADTClothingOuterStorageClothBase
   id: ADTClothingOuterDutch
   name: dutch's jacket
   description: For those long nights on the beach in Tahiti.
@@ -334,7 +353,7 @@
     sprite: ADT/Clothing/OuterClothing/Coats/dutch_jacket.rsi
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: ADTClothingOuterStorageClothBase
   id: ADTClothingOuterLettermanNanoTrasen
   name: blue letterman jacket
   description: A blue letterman jacket with a proud Nanotrasen N on the back. The tag says that it was made by Mr.Chang's corp.
@@ -345,7 +364,7 @@
     sprite: ADT/Clothing/OuterClothing/Coats/letterman_nanotrasen.rsi
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: ADTClothingOuterStorageClothBase
   id: ADTClothingOuterLettermanSyndie
   name: blood-red letterman jacket
   description: A blood-red letterman jacket with a huge S on the back. Nothing suspicious.
@@ -356,7 +375,7 @@
     sprite: ADT/Clothing/OuterClothing/Coats/letterman_syndie.rsi
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: ADTClothingOuterStorageClothBase
   id: ADTClothingOuterLettermanBlack
   name: black letterman jacket
   description: A black letterman jacket.

--- a/Resources/Prototypes/Entities/Clothing/Hands/base_clothinghands.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/base_clothinghands.yml
@@ -48,6 +48,7 @@
     tags:
     - Recyclable
     - WhitelistChameleon
+    - ClothMade # ADT-Tweak: добавлен тег ткани для перчаток
 
 # gloves that cover the fingertips and have synthetic fibers
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpsuits.yml
@@ -55,11 +55,6 @@
       - state: equipped-INNERCLOTHING
         color: "#b3b3b3"
       - state: trinkets-equipped-INNERCLOTHING
-### Start ADT Tweak
-  - type: Tag
-    tags:
-      - ADTJumpSuitSacrifice
-### End ADT Tweak
 
 # Black Jumpsuit
 - type: entity


### PR DESCRIPTION
## Описание PR
Теперь можно есть одежду из стильномата, есть разноцветные перчатки, и еще пара мелких фиксов

## Почему / Баланс
Моли не могли есть одежду из стильномата, хотя должны иметь возможность есть одежду. 

Также моли не могли есть разноцветные перчатки, серый комбез, лицевые шарфы, хотя должны иметь возможность их есть.

## Техническая информация
1) Для различных пальто из стильномата добавлен новый парент `ADTClothingOuterStorageClothBase`, который могут есть моли
2) `ClothingHandsButcherable` теперь имеет `ClothMade`, что позволяет молям есть разноцветные перчатки
3) У серого комбеза убраны теги, и теперь он наследует теги `ClothingUniformBase`
4) У черного лицевого шарфа убраны теги, и теперь он наследует теги `ClothingScarfBase`. Черный лицевой шарф является парентом для других лицевых шарфов, поэтому другие лицевые шарфы теперь тоже можно есть

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<img width="787" height="270" alt="image" src="https://github.com/user-attachments/assets/474cb4af-a51c-4ebd-9f65-328b3c42bd87" />
<img width="787" height="270" alt="image" src="https://github.com/user-attachments/assets/99f480a1-d48d-40c9-b3c0-6e584e45a6c8" />
<img width="787" height="270" alt="image" src="https://github.com/user-attachments/assets/cd21c406-d1de-4cbc-8ca0-70d6ca9c31ba" />
<img width="787" height="270" alt="image" src="https://github.com/user-attachments/assets/fc66ea49-da3b-4b99-b430-0e616da7b362" />


## Чейнджлог
:cl: FriendlyOne
- fix: Моли теперь могут есть одежду из стильномата, разноцветные перчатки, и еще пару вещей

