### PR TITLE
Нианы теперь царапаются когтями

### DIFF
--- a/Resources/Prototypes/Body/Species/moth.yml
+++ b/Resources/Prototypes/Body/Species/moth.yml
@@ -167,6 +167,15 @@
         Burn:
           sprite: Mobs/Effects/burn_damage.rsi
     - type: MothAccent
+    # ADT-Tweak start: моли дерутся когтями (режущий урон)
+    - type: MeleeWeapon
+      soundHit:
+        path: /Audio/Weapons/slash.ogg
+      animation: WeaponArcClaw
+      damage:
+        types:
+          Slash: 5
+    # ADT-Tweak end
     # ADT-Tweak start
     - type: Vocal
       sounds:


### PR DESCRIPTION
## Описание PR
Нианы теперь дерутся когтями, нанося режущий урон с руки, вместо дробящего

## Почему / Баланс
По лору, у молей когти, и в бою они используют их при отсутсвии оружия. Цитата с вики сс220
> Когда же их заставляют драться, они инстинктивно используют когти на руках, а не жвалы. 

## Техническая информация
У молей дефайнут свой собственный MeleeWeapon, который использует звуки и анимации когтей, и наносит 5 режущих. По сути точь в точь как у других когтистых рас
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
https://github.com/user-attachments/assets/458216cc-fe7e-4b7f-910e-80ababb673b4

## Чейнджлог
:cl: FriendlyOne
- tweak: Нианы теперь дерутся когтями, нанося режущий урон с руки