### PR TITLE
feat: лайтовая зависимость от кофе (попапы ломки без симптомов)

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml.cs
@@ -489,6 +489,7 @@ public sealed partial class HealthAnalyzerControl : BoxContainer
         AddictionKind.Drug => "drug",
         AddictionKind.Medicine => "medicine",
         AddictionKind.Omnizine => "omnizine",
+        AddictionKind.Coffee => "coffee",
         _ => "alcohol",
     };
     // ADT-Tweak-End

--- a/Content.Server/ADT/Addiction/AddictionSymptomsSystem.cs
+++ b/Content.Server/ADT/Addiction/AddictionSymptomsSystem.cs
@@ -78,7 +78,6 @@ public sealed partial class AddictionSymptomsSystem : EntitySystem
             if (!channel.InWithdrawal)
                 continue;
 
-            // Кофе - лайтовая зависимость: только попапы, без симптомов
             if (channel.Kind == AddictionKind.Coffee)
                 continue;
 

--- a/Content.Server/ADT/Addiction/AddictionSymptomsSystem.cs
+++ b/Content.Server/ADT/Addiction/AddictionSymptomsSystem.cs
@@ -36,7 +36,7 @@ public sealed partial class AddictionSymptomsSystem : EntitySystem
             var due = false;
             foreach (var channel in comp.Channels)
             {
-                if (!channel.InWithdrawal)
+                if (!channel.InWithdrawal || channel.Kind == AddictionKind.Coffee)
                     continue;
 
                 anyWithdrawal = true;
@@ -51,8 +51,10 @@ public sealed partial class AddictionSymptomsSystem : EntitySystem
 
             foreach (var channel in comp.Channels)
             {
-                if (channel.InWithdrawal)
-                    channel.NextSymptomsTime = _timing.CurTime + comp.SymptomRefreshInterval;
+                if (!channel.InWithdrawal || channel.Kind == AddictionKind.Coffee)
+                    continue;
+
+                channel.NextSymptomsTime = _timing.CurTime + comp.SymptomRefreshInterval;
             }
         }
     }
@@ -74,6 +76,10 @@ public sealed partial class AddictionSymptomsSystem : EntitySystem
         foreach (var channel in comp.Channels)
         {
             if (!channel.InWithdrawal)
+                continue;
+
+            // Кофе - лайтовая зависимость: только попапы, без симптомов
+            if (channel.Kind == AddictionKind.Coffee)
                 continue;
 
             anyWithdrawal = true;

--- a/Content.Server/ADT/Addiction/AddictionSystem.cs
+++ b/Content.Server/ADT/Addiction/AddictionSystem.cs
@@ -110,7 +110,6 @@ public sealed partial class AddictionSystem : EntitySystem
         {
             channel.InWithdrawal = true;
             channel.Stage = stage;
-            // Кофе без симптомов - пересчитывать нечего, иначе снимем чужие (дрожь и т.п.)
             if (channel.Kind != AddictionKind.Coffee)
                 RaiseSymptomsChanged(uid);
         }

--- a/Content.Server/ADT/Addiction/AddictionSystem.cs
+++ b/Content.Server/ADT/Addiction/AddictionSystem.cs
@@ -110,7 +110,9 @@ public sealed partial class AddictionSystem : EntitySystem
         {
             channel.InWithdrawal = true;
             channel.Stage = stage;
-            RaiseSymptomsChanged(uid);
+            // Кофе без симптомов - пересчитывать нечего, иначе снимем чужие (дрожь и т.п.)
+            if (channel.Kind != AddictionKind.Coffee)
+                RaiseSymptomsChanged(uid);
         }
 
         if (_timing.CurTime >= channel.NextPopupTime)
@@ -143,7 +145,9 @@ public sealed partial class AddictionSystem : EntitySystem
     {
         channel.InWithdrawal = false;
         channel.Stage = 0;
-        RaiseSymptomsChanged(uid);
+        // Кофе без симптомов - пересчитывать нечего, иначе снимем чужие (дрожь и т.п.)
+        if (channel.Kind != AddictionKind.Coffee)
+            RaiseSymptomsChanged(uid);
     }
 
     private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent args)
@@ -227,6 +231,9 @@ public sealed partial class AddictionSystem : EntitySystem
         if (reagent.Prototype == comp.NicotineReagent)
             return AddictionKind.Nicotine;
 
+        if (reagent.Prototype == comp.CoffeeReagent)
+            return AddictionKind.Coffee;
+
         if (!_proto.TryIndex(reagent.Prototype, out ReagentPrototype? proto))
             return null;
 
@@ -255,6 +262,7 @@ public sealed partial class AddictionSystem : EntitySystem
         AddictionKind.Drug => "drug",
         AddictionKind.Medicine => "medicine",
         AddictionKind.Omnizine => "omnizine",
+        AddictionKind.Coffee => "coffee",
         _ => "alcohol",
     };
 }

--- a/Content.Shared/ADT/Addiction/AddictionComponent.cs
+++ b/Content.Shared/ADT/Addiction/AddictionComponent.cs
@@ -122,6 +122,12 @@ public sealed partial class AddictionComponent : Component
     public ProtoId<ReagentPrototype> NicotineReagent = "Nicotine";
 
     /// <summary>
+    /// Реагент, который кормит кофейный канал (по id, как никотин).
+    /// </summary>
+    [DataField]
+    public ProtoId<ReagentPrototype> CoffeeReagent = "Coffee";
+
+    /// <summary>
     /// Id родительского прототипа, по которому реагент считается алкоголем (в ADT все спиртные наследуют BaseAlcohol).
     /// </summary>
     [DataField]
