### PR TITLE
fix: спрайт набора с топором в колизее не совпадает с выдачей

### DIFF
--- a/Resources/Prototypes/ADT/Thunderdome/thunderdome_rule.yml
+++ b/Resources/Prototypes/ADT/Thunderdome/thunderdome_rule.yml
@@ -75,7 +75,7 @@
           name: thunderdome-loadout-fireaxe
           description: thunderdome-desc-fireaxe
           category: thunderdome-category-melee
-          sprite: FireAxeFlaming
+          sprite: FireAxe
         - gear: ThunderdomeEnergyDagger
           name: thunderdome-loadout-edagger
           description: thunderdome-desc-edagger


### PR DESCRIPTION
## Описание PR
Набор с пожарным топором в меню выбора снаряжения колизея (Thunderdome) отображал спрайт пылающего топора Синди (FireAxeFlaming), но выдавал обычный пожарный топор (FireAxe). Спрайт в карточке набора заменён на FireAxe, теперь картинка совпадает с выдачей.

## Почему / Баланс
Баг-репорт: картинка набора не соответствовала получаемому предмету. Баланс не менялся.

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

Правка YAML: `sprite: FireAxeFlaming` -> `sprite: FireAxe` в `thunderdome_rule.yml`. YAML-линтер отдельно не прогонялся: бинарник падает на несвязанной pre-existing ошибке (CryoPodMetabolism), правка не затрагивает структуру прототипа.

## Медиа
Нет.

## Чейнджлог
:cl: ultradyper
- fix: Спрайт набора с топором в колизее больше не показывает топор Синди
