### PR TITLE
feat: мешки для тел требуют времени на открытие/закрытие

### DIFF
--- a/Content.Shared/ADT/Storage/Components/StorageOpenDoAfterComponent.cs
+++ b/Content.Shared/ADT/Storage/Components/StorageOpenDoAfterComponent.cs
@@ -1,0 +1,30 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.ADT.Storage.Components;
+
+/// <summary>
+/// Requires a do-after to open or close this EntityStorage (e.g. body bags), so it can't be
+/// toggled instantly. The do-after breaks on movement, so a bag that is being dragged cannot be
+/// opened by a bystander.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class StorageOpenDoAfterComponent : Component
+{
+    /// <summary>
+    /// How long the open/close do-after takes.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan Delay = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Set right before re-toggling after the do-after completes, so the follow-up toggle is not
+    /// delayed again. Transient, reset within the same tick.
+    /// </summary>
+    [ViewVariables]
+    public bool BypassDoAfter;
+}
+
+[Serializable, NetSerializable]
+public sealed partial class StorageOpenDoAfterEvent : SimpleDoAfterEvent { }

--- a/Content.Shared/ADT/Storage/Components/StorageOpenDoAfterComponent.cs
+++ b/Content.Shared/ADT/Storage/Components/StorageOpenDoAfterComponent.cs
@@ -20,4 +20,21 @@ public sealed partial class StorageOpenDoAfterComponent : Component
 }
 
 [Serializable, NetSerializable]
-public sealed partial class StorageOpenDoAfterEvent : SimpleDoAfterEvent { }
+public sealed partial class StorageOpenDoAfterEvent : SimpleDoAfterEvent
+{
+    /// <summary>
+    /// The operation that was requested: true to open, false to close. Applied on completion so a
+    /// state change during the do-after can't invert the original action.
+    /// </summary>
+    [DataField]
+    public bool Open;
+
+    public StorageOpenDoAfterEvent()
+    {
+    }
+
+    public StorageOpenDoAfterEvent(bool open)
+    {
+        Open = open;
+    }
+}

--- a/Content.Shared/ADT/Storage/Components/StorageOpenDoAfterComponent.cs
+++ b/Content.Shared/ADT/Storage/Components/StorageOpenDoAfterComponent.cs
@@ -17,13 +17,6 @@ public sealed partial class StorageOpenDoAfterComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public TimeSpan Delay = TimeSpan.FromSeconds(1);
-
-    /// <summary>
-    /// Set right before re-toggling after the do-after completes, so the follow-up toggle is not
-    /// delayed again. Transient, reset within the same tick.
-    /// </summary>
-    [ViewVariables]
-    public bool BypassDoAfter;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/ADT/Storage/Components/StorageOpenDoAfterComponent.cs
+++ b/Content.Shared/ADT/Storage/Components/StorageOpenDoAfterComponent.cs
@@ -4,17 +4,9 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.ADT.Storage.Components;
 
-/// <summary>
-/// Requires a do-after to open or close this EntityStorage (e.g. body bags), so it can't be
-/// toggled instantly. The do-after breaks on movement, so a bag that is being dragged cannot be
-/// opened by a bystander.
-/// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class StorageOpenDoAfterComponent : Component
 {
-    /// <summary>
-    /// How long the open/close do-after takes.
-    /// </summary>
     [DataField, AutoNetworkedField]
     public TimeSpan Delay = TimeSpan.FromSeconds(1);
 }
