### PR TITLE
remove SubGamemodesRule Shadowling

### DIFF
--- a/Resources/Prototypes/ADT/game_presets.yml
+++ b/Resources/Prototypes/ADT/game_presets.yml
@@ -26,7 +26,6 @@
   rules:
     - ADTShadowlingGameRule
     - BasicRoundstartVariation
-    - SubGamemodesRule
     - BasicStationEventScheduler
     - MeteorSwarmScheduler
     - CrewTransferScheduler


### PR DESCRIPTION
При тенелингах не могут быть другие антаги из SubGamemodes (Вор, Xenoborgs, SubXenoborgs)

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.
