### PR TITLE
Бум СМа

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Structures/Power/Generation/Supermatter/SupermatterCrystal.yml
+++ b/Resources/Prototypes/ADT/Entities/Structures/Power/Generation/Supermatter/SupermatterCrystal.yml
@@ -93,7 +93,7 @@
       GlowDelam: { state: supermatter-glow-delam }
   - type: Explosive
     explosionType: Supermatter
-    totalIntensity: 250000
+    totalIntensity: 1350000
     intensitySlope: 5
     maxIntensity: 100
   - type: GravityWell


### PR DESCRIPTION
## Описание PR
Увеличен взрыв СМа примерно в 2 раза

## Почему / Баланс
На данный момент взрыв СМа затрагивает в основном атмос, иногда ИО, иногда даже не затрагивая дистру. Тобеж станция в теории могла бы даже продолжить работу. Это немного не работает с тем, что взрыв СМа - завершающий раунд ивент
- [Предложение](https://discord.com/channels/901772674865455115/1539610331092099283)

## Техническая информация
`totalIntensity` 250000 > 1350000  
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d7452d12-bdfd-448f-99b3-25d6ac38feea" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/512ff70b-8038-4ae5-afb1-271b89f777ad" />

:cl: FriendlyOne
- tweak: Взрыв СМа увеличен в ~2 раза