@@ -150,6 +156,7 @@ public enum AddictionKind : byte
     Drug,
     Medicine,
     Omnizine,
+    Coffee,
 }
 
 /// <summary>

--- a/Resources/Locale/ru-RU/ADT/addictions.ftl
+++ b/Resources/Locale/ru-RU/ADT/addictions.ftl
@@ -19,12 +19,14 @@ addiction-begin-nicotine = Ты замечаешь, что начинаешь п
 addiction-begin-drug = Ты замечаешь, что начинаешь привыкать к наркотикам...
 addiction-begin-medicine = Ты замечаешь, что начинаешь привыкать к лекарствам...
 addiction-begin-omnizine = Ты замечаешь, что начинаешь привыкать к омнизину...
+addiction-begin-coffee = Ты замечаешь, что начинаешь привыкать к кофе...
 
 addiction-dose-alcohol = Глоток. По телу разливается тепло, ломка отступает.
 addiction-dose-nicotine = Затяжка. Голова проясняется, руки перестают трястись.
 addiction-dose-drug = Доза ударила в голову. Ломка отступает.
 addiction-dose-medicine = Доза лекарства. Ломка отступает.
 addiction-dose-omnizine = Доза омнизина. По телу разливается тепло, ломка отступает.
+addiction-dose-coffee = Кофе. Наконец-то. Ломка отступает.
 
 addiction-withdrawal-alcohol-0 = Руки слегка трясутся. Неплохо бы выпить...
 addiction-withdrawal-alcohol-1 = Всё раздражает, слова путаются. Без выпивки невыносимо.
@@ -41,15 +43,19 @@ addiction-withdrawal-medicine-2 = Ломка скручивает, мысли п
 addiction-withdrawal-omnizine-0 = Становится не по себе. Нужна доза омнизина.
 addiction-withdrawal-omnizine-1 = Тело ноет, привычные раны дают о себе знать. Без омнизина невыносимо.
 addiction-withdrawal-omnizine-2 = Ломка скручивает, боль возвращается. Омнизин. Сейчас же.
+addiction-withdrawal-coffee-0 = Хочется кофе. Очень.
+addiction-withdrawal-coffee-1 = Голова не варит, всё бесит. Нужна чашка кофе.
+addiction-withdrawal-coffee-2 = Я не я, если не выпью кофейку! Кофе. Сейчас же.
 
 addiction-cured-alcohol = Зависимость от алкоголя отпустила тебя.
 addiction-cured-nicotine = Зависимость от никотина отпустила тебя.
 addiction-cured-drug = Зависимость от наркотиков отпустила тебя.
 addiction-cured-medicine = Зависимость от лекарств отпустила тебя.
 addiction-cured-omnizine = Зависимость от омнизина отпустила тебя.
+addiction-cured-coffee = Зависимость от кофе отпустила тебя.
 
 reagent-name-adt-detoxin = Детоксин
-reagent-desc-adt-detoxin = Снимает абстинентный синдром и постепенно лечит зависимость от алкоголя, никотина, наркотиков, лекарств и омнизина. Бессилен против врождённых зависимостей.
+reagent-desc-adt-detoxin = Снимает абстинентный синдром и постепенно лечит зависимость от алкоголя, никотина, наркотиков, лекарств, омнизина и кофе. Бессилен против врождённых зависимостей.
 
 entity-effect-guidebook-adjust-addiction-level = Снижает уровень привыкания на {$amount} за цикл метаболизма.
 
@@ -61,6 +67,7 @@ health-analyzer-addiction-nicotine = Никотиновая
 health-analyzer-addiction-drug = Наркотическая
 health-analyzer-addiction-medicine = Лекарственная
 health-analyzer-addiction-omnizine = Омнизиновая
+health-analyzer-addiction-coffee = Кофейная
 health-analyzer-window-addiction-line = { $kind } зависимость: стадия { $stage } ({ $stageName })
 health-analyzer-window-addiction-permanent = { $kind } зависимость: стадия { $stage } ({ $stageName }, не лечится)
 health-analyzer-addiction-stage-1 = лёгкая


### PR DESCRIPTION
## Описание PR
Лайтовая зависимость от кофе для экипажа: "Я не я, если не выпью кофейку". Новый канал `Coffee` в существующей системе аддикций ADT.

## Почему / Баланс
Без трайта, только получаемая зависимость (как никотин/алкоголь). Никаких сильных последствий - только попапы: через 10 минут без кофе каждые 60 секунд напоминание о ломке. Ни дрожи, ни заикания, ни слабости. Лечится воздержанием или детоксином, видна в анализаторе здоровья.

## Техническая информация
- `AddictionKind.Coffee` - шестой канал, добавлен в конец enum (безопасно для сети)
- Определение по id реагента `Coffee` (DataField `CoffeeReagent`), как у никотина; латте/айс-кофе/кофейные ликёры не подсаживают
- Кофе исключён из всей симптомной логики (`Update`-лупа, `RefreshSymptoms`, `RaiseSymptomsChanged`), чтобы кофейная ломка не снимала чужие симптомы вроде дрожи от электрошока
- Локализация в `Resources/Locale/ru-RU/ADT/addictions.ftl`

- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа

## Чейнджлог

:cl: ultradyper
- add: Добавлена зависимость от кофе.
