### PR TITLE
Правки внешности рас

### DIFF
--- a/Resources/Prototypes/ADT/Body/markingsGroups.yml
+++ b/Resources/Prototypes/ADT/Body/markingsGroups.yml
@@ -13,10 +13,10 @@
       limit: 1
       required: false
     enum.HumanoidVisualLayers.Hair:
-      limit: 3 #ADT-tweak 1>3
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.FacialHair:
-      limit: 2 #ADT-tweak 1>2
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.Chest:
       limit: 4
@@ -679,10 +679,10 @@
       limit: 1
       required: false
     enum.HumanoidVisualLayers.Hair:
-      limit: 3 #ADT-tweak 1>3
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.FacialHair:
-      limit: 2 #ADT-tweak 1>2
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.Chest:
       limit: 4
@@ -709,28 +709,28 @@
       limit: 1
       required: false
     enum.HumanoidVisualLayers.RArm:
-      limit: 3 #ADT-tweak 2>3
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.LArm:
-      limit: 3 #ADT-tweak 2>3 
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.RHand:
-      limit: 3 #ADT-tweak 2>3
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.LHand:
-      limit: 3 #ADT-tweak 2>3
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.RLeg:
-      limit: 3 #ADT-tweak 2>3
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.LLeg:
-      limit: 3 #ADT-tweak 2>3
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.RFoot:
-      limit: 3 #ADT-tweak 2>3
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.LFoot:
-      limit: 3 #ADT-tweak 2>3
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.Overlay:
       limit: 1

--- a/Resources/Prototypes/ADT/Body/markingsGroups.yml
+++ b/Resources/Prototypes/ADT/Body/markingsGroups.yml
@@ -13,10 +13,10 @@
       limit: 1
       required: false
     enum.HumanoidVisualLayers.Hair:
-      limit: 1
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.FacialHair:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.Chest:
       limit: 4
@@ -679,10 +679,10 @@
       limit: 1
       required: false
     enum.HumanoidVisualLayers.Hair:
-      limit: 1
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.FacialHair:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.Chest:
       limit: 4
@@ -709,28 +709,28 @@
       limit: 1
       required: false
     enum.HumanoidVisualLayers.RArm:
-      limit: 2
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.LArm:
-      limit: 2
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.RHand:
-      limit: 2
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.LHand:
-      limit: 2
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.RLeg:
-      limit: 2
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.LLeg:
-      limit: 2
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.RFoot:
-      limit: 2
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.LFoot:
-      limit: 2
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.Overlay:
       limit: 1

--- a/Resources/Prototypes/ADT/Body/markingsGroups.yml
+++ b/Resources/Prototypes/ADT/Body/markingsGroups.yml
@@ -13,10 +13,10 @@
       limit: 1
       required: false
     enum.HumanoidVisualLayers.Hair:
-      limit: 3
+      limit: 3 #ADT-tweak 1>3
       required: false
     enum.HumanoidVisualLayers.FacialHair:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.Chest:
       limit: 4
@@ -679,10 +679,10 @@
       limit: 1
       required: false
     enum.HumanoidVisualLayers.Hair:
-      limit: 3
+      limit: 3 #ADT-tweak 1>3
       required: false
     enum.HumanoidVisualLayers.FacialHair:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.Chest:
       limit: 4
@@ -709,28 +709,28 @@
       limit: 1
       required: false
     enum.HumanoidVisualLayers.RArm:
-      limit: 3
+      limit: 3 #ADT-tweak 2>3
       required: false
     enum.HumanoidVisualLayers.LArm:
-      limit: 3
+      limit: 3 #ADT-tweak 2>3 
       required: false
     enum.HumanoidVisualLayers.RHand:
-      limit: 3
+      limit: 3 #ADT-tweak 2>3
       required: false
     enum.HumanoidVisualLayers.LHand:
-      limit: 3
+      limit: 3 #ADT-tweak 2>3
       required: false
     enum.HumanoidVisualLayers.RLeg:
-      limit: 3
+      limit: 3 #ADT-tweak 2>3
       required: false
     enum.HumanoidVisualLayers.LLeg:
-      limit: 3
+      limit: 3 #ADT-tweak 2>3
       required: false
     enum.HumanoidVisualLayers.RFoot:
