### PR TITLE
opt again xenobiology

### DIFF
--- a/Content.Client/ADT/Xenobiology/XenoSlimeVisualizerSystem.cs
+++ b/Content.Client/ADT/Xenobiology/XenoSlimeVisualizerSystem.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Content.Client.DamageState;
 using Content.Shared.ADT.Xenobiology;
 using Content.Shared.ADT.Xenobiology.Components;
@@ -18,22 +17,16 @@ public sealed class XenoSlimeVisualizerSystem : VisualizerSystem<SlimeComponent>
 
     protected override void OnAppearanceChange(EntityUid uid, SlimeComponent component, ref AppearanceChangeEvent args)
     {
-        if (args.Sprite == null || !AppearanceSystem.TryGetData<Color>(uid, XenoSlimeVisuals.Color, out var color, args.Component) || !TryComp<SpriteComponent>(uid, out var spriteComponent))
+        if (args.Sprite == null || !AppearanceSystem.TryGetData<Color>(uid, XenoSlimeVisuals.Color, out var color, args.Component))
             return;
 
         foreach (var layer in args.Sprite.AllLayers)
             layer.Color = color.WithAlpha(layer.Color.A);
 
-        if (!AppearanceSystem.TryGetData<string>(uid, XenoSlimeVisuals.Shader, out var shader, args.Component))
+        if (!AppearanceSystem.TryGetData<string>(uid, XenoSlimeVisuals.Shader, out var shader, args.Component)
+            || !_sprite.LayerMapTryGet(uid, DamageStateVisualLayers.Base, out var layerKey, false))
             return;
-        var spriteComp = args.Sprite;
-        var newShader = _proto.Index<ShaderPrototype>(shader).InstanceUnique();
 
-        var layerExists = _sprite.LayerMapTryGet(uid, DamageStateVisualLayers.Base, out var layerKey, false);
-        if (!layerExists)
-            return;
-        spriteComp.LayerSetShader(layerKey, newShader);
-        spriteComp.GetScreenTexture = true;
-        spriteComp.RaiseShaderEvent = true;
+        args.Sprite.LayerSetShader(layerKey, _proto.Index<ShaderPrototype>(shader).Instance());
     }
 }

--- a/Content.Server/ADT/Xenobiology/SlimeLatchSystem.cs
+++ b/Content.Server/ADT/Xenobiology/SlimeLatchSystem.cs
@@ -90,13 +90,16 @@ public sealed partial class SlimeLatchSystem : EntitySystem
             UpdateHunger((uid, dotComp), (source, slimeComp));
         }
 
-        var query = EntityQueryEnumerator<SlimeComponent>();
-        while (query.MoveNext(out var uid, out var slime))
+        var query = EntityQueryEnumerator<SlimeComponent, SlimeLatchedComponent>();
+        while (query.MoveNext(out var uid, out var slime, out _))
         {
             var slimeEnt = new Entity<SlimeComponent>(uid, slime);
 
             if (!IsLatched(slimeEnt))
+            {
+                RemCompDeferred<SlimeLatchedComponent>(uid);
                 continue;
+            }
 
             var target = slime.LatchedTarget!.Value;
 
@@ -245,10 +248,7 @@ public sealed partial class SlimeLatchSystem : EntitySystem
         // Восполняем голод слайма ТОЛЬКО если он прикреплен
         var addedHunger = (float)ent.Comp.Damage.GetTotal();
         if (TryComp<HungerComponent>(source, out var hunger))
-        {
             _hunger.ModifyHunger(source, addedHunger, hunger);
-            Dirty(source, hunger);
-        }
 
         // Трансфер растворов
         if (!TryComp<BodyComponent>(source, out var bodyComp))
@@ -297,7 +297,6 @@ public sealed partial class SlimeLatchSystem : EntitySystem
         if (HasComp<MonkeyAccentComponent>(corpse))
         {
             slime.Comp.Friendship = MathF.Min(1f, slime.Comp.Friendship + slime.Comp.FriendshipPerMeal);
-            Dirty(slime);
         }
     }
 
@@ -347,6 +346,7 @@ public sealed partial class SlimeLatchSystem : EntitySystem
             _physics.SetCanCollide(ent, false, body: physics);
 
         ent.Comp.LatchedTarget = target;
+        EnsureComp<SlimeLatchedComponent>(ent);
 
         EnsureComp<BeingLatchedComponent>(target);
         EnsureComp(target, out SlimeDamageOvertimeComponent comp);
