### PR TITLE
upd postMapinit

### DIFF
--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -464,10 +464,18 @@ namespace Content.IntegrationTests.Tests
                             var spawnPointProtos = protoManager.EnumeratePrototypes<EntityPrototype>()
                                 .Where(proto => !proto.Abstract
                                     && proto.TryGetComponent<SpawnPointComponent>(out var spawn, componentFactory)
+                                    && spawn.SpawnType == SpawnPointType.Job
                                     && spawn.Job == job)
                                 .Select(proto => proto.ID);
 
-                            var protos = string.Join(", ", spawnPointProtos);
+                            var containerSpawnPointProtos = protoManager.EnumeratePrototypes<EntityPrototype>()
+                                .Where(proto => !proto.Abstract
+                                    && proto.TryGetComponent<ContainerSpawnPointComponent>(out var spawn, componentFactory)
+                                    && spawn.SpawnType is SpawnPointType.Job or SpawnPointType.Unset
+                                    && spawn.Job == job)
+                                .Select(proto => proto.ID);
+
+                            var protos = string.Join(", ", spawnPointProtos.Concat(containerSpawnPointProtos).Distinct());
                             return protos.Length == 0
                                 ? $"{job} (no spawn point entity prototype found)"
                                 : $"{job} (spawn point entity prototypes: {protos})";

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -136,8 +136,10 @@ namespace Content.IntegrationTests.Tests
                 mapSystem.CreateMap(out var mapId);
                 try
                 {
+                    // ADT-Tweak start
                     Assert.That(mapLoader.TryLoadGrid(mapId, path, out var grid),
-                        $"Failed to load grid {mapFile}, was it saved as a map instead of a grid?"); // ADT-Tweak
+                        $"Failed to load grid {mapFile}, was it saved as a map instead of a grid?");
+                    // ADT-Tweak end
                 }
                 catch (Exception ex)
                 {
@@ -239,8 +241,10 @@ namespace Content.IntegrationTests.Tests
 
             if (isV7Map)
             {
+                // ADT-Tweak start
                 Assert.That(IsPreInit(map, loader, deps, ev.RenamedPrototypes, ev.DeletedPrototypes),
-                    $"Map {map} was saved post-map-init, open it in the map editor and save it again without running map init."); // ADT-Tweak
+                    $"Map {map} was saved post-map-init, open it in the map editor and save it again without running map init.");
+                // ADT-Tweak end
             }
 
             // Check that the test actually does manage to catch post-init maps and isn't just blindly passing everything.
@@ -252,15 +256,20 @@ namespace Content.IntegrationTests.Tests
 
             // First check that a pre-init version passes
             var path = new ResPath($"{nameof(NoSavedPostMapInitTest)}.yml");
-            Assert.That(loader.TrySaveMap(id, path), $"Failed to save map {path}"); // ADT-Tweak
+            // ADT-Tweak start
+            Assert.That(loader.TrySaveMap(id, path), $"Failed to save map {path}");
             Assert.That(IsPreInit(path, loader, deps, ev.RenamedPrototypes, ev.DeletedPrototypes),
-                $"Test map {path} failed pre-init check"); // ADT-Tweak
+                $"Test map {path} failed pre-init check");
+            // ADT-Tweak end
 
             // and the post-init version fails.
             await server.WaitPost(() => mapSys.InitializeMap(id));
-            Assert.That(loader.TrySaveMap(id, path), $"Failed to save map {path}"); // ADT-Tweak
+            // ADT-Tweak start
+            Assert.That(loader.TrySaveMap(id, path), $"Failed to save map {path}");
+            // ADT-Tweak start
             Assert.That(IsPreInit(path, loader, deps, ev.RenamedPrototypes, ev.DeletedPrototypes), Is.False,
-                $"Test map {path} unexpectedly passed pre-init check"); // ADT-Tweak
+                $"Test map {path} unexpectedly passed pre-init check");
+            // ADT-Tweak end
         }
 
         private bool IsWhitelistedForMap(EntProtoId protoId, ResPath map)

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -266,7 +266,6 @@ namespace Content.IntegrationTests.Tests
             await server.WaitPost(() => mapSys.InitializeMap(id));
             // ADT-Tweak start
             Assert.That(loader.TrySaveMap(id, path), $"Failed to save map {path}");
