### PR TITLE
Fix xenobio extract

### DIFF
--- a/Content.Server/ADT/EntityEffects/ChangeFactionNearbyEffectSystem.cs
+++ b/Content.Server/ADT/EntityEffects/ChangeFactionNearbyEffectSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.ADT.EntityEffects;
 using Content.Shared.EntityEffects;
 using Content.Server.ADT.NPC;
+using Content.Shared.Ghost;
 using Robust.Shared.Map;
 
 namespace Content.Server.ADT.EntityEffects;
@@ -17,6 +18,9 @@ public sealed partial class ChangeFactionNearbyEffectSystem : EntityEffectSystem
 
         foreach (var target in _lookup.GetEntitiesInRange(uid, effect.Radius))
         {
+            if (HasComp<GhostComponent>(target))
+                continue;
+
             _changeFaction.TryChangeFaction(target, effect.NewFaction, out _, effect.Duration);
         }
     }

--- a/Content.Server/ADT/EntityEffects/ForceStealthNearbyEffectSystem.cs
+++ b/Content.Server/ADT/EntityEffects/ForceStealthNearbyEffectSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.ADT.EntityEffects;
 using Content.Server.ADT.Stealth;
 using Content.Shared.EntityEffects;
+using Content.Shared.Ghost;
 using Robust.Shared.Map;
 using Robust.Shared.Random;
 
@@ -19,6 +20,9 @@ public sealed partial class ForceStealthNearbyEffectSystem : EntityEffectSystem<
 
         foreach (var target in _lookup.GetEntitiesInRange(uid, effect.Radius))
         {
+            if (HasComp<GhostComponent>(target))
+                continue;
+
             if (_random.Prob(effect.Chance))
                 _stealth.TryApplyForceStealth(target, out _, effect.Duration);
         }

--- a/Content.Server/ADT/EntityEffects/RandomSpeciesChangeSystem.cs
+++ b/Content.Server/ADT/EntityEffects/RandomSpeciesChangeSystem.cs
@@ -1,10 +1,12 @@
 using Content.Shared.ADT.EntityEffects;
 using Content.Server.Polymorph.Systems;
+using Content.Shared.Body;
 using Content.Shared.EntityEffects;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Polymorph;
 using Content.Server.Polymorph.Components;
+using Robust.Shared.GameObjects.Components.Localization;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using System.Linq;
@@ -16,6 +18,9 @@ public sealed partial class RandomSpeciesChangeSystem : EntityEffectSystem<Human
     [Dependency] private readonly PolymorphSystem _polymorph = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly HumanoidProfileSystem _humanoid = default!;
+    [Dependency] private readonly SharedVisualBodySystem _visualBody = default!;
+    [Dependency] private readonly GrammarSystem _grammar = default!;
 
     protected override void Effect(Entity<HumanoidProfileComponent> entity, ref EntityEffectEvent<RandomSpeciesChange> args)
     {
@@ -51,6 +56,25 @@ public sealed partial class RandomSpeciesChangeSystem : EntityEffectSystem<Human
         {
             if (TryComp<PolymorphedEntityComponent>(result.Value, out _))
                 RemCompDeferred<PolymorphedEntityComponent>(result.Value);
+
+            PreserveSexGender(result.Value, entity.Comp);
         }
+    }
+
+    private void PreserveSexGender(EntityUid newEntity, HumanoidProfileComponent profile)
+    {
+        _humanoid.SetSex((newEntity, null), profile.Sex);
+        _humanoid.SetGender((newEntity, null), profile.Gender);
+
+        if (_visualBody.TryGatherMarkingsData(newEntity, null, out var organProfiles, out _, out _))
+        {
+            foreach (var category in organProfiles.Keys)
+                organProfiles[category] = organProfiles[category] with { Sex = profile.Sex };
+
+            _visualBody.ApplyProfiles(newEntity, organProfiles);
+        }
+
+        if (TryComp<GrammarComponent>(newEntity, out var grammar))
+            _grammar.SetGender((newEntity, grammar), profile.Gender);
     }
 }

--- a/Content.Server/ADT/EntityEffects/ScrambleNearbyEffectSystem.cs
+++ b/Content.Server/ADT/EntityEffects/ScrambleNearbyEffectSystem.cs
@@ -1,11 +1,14 @@
 using System.Linq;
 using Content.Shared.ADT.EntityEffects;
 using Content.Server.Polymorph.Systems;
+using Content.Shared.Body;
 using Content.Shared.EntityEffects;
+using Content.Shared.Ghost;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Polymorph;
 using Content.Server.Polymorph.Components;
+using Robust.Shared.GameObjects.Components.Localization;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
@@ -17,6 +20,9 @@ public sealed partial class ScrambleNearbyEffectSystem : EntityEffectSystem<Tran
     [Dependency] private readonly PolymorphSystem _polymorph = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly HumanoidProfileSystem _humanoid = default!;
