### PR TITLE
Фикс самопингов

### DIFF
--- a/Content.Client/ADT/Chat/ChatUIController.HighlightSound.cs
+++ b/Content.Client/ADT/Chat/ChatUIController.HighlightSound.cs
@@ -16,6 +16,9 @@ public sealed partial class ChatUIController
         if (!playHighlightSound)
             return;
 
+        if (_player.LocalEntity is { } localEntity && _ent.GetEntity(msg.SenderEntity) == localEntity)
+            return;
+
         if (!_config.GetCVar(ADTCCVars.ChatHighlightSoundEnabled))
             return;
 

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -200,7 +200,7 @@ public sealed class RadioSystem : EntitySystem
             ChatChannel.Radio,
             message,
             wrappedMessage,
-            NetEntity.Invalid,
+            GetNetEntity(messageSource), // ADT-Tweak: NetEntity.Invalid -> отправитель, чтобы клиент отличал свои сообщения
             null);
 
         // ADT Languages start
@@ -208,7 +208,7 @@ public sealed class RadioSystem : EntitySystem
             ChatChannel.Radio,
             message,
             wrappedEncodedMessage,
-            NetEntity.Invalid,
+            GetNetEntity(messageSource), // ADT-Tweak: NetEntity.Invalid -> отправитель
             null);
         // ADT Languages end
 


### PR DESCRIPTION
## Описание PR
Самопинги теперь не проигрывают звук

## Почему / Баланс
На данный момент, самопинги проигрывают звук. Тобеж, если у тебя в имени есть "Теокайа", и у тебя хайлайтяться сообщения где есть "Тео", то самопинг будет проигрываться при шопоте, при емоутах, при сообщении в LOOC

## Техническая информация
В `TryPlayHighlightSound` добавлен гард, который возвращает, если сообщение отправляет моб, которым ты управляешь

Для этого также было изменено то, что по рации теперь отправляется не `invalid`, правильный сендер ентити
- [X] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [X] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: FriendlyOne
- fix: Пинги теперь не проигрываются при емоутах, сообщениях в рацию, сообщениях в мертвый чат, т.д.