### PR TITLE
fix: корабли с выключенной системой опознавания не показываются на консоли мониторинга екипажа

### DIFF
--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringNavMapControl.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringNavMapControl.cs
@@ -10,6 +10,7 @@ using Robust.Shared.Map.Components;
 using Robust.Shared.Threading;
 using Content.Shared.Atmos;
 using Content.Shared.Pinpointer;
+using Content.Shared.Shuttles.Systems; // ADT-Tweak
 using System.Numerics;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface.Controls;
@@ -35,6 +36,7 @@ public sealed partial class CrewMonitoringNavMapControl : NavMapControl
         Math.Max(1, MidPoint - (int)(MinimapMargin * UIScale));
 
     private readonly SharedTransformSystem _transform;
+    private readonly SharedShuttleSystem _shuttles; // ADT-Tweak: фильтр стелс-кораблей по IFF
     private readonly GridRadarRenderer _gridRenderer;
     private readonly IGameTiming _gameTiming;
     private List<Entity<MapGridComponent>> _grids = new();
@@ -86,6 +88,7 @@ public sealed partial class CrewMonitoringNavMapControl : NavMapControl
     public CrewMonitoringNavMapControl()
     {
         _transform = EntManager.System<SharedTransformSystem>();
+        _shuttles = EntManager.System<SharedShuttleSystem>(); // ADT-Tweak
         _gameTiming = IoCManager.Resolve<IGameTiming>();
         _gridRenderer = new GridRadarRenderer(
             EntManager.System<SharedMapSystem>(),
@@ -670,6 +673,7 @@ public sealed partial class CrewMonitoringNavMapControl : NavMapControl
             ref _grids,
             approx: true,
             includeMap: false);
+        _grids.RemoveAll(g => !_shuttles.CanDraw(g.Owner)); // ADT-Tweak: не рисуем стелс-корабли (IFF Hide)
         _cachedGridQueryMap = mapId;
         _cachedGridQueryCenter = coverageCenter;
         _cachedGridQueryRange = coverageRange;

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringNavMapControl.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringNavMapControl.cs
@@ -10,7 +10,7 @@ using Robust.Shared.Map.Components;
 using Robust.Shared.Threading;
 using Content.Shared.Atmos;
 using Content.Shared.Pinpointer;
-using Content.Shared.Shuttles.Systems; // ADT-Tweak
+using Content.Shared.Shuttles.Systems;
 using System.Numerics;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface.Controls;
@@ -673,7 +673,7 @@ public sealed partial class CrewMonitoringNavMapControl : NavMapControl
             ref _grids,
             approx: true,
             includeMap: false);
-        _grids.RemoveAll(g => !_shuttles.CanDraw(g.Owner)); // ADT-Tweak: не рисуем стелс-корабли (IFF Hide)
+        _grids.RemoveAll(g => !_shuttles.CanDraw(g.Owner)); // ADT-Tweak
         _cachedGridQueryMap = mapId;
         _cachedGridQueryCenter = coverageCenter;
         _cachedGridQueryRange = coverageRange;


### PR DESCRIPTION
## Описание PR
Корабли с выключенной системой опознавания не показываются на консоли мониторинга екипажа

## Почему / Баланс
Стелсовые корабли можно было видеть на консоли мониторинга екипажа, что ломало игру для стелс путей антагонистов (ЯО, ксеноборги, пираты)

- [Баг-репорт](https://discord.com/channels/901772674865455115/1534257918910927018)

## Техническая информация
Использует `SharedShuttleSystem.CanDraw` для фильтрации гридов, которые можно рисовать. Механизм по сути такой же, как и на других корабельных консолях
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
https://github.com/user-attachments/assets/5cb16dae-d8fc-415d-9114-bd09262a8ef8

## Чейнджлог
:cl: FriendlyOne
- fix: Корабли с выключенной системой опознавания больше не показываются на консоли мониторинга екипажа