@@ -22,10 +14,6 @@ public sealed partial class StorageOpenDoAfterComponent : Component
 [Serializable, NetSerializable]
 public sealed partial class StorageOpenDoAfterEvent : SimpleDoAfterEvent
 {
-    /// <summary>
-    /// The operation that was requested: true to open, false to close. Applied on completion so a
-    /// state change during the do-after can't invert the original action.
-    /// </summary>
     [DataField]
     public bool Open;
 

--- a/Content.Shared/ADT/Storage/StorageOpenDoAfterSystem.cs
+++ b/Content.Shared/ADT/Storage/StorageOpenDoAfterSystem.cs
@@ -1,0 +1,80 @@
+using Content.Shared.ADT.Storage.Components;
+using Content.Shared.DoAfter;
+using Content.Shared.Storage.Components;
+using Content.Shared.Storage.EntitySystems;
+
+namespace Content.Shared.ADT.Storage;
+
+/// <summary>
+/// Turns opening/closing an <see cref="StorageOpenDoAfterComponent"/> storage into a do-after.
+/// Hooks the storage open/close attempt events, so it covers both the click interaction and the
+/// right-click verb. The do-after breaks on movement, so a bag that is being dragged can't be opened.
+/// </summary>
+public sealed class StorageOpenDoAfterSystem : EntitySystem
+{
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly SharedEntityStorageSystem _storage = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<StorageOpenDoAfterComponent, StorageOpenAttemptEvent>(OnOpenAttempt);
+        SubscribeLocalEvent<StorageOpenDoAfterComponent, StorageCloseAttemptEvent>(OnCloseAttempt);
+        SubscribeLocalEvent<StorageOpenDoAfterComponent, StorageOpenDoAfterEvent>(OnDoAfter);
+    }
+
+    private void OnOpenAttempt(Entity<StorageOpenDoAfterComponent> ent, ref StorageOpenAttemptEvent args)
+    {
+        // Silent attempts are used to decide whether to show the verb; don't start a do-after for those.
+        if (args.Cancelled || args.Silent)
+            return;
+
+        if (TryDelay(ent, args.User))
+            args.Cancelled = true;
+    }
+
+    private void OnCloseAttempt(Entity<StorageOpenDoAfterComponent> ent, ref StorageCloseAttemptEvent args)
+    {
+        // A null user means a programmatic close (e.g. something being inserted); leave those instant.
+        if (args.Cancelled || args.User is not { } user)
+            return;
+
+        if (TryDelay(ent, user))
+            args.Cancelled = true;
+    }
+
+    /// <summary>
+    /// Starts (or ignores a duplicate) do-after and returns true when the immediate toggle should be blocked.
+    /// </summary>
+    private bool TryDelay(Entity<StorageOpenDoAfterComponent> ent, EntityUid user)
+    {
+        // The follow-up toggle from a completed do-after is allowed straight through.
+        if (ent.Comp.BypassDoAfter)
+        {
+            ent.Comp.BypassDoAfter = false;
+            return false;
+        }
+
+        var doAfter = new DoAfterArgs(EntityManager, user, ent.Comp.Delay, new StorageOpenDoAfterEvent(), ent, target: ent)
+        {
+            BreakOnMove = true,
+        };
+        _doAfter.TryStartDoAfter(doAfter);
+
+        // Block the instant toggle whether or not the do-after started (a duplicate is already running).
+        return true;
+    }
+
+    private void OnDoAfter(Entity<StorageOpenDoAfterComponent> ent, ref StorageOpenDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled)
+            return;
+
+        args.Handled = true;
+
+        ent.Comp.BypassDoAfter = true;
+        _storage.ToggleOpen(args.User, ent);
+        ent.Comp.BypassDoAfter = false; // reset in case ToggleOpen short-circuited before the attempt event
+    }
+}

--- a/Content.Shared/ADT/Storage/StorageOpenDoAfterSystem.cs
+++ b/Content.Shared/ADT/Storage/StorageOpenDoAfterSystem.cs
@@ -49,12 +49,10 @@ public sealed class StorageOpenDoAfterSystem : EntitySystem
     /// </summary>
     private bool TryDelay(Entity<StorageOpenDoAfterComponent> ent, EntityUid user)
     {
-        // The follow-up toggle from a completed do-after is allowed straight through.
-        if (ent.Comp.BypassDoAfter)
-        {
-            ent.Comp.BypassDoAfter = false;
+        // A zero delay means no do-after: the follow-up toggle from a completed do-after zeroes the
+        // delay so it passes straight through, and a bag configured with Delay 0 just toggles instantly.
+        if (ent.Comp.Delay <= TimeSpan.Zero)
             return false;
-        }
 
         var doAfter = new DoAfterArgs(EntityManager, user, ent.Comp.Delay, new StorageOpenDoAfterEvent(), ent, target: ent)
         {
@@ -73,8 +71,11 @@ public sealed class StorageOpenDoAfterSystem : EntitySystem
 
         args.Handled = true;
 
-        ent.Comp.BypassDoAfter = true;
+        // ToggleOpen re-raises the open/close attempt; zero the delay so it isn't queued behind
+        // another do-after. Restored right after (no Dirty in between, so no networked state change).
+        var delay = ent.Comp.Delay;
+        ent.Comp.Delay = TimeSpan.Zero;
         _storage.ToggleOpen(args.User, ent);
-        ent.Comp.BypassDoAfter = false; // reset in case ToggleOpen short-circuited before the attempt event
+        ent.Comp.Delay = delay;
     }
 }

--- a/Content.Shared/ADT/Storage/StorageOpenDoAfterSystem.cs
+++ b/Content.Shared/ADT/Storage/StorageOpenDoAfterSystem.cs
@@ -30,7 +30,7 @@ public sealed class StorageOpenDoAfterSystem : EntitySystem
         if (args.Cancelled || args.Silent)
             return;
 
-        if (TryDelay(ent, args.User))
+        if (TryDelay(ent, args.User, open: true))
             args.Cancelled = true;
     }
 
@@ -40,21 +40,20 @@ public sealed class StorageOpenDoAfterSystem : EntitySystem
         if (args.Cancelled || args.User is not { } user)
             return;
 