-            // ADT-Tweak start
             Assert.That(IsPreInit(path, loader, deps, ev.RenamedPrototypes, ev.DeletedPrototypes), Is.False,
                 $"Test map {path} unexpectedly passed pre-init check");
             // ADT-Tweak end

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -136,7 +136,8 @@ namespace Content.IntegrationTests.Tests
                 mapSystem.CreateMap(out var mapId);
                 try
                 {
-                    Assert.That(mapLoader.TryLoadGrid(mapId, path, out var grid));
+                    Assert.That(mapLoader.TryLoadGrid(mapId, path, out var grid),
+                        $"Failed to load grid {mapFile}, was it saved as a map instead of a grid?"); // ADT-Tweak
                 }
                 catch (Exception ex)
                 {
@@ -238,7 +239,8 @@ namespace Content.IntegrationTests.Tests
 
             if (isV7Map)
             {
-                Assert.That(IsPreInit(map, loader, deps, ev.RenamedPrototypes, ev.DeletedPrototypes));
+                Assert.That(IsPreInit(map, loader, deps, ev.RenamedPrototypes, ev.DeletedPrototypes),
+                    $"Map {map} was saved post-map-init, open it in the map editor and save it again without running map init."); // ADT-Tweak
             }
 
             // Check that the test actually does manage to catch post-init maps and isn't just blindly passing everything.
@@ -250,13 +252,15 @@ namespace Content.IntegrationTests.Tests
 
             // First check that a pre-init version passes
             var path = new ResPath($"{nameof(NoSavedPostMapInitTest)}.yml");
-            Assert.That(loader.TrySaveMap(id, path));
-            Assert.That(IsPreInit(path, loader, deps, ev.RenamedPrototypes, ev.DeletedPrototypes));
+            Assert.That(loader.TrySaveMap(id, path), $"Failed to save map {path}"); // ADT-Tweak
+            Assert.That(IsPreInit(path, loader, deps, ev.RenamedPrototypes, ev.DeletedPrototypes),
+                $"Test map {path} failed pre-init check"); // ADT-Tweak
 
             // and the post-init version fails.
             await server.WaitPost(() => mapSys.InitializeMap(id));
-            Assert.That(loader.TrySaveMap(id, path));
-            Assert.That(IsPreInit(path, loader, deps, ev.RenamedPrototypes, ev.DeletedPrototypes), Is.False);
+            Assert.That(loader.TrySaveMap(id, path), $"Failed to save map {path}"); // ADT-Tweak
+            Assert.That(IsPreInit(path, loader, deps, ev.RenamedPrototypes, ev.DeletedPrototypes), Is.False,
+                $"Test map {path} unexpectedly passed pre-init check"); // ADT-Tweak
         }
 
         private bool IsWhitelistedForMap(EntProtoId protoId, ResPath map)
@@ -363,6 +367,7 @@ namespace Content.IntegrationTests.Tests
             var ticker = entManager.EntitySysManager.GetEntitySystem<GameTicker>();
             var shuttleSystem = entManager.EntitySysManager.GetEntitySystem<ShuttleSystem>();
             var cfg = server.ResolveDependency<IConfigurationManager>();
+            var mapPath = protoManager.Index<GameMapPrototype>(mapProto).MapPath; // ADT-Tweak
 
             await server.WaitPost(() =>
             {
@@ -429,7 +434,7 @@ namespace Content.IntegrationTests.Tests
                         lateSpawns += GetCountLateSpawn<SpawnPointComponent>(gridUids, entManager);
                         lateSpawns += GetCountLateSpawn<ContainerSpawnPointComponent>(gridUids, entManager);
 
-                        Assert.That(lateSpawns, Is.GreaterThan(0), $"Found no latejoin spawn points on {mapProto}");
+                        Assert.That(lateSpawns, Is.GreaterThan(0), $"Found no latejoin spawn points on {mapProto} ({mapPath})"); // ADT-Tweak
                     }
 
                     // Test all availableJobs have spawnPoints
@@ -449,7 +454,29 @@ namespace Content.IntegrationTests.Tests
 
                     jobs.ExceptWith(spawnPoints);
 
-                    Assert.That(jobs, Is.Empty, $"There is no spawnpoints for {string.Join(", ", jobs)} on {mapProto}.");
+                    // ADT-Tweak start
+                    if (jobs.Count > 0)
+                    {
+                        var componentFactory = server.ResolveDependency<IComponentFactory>();
+
+                        var missing = jobs.Select(job =>
+                        {
+                            var spawnPointProtos = protoManager.EnumeratePrototypes<EntityPrototype>()
+                                .Where(proto => !proto.Abstract
+                                    && proto.TryGetComponent<SpawnPointComponent>(out var spawn, componentFactory)
+                                    && spawn.Job == job)
+                                .Select(proto => proto.ID);
+
+                            var protos = string.Join(", ", spawnPointProtos);
+                            return protos.Length == 0
+                                ? $"{job} (no spawn point entity prototype found)"
+                                : $"{job} (spawn point entity prototypes: {protos})";
+                        });
+
+                        Assert.Fail($"Map {mapPath} ({mapProto}) is missing spawn points for jobs: {string.Join("; ", missing)}. " +
+                            "Add the corresponding spawn point entities to the map and save it.");
+                    }
+                    // ADT-Tweak end
                 }
 
                 try


### PR DESCRIPTION
## Описание PR
Улучшил сообщения об ошибках в тестах карт, чтобы при падении было сразу видно, что сломано, в каком файле и что исправить. Раньше часть проверок падала с бесполезным Expected: True But was: False или сообщением без пути к карте.