+    [Dependency] private readonly SharedVisualBodySystem _visualBody = default!;
+    [Dependency] private readonly GrammarSystem _grammar = default!;
 
     protected override void Effect(Entity<TransformComponent> entity, ref EntityEffectEvent<ScrambleNearbyEffect> args)
     {
@@ -36,7 +42,10 @@ public sealed partial class ScrambleNearbyEffectSystem : EntityEffectSystem<Tran
 
         foreach (var target in _lookup.GetEntitiesInRange(uid, effect.Radius))
         {
-            if (!TryComp<HumanoidProfileComponent>(target, out _))
+            if (!TryComp<HumanoidProfileComponent>(target, out var profile))
+                continue;
+
+            if (HasComp<GhostComponent>(target))
                 continue;
 
             var randomSpecies = _random.Pick(species);
@@ -57,7 +66,26 @@ public sealed partial class ScrambleNearbyEffectSystem : EntityEffectSystem<Tran
             {
                 if (TryComp<PolymorphedEntityComponent>(result.Value, out _))
                     RemCompDeferred<PolymorphedEntityComponent>(result.Value);
+
+                PreserveSexGender(result.Value, profile);
             }
         }
+    }
+
+    private void PreserveSexGender(EntityUid newEntity, HumanoidProfileComponent profile)
+    {
+        _humanoid.SetSex((newEntity, null), profile.Sex);
+        _humanoid.SetGender((newEntity, null), profile.Gender);
+
+        if (_visualBody.TryGatherMarkingsData(newEntity, null, out var organProfiles, out _, out _))
+        {
+            foreach (var category in organProfiles.Keys)
+                organProfiles[category] = organProfiles[category] with { Sex = profile.Sex };
+
+            _visualBody.ApplyProfiles(newEntity, organProfiles);
+        }
+
+        if (TryComp<GrammarComponent>(newEntity, out var grammar))
+            _grammar.SetGender((newEntity, grammar), profile.Gender);
     }
 }

--- a/Content.Server/ADT/EntityEffects/SpeciesChangeSystem.cs
+++ b/Content.Server/ADT/EntityEffects/SpeciesChangeSystem.cs
@@ -1,10 +1,12 @@
 using Content.Shared.ADT.EntityEffects;
 using Content.Server.Polymorph.Systems;
+using Content.Shared.Body;
 using Content.Shared.EntityEffects;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Polymorph;
 using Content.Server.Polymorph.Components;
+using Robust.Shared.GameObjects.Components.Localization;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server.ADT.EntityEffects;
@@ -13,6 +15,9 @@ public sealed partial class SpeciesChangeSystem : EntityEffectSystem<HumanoidPro
 {
     [Dependency] private readonly PolymorphSystem _polymorph = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly HumanoidProfileSystem _humanoid = default!;
+    [Dependency] private readonly SharedVisualBodySystem _visualBody = default!;
+    [Dependency] private readonly GrammarSystem _grammar = default!;
 
     protected override void Effect(Entity<HumanoidProfileComponent> entity, ref EntityEffectEvent<SpeciesChange> args)
     {
@@ -39,6 +44,25 @@ public sealed partial class SpeciesChangeSystem : EntityEffectSystem<HumanoidPro
             // Удаляем компонент, используя правильный тип
             if (TryComp<PolymorphedEntityComponent>(result.Value, out _))
                 RemCompDeferred<PolymorphedEntityComponent>(result.Value);
+
+            PreserveSexGender(result.Value, entity.Comp);
         }
+    }
+
+    private void PreserveSexGender(EntityUid newEntity, HumanoidProfileComponent profile)
+    {
+        _humanoid.SetSex((newEntity, null), profile.Sex);
+        _humanoid.SetGender((newEntity, null), profile.Gender);
+
+        if (_visualBody.TryGatherMarkingsData(newEntity, null, out var organProfiles, out _, out _))
+        {
+            foreach (var category in organProfiles.Keys)
+                organProfiles[category] = organProfiles[category] with { Sex = profile.Sex };
+
+            _visualBody.ApplyProfiles(newEntity, organProfiles);
+        }
+
+        if (TryComp<GrammarComponent>(newEntity, out var grammar))
+            _grammar.SetGender((newEntity, grammar), profile.Gender);
     }
 }

--- a/Resources/Prototypes/ADT/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t4/light_pink.yml
+++ b/Resources/Prototypes/ADT/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t4/light_pink.yml
@@ -60,6 +60,8 @@
         - Skeleton
         - GhostSpecies
         - IPC
+        - ADTShadowlingSpecies
+        - ADTLesserShadowlingSpecies
   - type: Tag
     tags:
     - XenobiologyLightPinkExtract

--- a/Resources/Prototypes/ADT/Xenobiology/Reagents/reagents.yml
+++ b/Resources/Prototypes/ADT/Xenobiology/Reagents/reagents.yml
@@ -267,6 +267,8 @@
         - Skeleton
         - GhostSpecies
         - IPC
+        - ADTShadowlingSpecies
+        - ADTLesserShadowlingSpecies
         conditions:
         - !type:ReagentCondition
           reagent: AdvancedMutationToxin


### PR DESCRIPTION
## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- fix: Реакции экстрактор рассчитанные по зоне, больше не действуют на призраков
- fix: Смена расы экстрактами больше не сбрасывает пол и гендер персонажа
- tweak: Тенеморфы исключены из случайных рас, выдаваемых экстрактами