@@ -354,9 +354,6 @@ public sealed partial class SlimeLatchSystem : EntitySystem
 
         _audio.PlayEntity(ent.Comp.EatSound, ent, ent);
         _popup.PopupEntity(Loc.GetString("slime-action-latch-success", ("slime", ent), ("target", target)), ent, PopupType.SmallCaution);
-
-        Dirty(ent);
-        Dirty(target, comp);
     }
 
     public void Unlatch(Entity<SlimeComponent> ent)
@@ -380,6 +377,7 @@ public sealed partial class SlimeLatchSystem : EntitySystem
             _physics.SetCanCollide(ent, true, body: physics);
 
         ent.Comp.LatchedTarget = null;
+        RemCompDeferred<SlimeLatchedComponent>(ent);
     }
 
     #endregion

--- a/Content.Server/ADT/Xenobiology/SlimeSpeechSystem.cs
+++ b/Content.Server/ADT/Xenobiology/SlimeSpeechSystem.cs
@@ -73,8 +73,8 @@ public sealed partial class SlimeSpeechSystem : EntitySystem
     {
         base.Update(frameTime);
 
-        var query = EntityQueryEnumerator<SlimeComponent>();
-        while (query.MoveNext(out var uid, out var slime))
+        var query = EntityQueryEnumerator<SlimeComponent, SlimeFollowingComponent>();
+        while (query.MoveNext(out var uid, out var slime, out _))
         {
             UpdateFollowing(uid, slime);
         }
@@ -145,6 +145,7 @@ public sealed partial class SlimeSpeechSystem : EntitySystem
 
         slime.Comp.FollowingTarget = speaker;
         slime.Comp.NextFollowUpdate = TimeSpan.Zero;
+        EnsureComp<SlimeFollowingComponent>(slime);
         SayForCommand(slime, Loc.GetString("slime-speech-follow", ("target", speaker)), speaker);
         return true;
     }
@@ -160,7 +161,6 @@ public sealed partial class SlimeSpeechSystem : EntitySystem
         {
             slime.Comp.Friendship = Math.Max(0f, slime.Comp.Friendship - slime.Comp.FriendshipLossOnRefusal);
             SayForCommand(slime, Loc.GetString("slime-speech-grrr"), speaker);
-            Dirty(slime);
             return true;
         }
 
@@ -205,7 +205,6 @@ public sealed partial class SlimeSpeechSystem : EntitySystem
             if (!order.Slimes.Contains(slime))
                 order.Slimes.Add(slime);
             order.ExpiresAt = _timing.CurTime + PointOrderDuration;
-            Dirty(speaker, order);
 
             // Freeze the slime so it doesn't hunt on its own while waiting.
             FreezeSlime(slime, PointOrderDuration);
@@ -253,7 +252,6 @@ public sealed partial class SlimeSpeechSystem : EntitySystem
         StopFollowing(slime);
         var stopped = EnsureComp<SlimeStoppedComponent>(slime);
         stopped.ExpiresAt = _timing.CurTime + duration;
-        Dirty(slime, stopped);
 
         if (TryComp<HTNComponent>(slime, out var htn))
             _htn.SetHTNEnabled((slime, htn), false);