-      limit: 3
+      limit: 3 #ADT-tweak 2>3
       required: false
     enum.HumanoidVisualLayers.LFoot:
-      limit: 3
+      limit: 3 #ADT-tweak 2>3
       required: false
     enum.HumanoidVisualLayers.Overlay:
       limit: 1

--- a/Resources/Prototypes/Body/Species/arachnid.yml
+++ b/Resources/Prototypes/Body/Species/arachnid.yml
@@ -21,16 +21,16 @@
       required: true
       default: [ ArachnidCheliceraeDownwards ]
     enum.HumanoidVisualLayers.LArm:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.RArm:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.LLeg:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.RLeg:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
 
 - type: entity

--- a/Resources/Prototypes/Body/Species/arachnid.yml
+++ b/Resources/Prototypes/Body/Species/arachnid.yml
@@ -21,16 +21,16 @@
       required: true
       default: [ ArachnidCheliceraeDownwards ]
     enum.HumanoidVisualLayers.LArm:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.RArm:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.LLeg:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.RLeg:
-      limit: 1
+      limit: 2
       required: false
 
 - type: entity

--- a/Resources/Prototypes/Body/Species/diona.yml
+++ b/Resources/Prototypes/Body/Species/diona.yml
@@ -7,10 +7,10 @@
       limit: 2
       required: false
     enum.HumanoidVisualLayers.HeadTop:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.HeadSide:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.Chest:
       limit: 2

--- a/Resources/Prototypes/Body/Species/diona.yml
+++ b/Resources/Prototypes/Body/Species/diona.yml
@@ -7,10 +7,10 @@
       limit: 2
       required: false
     enum.HumanoidVisualLayers.HeadTop:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.HeadSide:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.Chest:
       limit: 2

--- a/Resources/Prototypes/Body/Species/human.yml
+++ b/Resources/Prototypes/Body/Species/human.yml
@@ -12,7 +12,7 @@
       limit: 2
       required: false
     enum.HumanoidVisualLayers.Chest:
-      limit: 2
+      limit: 4
       required: false
     enum.HumanoidVisualLayers.Snout:
       limit: 1

--- a/Resources/Prototypes/Body/Species/human.yml
+++ b/Resources/Prototypes/Body/Species/human.yml
@@ -6,40 +6,40 @@
       limit: 1
       required: false
     enum.HumanoidVisualLayers.Hair:
-      limit: 3
+      limit: 3 #ADT-tweak 1>3
       required: false
     enum.HumanoidVisualLayers.FacialHair:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.Chest:
-      limit: 4
+      limit: 4 #ADT-tweak 2>4
       required: false
     enum.HumanoidVisualLayers.Snout:
       limit: 1
       required: false
     enum.HumanoidVisualLayers.LArm:
-      limit: 3
+      limit: 3 #ADT-tweak 1>3
       required: false
     enum.HumanoidVisualLayers.RArm:
-      limit: 3
+      limit: 3 #ADT-tweak 1>3
       required: false
     enum.HumanoidVisualLayers.LHand:
-      limit: 3
+      limit: 3 #ADT-tweak 1>3
       required: false
     enum.HumanoidVisualLayers.RHand:
-      limit: 3
+      limit: 3 #ADT-tweak 1>3
       required: false
     enum.HumanoidVisualLayers.LLeg:
-      limit: 3
+      limit: 3 #ADT-tweak 1>3
       required: false
     enum.HumanoidVisualLayers.RLeg:
-      limit: 3
+      limit: 3 #ADT-tweak 1>3
       required: false
     enum.HumanoidVisualLayers.LFoot:
-      limit: 3
+      limit: 3 #ADT-tweak 1>3
       required: false
     enum.HumanoidVisualLayers.RFoot:
-      limit: 3
+      limit: 3 #ADT-tweak 1>3
       required: false
     enum.HumanoidVisualLayers.Tail:
       limit: 1

--- a/Resources/Prototypes/Body/Species/human.yml
+++ b/Resources/Prototypes/Body/Species/human.yml
@@ -6,10 +6,10 @@
       limit: 1
       required: false
     enum.HumanoidVisualLayers.Hair:
