### PR TITLE
tweak: увеличение молодого возраста у молей

### DIFF
--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -33,5 +33,5 @@
   - Nian
   maxAge: 70
   oldAge: 45
-  youngAge: 20
+  youngAge: 27
   # ADT end

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -33,5 +33,5 @@
   - Nian
   maxAge: 70
   oldAge: 45
-  youngAge: 27 # ADT-Tweak: увеличен порог молодого возраста
+  youngAge: 27
   # ADT end

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -33,5 +33,5 @@
   - Nian
   maxAge: 70
   oldAge: 45
-  youngAge: 27
+  youngAge: 27 # ADT-Tweak: увеличен порог молодого возраста
   # ADT end


### PR DESCRIPTION
## Описание PR
У молей увеличен молодой возраст до 27

## Почему / Баланс
Поиграть за молодую моль было почти невозможно, только 18 и 19 лет. 

Также, у резоми молодой возраст до 25 лет, хотя продолжительность жизни на 5 лет меньше

- [Предложение](https://discord.com/channels/901772674865455115/1539399050963718267)

## Техническая информация
`youngAge` теперь 27
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: FriendlyOne
- tweak: Молодой возраст молей увеличен до 27 лет

