### PR TITLE
fix: Побочные еффекты аломицина, детоксизола, и ковриния

### DIFF
--- a/Resources/Prototypes/ADT/Reagents/medicine.yml
+++ b/Resources/Prototypes/ADT/Reagents/medicine.yml
@@ -504,8 +504,8 @@
               Poison: -9
               Slash: 0.4
               Piercing: 0.8
-        - !type:GenericStatusEffect
-          key: Drunk
+        - !type:ModifyStatusEffect
+          effectProto: StatusEffectDrunk
           time: 8.0
           type: Add
 
@@ -580,9 +580,8 @@
             types:
               Shock: -6.2
               Caustic: -5.1
-        - !type:GenericStatusEffect
-          key: TemporaryBlindness
-          component: TemporaryBlindness
+        - !type:ModifyStatusEffect
+          effectProto: StatusEffectBlindness
           time: 60
           type: Add
 

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -21,12 +21,11 @@
           type: [ Moth ]
         key: Stutter
         component: StutteringAccent
-      - !type:GenericStatusEffect
+      - !type:ModifyStatusEffect
         conditions:
         - !type:MetabolizerTypeCondition
           type: [ Moth ]
-        key: SeeingRainbows
-        component: SeeingRainbows
+        effectProto: StatusEffectSeeingRainbow
         type: Add
         time: 8
     # End ADT tweak


### PR DESCRIPTION
## Описание PR
Фикс еффектов аломицина, детоксизола, и ковриния

## Почему / Баланс
Оно должно работать, но оно не работает, теперь работает
- [Баг-репорт](https://discord.com/channels/901772674865455115/1537745425338208346)

## Техническая информация
Еффекты `SeeingRainbows`, `Drunk` и `TemporaryBlindness` были переведены на новую систему статус-еффектов, из-за чего старый вызов через `GenericStatusEffect` перестал их применять.
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/19563a4e-6607-4522-b4ac-1c13f4a7740b" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2c0106cc-cdb9-40df-be46-69db06237445" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4acf91b6-073a-493b-8755-fd9d46cbac6d" />

## Чейнджлог
:cl: FriendlyOne
- fix: Побочные еффекты аломицина, детоксизола, и ковриния теперь работают как надо