@@ -319,7 +317,10 @@ public sealed partial class SlimeSpeechSystem : EntitySystem
     private void UpdateFollowing(EntityUid uid, SlimeComponent slime)
     {
         if (slime.FollowingTarget is not { } target)
+        {
+            RemCompDeferred<SlimeFollowingComponent>(uid);
             return;
+        }
 
         if (Deleted(target)
             || _mobState.IsDead(target)
@@ -343,6 +344,7 @@ public sealed partial class SlimeSpeechSystem : EntitySystem
             return;
 
         slime.Comp.FollowingTarget = null;
+        RemCompDeferred<SlimeFollowingComponent>(slime);
         var htn = CompOrNull<HTNComponent>(slime);
         htn?.Blackboard.Remove<EntityCoordinates>(NPCBlackboard.FollowTarget);
     }

--- a/Content.Shared/ADT/Xenobiology/Components/MobGrowthComponent.cs
+++ b/Content.Shared/ADT/Xenobiology/Components/MobGrowthComponent.cs
@@ -8,25 +8,25 @@ namespace Content.Shared.ADT.Xenobiology.Components;
 /// <summary>
 /// This is used for mob growth between baby, adult etc...
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent]
 public sealed partial class MobGrowthComponent : Component
 {
     /// <summary>
     /// What hunger threshold must be reached to grow?
     /// </summary>
-    [DataField(required: true), AutoNetworkedField]
+    [DataField(required: true)]
     public float HungerRequired = 100f;
 
     /// <summary>
     /// How much hunger does growing consume?
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public float GrowthCost = -75f;
 
     /// <summary>
     /// What is the mob's current growth stage?
     /// </summary>
-    [DataField(required: true), AutoNetworkedField]
+    [DataField(required: true)]
     public string CurrentStage;
 
     [ViewVariables(VVAccess.ReadOnly)]
@@ -38,13 +38,13 @@ public sealed partial class MobGrowthComponent : Component
     /// <summary>
     /// A list of available stages.
     /// </summary>
-    [DataField(required: true), AutoNetworkedField]
+    [DataField(required: true)]
     public Dictionary<string, GrowthStageData> Stages = [];
 
-    [ViewVariables, AutoNetworkedField]
+    [ViewVariables]
     public TimeSpan NextGrowthTime;
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public TimeSpan GrowthInterval = TimeSpan.FromSeconds(1);
 
     /// <summary>

--- a/Content.Shared/ADT/Xenobiology/Components/SlimeComponent.cs
+++ b/Content.Shared/ADT/Xenobiology/Components/SlimeComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.ADT.Xenobiology.Components;
 /// <summary>
 /// Stores important information about slimes.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent]
 public sealed partial class SlimeComponent : Component
 {
     /// <summary>
@@ -20,13 +20,13 @@ public sealed partial class SlimeComponent : Component
     /// <summary>
     /// What color is the slime?
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public Color SlimeColor = Color.FromHex("#FFFFFF");
 
     /// <summary>
     /// What is the current slime's current breed?
     /// </summary>
-    [DataField(required: true), AutoNetworkedField]
+    [DataField(required: true)]
     public ProtoId<BreedPrototype> Breed = "GreyMutation";
 
     /// <summary>
@@ -39,7 +39,7 @@ public sealed partial class SlimeComponent : Component
     /// <summary>
     /// If the mutation chance is met, what potential mutations are available?
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public HashSet<ProtoId<BreedPrototype>> PotentialMutations = new();
 
     /// <summary>
@@ -69,7 +69,7 @@ public sealed partial class SlimeComponent : Component
     /// <summary>
     /// The entity which has tamed this slime.
     /// </summary>
-    [ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadOnly)]
     public EntityUid? Tamer;
 
     [DataField]
@@ -84,56 +84,56 @@ public sealed partial class SlimeComponent : Component
     /// <summary>
     /// The maximum amount of offspring produced by mitosis.
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public int MaxOffspring = 4;
 
     /// <summary>
     /// How many extracts will be produced by this slime?
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public int ExtractsProduced = 1;
 
     /// <summary>
     /// What is the chance of offspring mutating? (this is per/offspring)
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public float MutationChance = 0.45f;
 
     /// <summary>
     /// What hunger threshold must be met for mitosis?
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public float MitosisHunger = 125f;
 
     /// <summary>
     /// How long in between each mitosis/breeding check?
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public TimeSpan UpdateInterval = TimeSpan.FromSeconds(1);
 
     /// <summary>
     /// When is the next mitosis/breeding check?
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public TimeSpan NextUpdateTime;
 
     /// <summary>
     /// What should the minimum difference be between the current hunger and the mitosis hunger
     /// before the entity starts to shake?
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public float JitterDifference = 25f;
 
     /// <summary>
     /// Should this slime have a shader?
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public bool ShouldHaveShader;
 
     /// <summary>
     /// Which shader are we using?
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public string? Shader;
 
     /// <summary>
@@ -148,14 +148,14 @@ public sealed partial class SlimeComponent : Component
     [DataField]
     public SoundPathSpecifier EatSound = new("/Audio/Voice/Talk/slime.ogg");
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public float FriendSightRange = 10f;
 
     /// <summary>
     /// How much this slime likes its tamer. 0-1.
     /// Grows when the slime eats monkeys, shrinks when upset.
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public float Friendship;
 
     /// <summary>
@@ -167,13 +167,13 @@ public sealed partial class SlimeComponent : Component
     /// <summary>
     /// How much friendship is required for the slime to follow commands.
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public float MinFriendshipToCommand = 0.15f;
 
     /// <summary>
     /// How much friendship is lost when the slime refuses an order.
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public float FriendshipLossOnRefusal = 0.1f;
 
     [ViewVariables(VVAccess.ReadOnly)]
@@ -182,9 +182,9 @@ public sealed partial class SlimeComponent : Component
     [ViewVariables(VVAccess.ReadOnly)]
     public TimeSpan NextFollowUpdate;
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public float ChaseSpeedMultiplier = 1.3f;
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public TimeSpan StopDuration = TimeSpan.FromSeconds(10);
 }