-      limit: 1
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.FacialHair:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.Chest:
       limit: 2
@@ -18,28 +18,28 @@
       limit: 1
       required: false
     enum.HumanoidVisualLayers.LArm:
-      limit: 1
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.RArm:
-      limit: 1
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.LHand:
-      limit: 1
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.RHand:
-      limit: 1
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.LLeg:
-      limit: 1
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.RLeg:
-      limit: 1
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.LFoot:
-      limit: 1
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.RFoot:
-      limit: 1
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.Tail:
       limit: 1

--- a/Resources/Prototypes/Body/Species/moth.yml
+++ b/Resources/Prototypes/Body/Species/moth.yml
@@ -24,28 +24,28 @@
       limit: 1
       required: false
     enum.HumanoidVisualLayers.LArm:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.RArm:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.LHand:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.RHand:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.LLeg:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.RLeg:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.LFoot:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.RFoot:
-      limit: 1
+      limit: 2
       required: false
 
 - type: entity

--- a/Resources/Prototypes/Body/Species/moth.yml
+++ b/Resources/Prototypes/Body/Species/moth.yml
@@ -24,28 +24,28 @@
       limit: 1
       required: false
     enum.HumanoidVisualLayers.LArm:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.RArm:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.LHand:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.RHand:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.LLeg:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.RLeg:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.LFoot:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.RFoot:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
 
 - type: entity

--- a/Resources/Prototypes/Body/Species/slime.yml
+++ b/Resources/Prototypes/Body/Species/slime.yml
@@ -9,31 +9,31 @@
       limit: 1
       required: false
     enum.HumanoidVisualLayers.Chest:
-      limit: 2
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.LArm:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.RArm:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.LHand:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.RHand:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.LLeg:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.RLeg:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.LFoot:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.RFoot:
-      limit: 1
+      limit: 2
       required: false
     # Corvax-Sponsors-start
     enum.HumanoidVisualLayers.HeadTop:

--- a/Resources/Prototypes/Body/Species/slime.yml
+++ b/Resources/Prototypes/Body/Species/slime.yml
@@ -9,31 +9,31 @@
       limit: 1
       required: false
     enum.HumanoidVisualLayers.Chest:
-      limit: 3
+      limit: 3 #ADT-tweak 2>3
       required: false
     enum.HumanoidVisualLayers.LArm:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.RArm:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.LHand:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.RHand:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.LLeg:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.RLeg:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.LFoot:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     enum.HumanoidVisualLayers.RFoot:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       required: false
     # Corvax-Sponsors-start
     enum.HumanoidVisualLayers.HeadTop:

--- a/Resources/Prototypes/Body/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Body/Species/vulpkanin.yml
@@ -3,10 +3,10 @@
   id: Vulpkanin
   limits:
     enum.HumanoidVisualLayers.Hair:
-      limit: 1
+      limit: 3
       required: false
     enum.HumanoidVisualLayers.FacialHair:
-      limit: 1
+      limit: 2
       onlyGroupWhitelisted: true
       required: false
     enum.HumanoidVisualLayers.Head:

--- a/Resources/Prototypes/Body/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Body/Species/vulpkanin.yml
@@ -3,10 +3,10 @@
   id: Vulpkanin
   limits:
     enum.HumanoidVisualLayers.Hair:
-      limit: 3
+      limit: 3 #ADT-tweak 1>3
       required: false
     enum.HumanoidVisualLayers.FacialHair:
-      limit: 2
+      limit: 2 #ADT-tweak 1>2
       onlyGroupWhitelisted: true
       required: false
     enum.HumanoidVisualLayers.Head:


### PR DESCRIPTION
## Описание PR
Изменил возможное количество причёсок и других деталей внешнего вида некоторым расам

## Почему / Баланс
По двум предложениям
https://discord.com/channels/901772674865455115/1533124874007089183
https://discord.com/channels/901772674865455115/1540147014489214986

## Техническая информация
Дополнительное количество причёсок получили: люди, фелениды, вульпканины, арканы
Дополнительное количество слотов внешнего вида получили: люди, фелениды, дионы, арахниды, слаймолюды, моли
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [ ] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: Golyb4ik
- tweak: Изменено количество слотов внешности и причёсок некоторым расам

