### PR TITLE
Фикс сохранения айтема на спине когда одеваешь мод внутри меха

### DIFF
--- a/Content.Shared/ADT/Modsuit/Systems/ModSuitSystem.Parts.cs
+++ b/Content.Shared/ADT/Modsuit/Systems/ModSuitSystem.Parts.cs
@@ -273,7 +273,7 @@ public sealed partial class ModSuitSystem
     private void RestoreSuitStorage(EntityUid user, EntityUid parent, EntityUid? stashed)
     {
         if (stashed.HasValue)
-            _inventorySystem.TryEquip(user, parent, stashed.Value, "suitstorage", predicted: true);
+            _inventorySystem.TryEquip(user, parent, stashed.Value, "suitstorage", force: true, predicted: true);
     }
 
     private void RemoveAllParts(Entity<ModSuitComponent> ent)


### PR DESCRIPTION
## Описание PR
Айтем со спины теперь не выпадает, если вы одеваете мод внутри меха

## Почему / Баланс
Не должен выпадать
- [Баг-репорт](https://discord.com/channels/901772674865455115/1542982221672222802)

## Техническая информация
Добавлен `force: true`
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: FriendlyOne
- fix: Айтем со спины теперь не выпадает, если одеваешь мод внутри меха