--- a/Content.Shared/ADT/Xenobiology/Components/SlimeFollowingComponent.cs
+++ b/Content.Shared/ADT/Xenobiology/Components/SlimeFollowingComponent.cs
@@ -1,0 +1,6 @@
+namespace Content.Shared.ADT.Xenobiology.Components;
+
+[RegisterComponent]
+public sealed partial class SlimeFollowingComponent : Component
+{
+}

--- a/Content.Shared/ADT/Xenobiology/Components/SlimeLatchedComponent.cs
+++ b/Content.Shared/ADT/Xenobiology/Components/SlimeLatchedComponent.cs
@@ -1,0 +1,6 @@
+namespace Content.Shared.ADT.Xenobiology.Components;
+
+[RegisterComponent]
+public sealed partial class SlimeLatchedComponent : Component
+{
+}

--- a/Content.Shared/ADT/Xenobiology/Systems/MobGrowthSystem.cs
+++ b/Content.Shared/ADT/Xenobiology/Systems/MobGrowthSystem.cs
@@ -42,6 +42,9 @@ public sealed partial class MobGrowthSystem : EntitySystem
     {
         base.Update(frameTime);
 
+        if (_net.IsClient)
+            return;
+
         var query = EntityQueryEnumerator<MobGrowthComponent, HungerComponent>();
         while (query.MoveNext(out var uid, out var growth, out var hungerComp))
         {
@@ -81,7 +84,6 @@ public sealed partial class MobGrowthSystem : EntitySystem
 
         _hunger.ModifyHunger(uid, growth.GrowthCost, hunger);
         growth.CurrentStage = nextStage;
-        Dirty(uid, growth);
 
         UpdateAppearance((uid, growth));
     }

--- a/Content.Shared/ADT/Xenobiology/Systems/XenobiologySystem.Breeding.cs
+++ b/Content.Shared/ADT/Xenobiology/Systems/XenobiologySystem.Breeding.cs
@@ -43,7 +43,6 @@ public partial class XenobiologySystem
         slime.MaxOffspring += _random.Next(-1, 2);
         slime.ExtractsProduced += _random.Next(0, 2);
         slime.MitosisHunger *= _random.NextFloat(0.75f, 1.2f);
-        Dirty(args.Target, slime);
     }
 
     private void OnSlimeShutdown(Entity<SlimeComponent> ent, ref ComponentShutdown args)
@@ -67,9 +66,15 @@ public partial class XenobiologySystem
         ent.Comp.NextUpdateTime = _gameTiming.CurTime + ent.Comp.UpdateInterval;
     }
 
+    private readonly HashSet<Entity<SlimeComponent, MobGrowthComponent, HungerComponent>> _eligibleSlimes = [];
+    private readonly Dictionary<EntityUid, int> _slimeDensityByGrid = [];
+
     private void UpdateMitosis()
     {
-        var eligibleSlimes = new HashSet<Entity<SlimeComponent, MobGrowthComponent, HungerComponent>>();
+        if (_net.IsClient)
+            return;
+
+        _eligibleSlimes.Clear();
 
         var query = EntityQueryEnumerator<SlimeComponent, MobGrowthComponent, HungerComponent>();
         while (query.MoveNext(out var uid, out var slime, out var growthComp, out var hungerComp))
@@ -79,11 +84,16 @@ public partial class XenobiologySystem
                 || growthComp.IsFirstStage)
                 continue;
 
-            eligibleSlimes.Add((uid, slime, growthComp, hungerComp));
+            _eligibleSlimes.Add((uid, slime, growthComp, hungerComp));
             slime.NextUpdateTime = _gameTiming.CurTime + slime.UpdateInterval;
         }
 
-        foreach (var ent in eligibleSlimes)
+        if (_eligibleSlimes.Count == 0)
+            return;
+
+        ComputeSlimeDensity();
+
+        foreach (var ent in _eligibleSlimes)
         {
             var hunger = _hunger.GetHunger(ent);
 
@@ -93,18 +103,15 @@ public partial class XenobiologySystem
             if (hunger < ent.Comp1.MitosisHunger)
                 continue;
 
-            DoMitosis(ent);
+            DoMitosis(ent, GetGridSlimeDensity(ent));
         }
     }
 
