### PR TITLE
fix: КПБ и новакиды больше не могут быть генокрадами

### DIFF
--- a/Resources/Prototypes/_Goobstation/Changeling/game_rule.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/game_rule.yml
@@ -25,7 +25,7 @@
       blacklist:
         components:
         - CommandStaff
-        # ADT-Tweak-Start: КПБ получал роль и цели генокрада
+        # ADT-Tweak-Start
         - Silicon
         tags:
         - ChangelingBlacklist

--- a/Resources/Prototypes/_Goobstation/Changeling/game_rule.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/game_rule.yml
@@ -25,6 +25,11 @@
       blacklist:
         components:
         - CommandStaff
+        # ADT-Tweak-Start: КПБ получал роль и цели генокрада, но без способностей (MakeChangeling отклонял силиконы уже после выдачи роли)
+        - Silicon
+        tags:
+        - ChangelingBlacklist
+        # ADT-Tweak-End
       lateJoinAdditional: true
       mindRoles:
       - MindRoleChangeling

--- a/Resources/Prototypes/_Goobstation/Changeling/game_rule.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/game_rule.yml
@@ -25,7 +25,7 @@
       blacklist:
         components:
         - CommandStaff
-        # ADT-Tweak-Start: КПБ получал роль и цели генокрада, но без способностей (MakeChangeling отклонял силиконы уже после выдачи роли)
+        # ADT-Tweak-Start: КПБ получал роль и цели генокрада
         - Silicon
         tags:
         - ChangelingBlacklist


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
КПБ (раса IPC) и новакиды больше не попадают в отбор генокрада: в блеклист геймрула `Changeling` добавлен компонент `Silicon` и активирован существовавший, но не использовавшийся тег `ChangelingBlacklist` (он уже стоял на MobIPC и MobNovakid).

Раньше КПБ мог быть выбран генокрадом и получал роль `MindRoleChangeling` и цели генокрада, но без способностей: проверка `SiliconComponent` в `MakeChangeling` срабатывала уже после выдачи роли (в `MakeAntag`).

## Почему / Баланс
Железкам с проводами не место в органике генокрада. Правка повторяет прежний фикс «КПБ и новакиды больше не должны становиться генокрадами», но на уровне отбора антага, а не постфактум.

## Техническая информация
- `AntagSelectionSystem.IsEntityValid` проверяет `blacklist` (`EntityWhitelist`: components + tags, OR) до `MakeAntag`, поэтому роль, цели и брифинг генокрада КПБ/новакидам больше не выдаются.
- Отсев работает на раундстарте, лейтджойне и при запуске пресета.
- Проверка `HasComp<SiliconComponent>` в `ChangelingRuleSystem.MakeChangeling` оставлена как страховка.
- Проверено: YAML-линтер - No errors found.
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->
Не требуется.

## Чейнджлог

:cl: ultradyper
- fix: КПБ и новакиды больше не могут быть генокрадами