-        if (TryDelay(ent, user))
+        if (TryDelay(ent, user, open: false))
             args.Cancelled = true;
     }
 
     /// <summary>
     /// Starts (or ignores a duplicate) do-after and returns true when the immediate toggle should be blocked.
     /// </summary>
-    private bool TryDelay(Entity<StorageOpenDoAfterComponent> ent, EntityUid user)
+    private bool TryDelay(Entity<StorageOpenDoAfterComponent> ent, EntityUid user, bool open)
     {
-        // A zero delay means no do-after: the follow-up toggle from a completed do-after zeroes the
-        // delay so it passes straight through, and a bag configured with Delay 0 just toggles instantly.
+        // A bag configured with Delay 0 just opens/closes instantly, no do-after.
         if (ent.Comp.Delay <= TimeSpan.Zero)
             return false;
 
-        var doAfter = new DoAfterArgs(EntityManager, user, ent.Comp.Delay, new StorageOpenDoAfterEvent(), ent, target: ent)
+        var doAfter = new DoAfterArgs(EntityManager, user, ent.Comp.Delay, new StorageOpenDoAfterEvent(open), ent, target: ent)
         {
             BreakOnMove = true,
         };
@@ -71,11 +70,18 @@ public sealed class StorageOpenDoAfterSystem : EntitySystem
 
         args.Handled = true;
 
-        // ToggleOpen re-raises the open/close attempt; zero the delay so it isn't queued behind
-        // another do-after. Restored right after (no Dirty in between, so no networked state change).
-        var delay = ent.Comp.Delay;
-        ent.Comp.Delay = TimeSpan.Zero;
-        _storage.ToggleOpen(args.User, ent);
-        ent.Comp.Delay = delay;
+        // Perform exactly the requested operation, not a toggle, so a state change during the wait can't
+        // invert the action. Both methods are idempotent and skip the attempt event (no re-entrant do-after).
+        if (args.Open)
+        {
+            // Re-check via a silent attempt so foldable/welded/space guards still apply; our own handler
+            // ignores silent attempts, so this doesn't start another do-after.
+            if (_storage.CanOpen(args.User, ent, silent: true))
+                _storage.OpenStorage(ent);
+        }
+        else
+        {
+            _storage.CloseStorage(ent);
+        }
     }
 }

--- a/Content.Shared/ADT/Storage/StorageOpenDoAfterSystem.cs
+++ b/Content.Shared/ADT/Storage/StorageOpenDoAfterSystem.cs
@@ -5,11 +5,6 @@ using Content.Shared.Storage.EntitySystems;
 
 namespace Content.Shared.ADT.Storage;
 
-/// <summary>
-/// Turns opening/closing an <see cref="StorageOpenDoAfterComponent"/> storage into a do-after.
-/// Hooks the storage open/close attempt events, so it covers both the click interaction and the
-/// right-click verb. The do-after breaks on movement, so a bag that is being dragged can't be opened.
-/// </summary>
 public sealed class StorageOpenDoAfterSystem : EntitySystem
 {
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
@@ -26,7 +21,6 @@ public sealed class StorageOpenDoAfterSystem : EntitySystem
 
     private void OnOpenAttempt(Entity<StorageOpenDoAfterComponent> ent, ref StorageOpenAttemptEvent args)
     {
-        // Silent attempts are used to decide whether to show the verb; don't start a do-after for those.
         if (args.Cancelled || args.Silent)
             return;
 
@@ -36,20 +30,15 @@ public sealed class StorageOpenDoAfterSystem : EntitySystem
 
     private void OnCloseAttempt(Entity<StorageOpenDoAfterComponent> ent, ref StorageCloseAttemptEvent args)
     {
-        // A null user means a programmatic close (e.g. something being inserted); leave those instant.
-        if (args.Cancelled || args.User is not { } user)
+        if (args.Cancelled || args.Silent || args.User is not { } user)
             return;
 
         if (TryDelay(ent, user, open: false))
             args.Cancelled = true;
     }
 
-    /// <summary>
-    /// Starts (or ignores a duplicate) do-after and returns true when the immediate toggle should be blocked.
-    /// </summary>
     private bool TryDelay(Entity<StorageOpenDoAfterComponent> ent, EntityUid user, bool open)
     {
-        // A bag configured with Delay 0 just opens/closes instantly, no do-after.
         if (ent.Comp.Delay <= TimeSpan.Zero)
             return false;
 
@@ -59,7 +48,6 @@ public sealed class StorageOpenDoAfterSystem : EntitySystem
         };
         _doAfter.TryStartDoAfter(doAfter);
 
-        // Block the instant toggle whether or not the do-after started (a duplicate is already running).
         return true;
     }
 
@@ -70,18 +58,15 @@ public sealed class StorageOpenDoAfterSystem : EntitySystem
 
         args.Handled = true;
 
-        // Perform exactly the requested operation, not a toggle, so a state change during the wait can't
-        // invert the action. Both methods are idempotent and skip the attempt event (no re-entrant do-after).
         if (args.Open)
         {
-            // Re-check via a silent attempt so foldable/welded/space guards still apply; our own handler
-            // ignores silent attempts, so this doesn't start another do-after.
             if (_storage.CanOpen(args.User, ent, silent: true))
                 _storage.OpenStorage(ent);
         }
         else
         {
-            _storage.CloseStorage(ent);
+            if (_storage.CanClose(ent, args.User, silent: true))
+                _storage.CloseStorage(ent);
         }
     }
 }