-    private void DoMitosis(Entity<SlimeComponent> ent)
+    private void DoMitosis(Entity<SlimeComponent> ent, int localDensity)
     {
-        if (_net.IsClient)
-            return;
-
         var offspringCount = _random.Next(1, ent.Comp.MaxOffspring + 1);
 
-        var slowdown = GetBreedingSlowdown(ent);
+        var slowdown = GetBreedingSlowdown(ent, localDensity);
         if (slowdown >= 1f)
             return;
 
@@ -183,9 +190,6 @@ public partial class XenobiologySystem
 
     private void MakeMitosisFriends(Entity<SlimeComponent> ent, List<EntityUid> offspring)
     {
-        if (_net.IsClient)
-            return;
-
         var range = ent.Comp.FriendSightRange;
         if (range <= 0f)
             return;
@@ -217,7 +221,7 @@ public partial class XenobiologySystem
     private Entity<SlimeComponent>? SpawnSlime(EntityUid parent, EntProtoId newEntityProto, ProtoId<BreedPrototype> selectedBreed)
     {
         if (Deleted(parent)
-        || !_prototypeManager.TryIndex(selectedBreed, out _) || _net.IsClient)
+        || !_prototypeManager.TryIndex(selectedBreed, out _))
             return null;
 
         var newEntityUid = SpawnNextToOrDrop(newEntityProto, parent);
@@ -248,7 +252,6 @@ public partial class XenobiologySystem
 
         _appearance.SetData(ent, XenoSlimeVisuals.Color, slime.SlimeColor);
         _mobGrowth.SetBaseName(ent, Loc.GetString(breed.BreedName));
-        Dirty(ent);
     }
 
     /// <summary>
@@ -275,12 +278,30 @@ public partial class XenobiologySystem
         return count;
     }
 
+    private void ComputeSlimeDensity()
+    {
+        _slimeDensityByGrid.Clear();
+
+        var query = EntityQueryEnumerator<SlimeComponent, TransformComponent>();
+        while (query.MoveNext(out _, out _, out var xform))
+        {
+            var grid = xform.GridUid ?? EntityUid.Invalid;
+            _slimeDensityByGrid[grid] = _slimeDensityByGrid.GetValueOrDefault(grid) + 1;
+        }
+    }
+
+    private int GetGridSlimeDensity(Entity<SlimeComponent> ent)
+    {
+        var grid = Transform(ent).GridUid ?? EntityUid.Invalid;
+        return Math.Max(0, _slimeDensityByGrid.GetValueOrDefault(grid) - 1);
+    }
+
     /// <summary>
     /// Computes a breeding slowdown factor in the range [0, 1] based on local slime density.
     /// 0 means no slowdown (breeding unaffected), approaching 1 means breeding is nearly halted.
     /// The slowdown ramps up progressively between the slowdown-start threshold and the max cap.
     /// </summary>
-    public float GetBreedingSlowdown(Entity<SlimeComponent> ent)
+    public float GetBreedingSlowdown(Entity<SlimeComponent> ent, int? localDensity = null)
     {
         var max = _configuration.GetCVar(SimpleStationCCVars.XenobiologyMaxSlimesPerGrid);
         var start = _configuration.GetCVar(SimpleStationCCVars.XenobiologyBreedingSlowdownStart);
@@ -289,7 +310,7 @@ public partial class XenobiologySystem
         if (max <= 0 || factor <= 0)
             return 0f;
 
-        var density = GetLocalSlimeDensity(ent);
+        var density = localDensity ?? GetLocalSlimeDensity(ent);
         if (density <= start)
             return 0f;
 

--- a/Content.Shared/ADT/Xenobiology/Systems/XenobiologySystem.Taming.cs
+++ b/Content.Shared/ADT/Xenobiology/Systems/XenobiologySystem.Taming.cs
@@ -28,7 +28,5 @@ public partial class XenobiologySystem
         comp.Friendship = MathF.Max(comp.Friendship, comp.MinFriendshipToCommand);
 
         _popup.PopupEntity(Loc.GetString("slime-interaction-tame"), args.User, args.User);
-
-        Dirty(ent);
     }
 }


### PR DESCRIPTION
## Описание PR
Оптимизирована производительность ксенобиологии: симуляция размножения и роста слаймов перенесена на сервер  = снижена сетевая и рендерная нагрузка. Убран избыточный перенос состояния компонентов слаймов на клиент

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- tweak: Значительно уменьшена нагрузка на сторону клиента при работе с ксенобиологией.