--- a/Content.Shared/Storage/Components/EntityStorageComponent.cs
+++ b/Content.Shared/Storage/Components/EntityStorageComponent.cs
@@ -165,8 +165,7 @@ public readonly record struct StorageBeforeOpenEvent;
 public readonly record struct StorageAfterOpenEvent;
 
 [ByRefEvent]
-// ADT-Tweak: добавлено поле Silent для симметрии с StorageOpenAttemptEvent
-public record struct StorageCloseAttemptEvent(EntityUid? User, bool Silent = false, bool Cancelled = false);
+public record struct StorageCloseAttemptEvent(EntityUid? User, bool Silent = false, bool Cancelled = false); // ADT-Tweak: добавлено поле Silent для симметрии с StorageOpenAttemptEvent
 
 [ByRefEvent]
 public readonly record struct StorageBeforeCloseEvent(HashSet<EntityUid> Contents, HashSet<EntityUid> BypassChecks);

--- a/Content.Shared/Storage/Components/EntityStorageComponent.cs
+++ b/Content.Shared/Storage/Components/EntityStorageComponent.cs
@@ -165,7 +165,8 @@ public readonly record struct StorageBeforeOpenEvent;
 public readonly record struct StorageAfterOpenEvent;
 
 [ByRefEvent]
-public record struct StorageCloseAttemptEvent(EntityUid? User, bool Cancelled = false);
+// ADT-Tweak: добавлено поле Silent для симметрии с StorageOpenAttemptEvent
+public record struct StorageCloseAttemptEvent(EntityUid? User, bool Silent = false, bool Cancelled = false);
 
 [ByRefEvent]
 public readonly record struct StorageBeforeCloseEvent(HashSet<EntityUid> Contents, HashSet<EntityUid> BypassChecks);

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -444,7 +444,7 @@ public abstract class SharedEntityStorageSystem : EntitySystem
 
     public bool CanClose(EntityUid target, EntityUid? user = null, bool silent = false)
     {
-        var ev = new StorageCloseAttemptEvent(user);
+        var ev = new StorageCloseAttemptEvent(user, silent); // ADT-Tweak: передаём silent в событие
         RaiseLocalEvent(target, ref ev, silent);
 
         return !ev.Cancelled;

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
@@ -26,9 +26,10 @@
   - type: Tag
     tags:
     - BodyBag
-  # ADT-Tweak: задержка на открытие/закрытие
+  # ADT-Tweak start: задержка на открытие/закрытие
   - type: StorageOpenDoAfter
     delay: 0.5
+  # ADT-Tweak end
   - type: Clickable
   - type: InteractionOutline
   - type: MovedByPressure

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
@@ -26,6 +26,9 @@
   - type: Tag
     tags:
     - BodyBag
+  # ADT-Tweak: задержка на открытие/закрытие
+  - type: StorageOpenDoAfter
+    delay: 0.5
   - type: Clickable
   - type: InteractionOutline
   - type: MovedByPressure


### PR DESCRIPTION
## Описание PR
Мешки для тел требуют времени на открытие/закрытие

## Почему / Баланс
Мешки для тел требуют времени на открытие/закрытие, следственно, мешок для тела который активно куда-то переносят - не открыть

- [Предложение](https://discord.com/channels/901772674865455115/1539612551795572766)

## Техническая информация
1) Новый компонент `StorageOpenDoAfterComponent`. Помечает `EntityStorage`, у которого открытие/закрытие должно идти через дуафтер
2) Новая система `StorageOpenDoAfterSystem` подписана на `StorageOpenAttemptEvent` / `StorageCloseAttemptEvent`, отменяет мгновенное переключение и запускает дуафтер
3) На прототип мешка для тел повешен `StorageOpenDoAfter` с `delay: 0.5`
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
- [В ДС](https://discord.com/channels/901772674865455115/1539612551795572766/1539658751169142814)

## Чейнджлог
:cl: FriendlyOne
- add: Добавлена задержка в 0.5с на открытие\закрытие мешка для тел