### PR TITLE
Machine diff

### DIFF
--- a/Content.Server/ADT/Construction/Systems/AnomalyVesselMachinePartsSystem.cs
+++ b/Content.Server/ADT/Construction/Systems/AnomalyVesselMachinePartsSystem.cs
@@ -6,7 +6,7 @@ using Content.Shared.ADT.Construction.Events;
 namespace Content.Server.ADT.Construction.Systems;
 public sealed class AnomalyVesselMachinePartsSystem : EntitySystem
 {
-    private static readonly float[] TierPointMultipliers = [1.10f, 1.15f, 1.20f, 1.30f, 1.60f];
+    private static readonly float[] TierPointMultipliers = [1.00f, 1.10f, 1.20f, 1.30f, 1.60f];
 
     [Dependency] private readonly AnomalySystem _anomaly = default!;
 

--- a/Resources/Prototypes/ADT/Entities/Structures/Machines/dispencers.yml
+++ b/Resources/Prototypes/ADT/Entities/Structures/Machines/dispencers.yml
@@ -116,7 +116,7 @@
       #  1: 
       2: { TableSalt: 4, Water: 3, WeldingFuel: 8 }
       3: { Benzene: 10, Hydroxide: 8, Fersilicite: 12 }
-      4: { Uranium: 15, Plasma: 12, Siderlac: 15 }
+      # 4: { Uranium: 15, Plasma: 12, Siderlac: 15 }
       5: { Omnizine: 50, Cognizine: 50, Diethylamine: 10 }
     reagentsEmagged:
       Puncturase: 15

--- a/Resources/Prototypes/ADT/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/ADT/Recipes/Lathes/Packs/engineering.yml
@@ -46,11 +46,6 @@
   - ADTPowerCellHyperRecipe
 
 - type: latheRecipePack
-  id: ADTIndustrialCharger
-  recipes:
-  - ADTIndustrialChargerCircuitboard
-
-- type: latheRecipePack
   id: ADTAdvancedThruster
   recipes:
   - ADTMachineMediumThrusterCircuitboard

--- a/Resources/Prototypes/ADT/Recipes/Lathes/botany.yml
+++ b/Resources/Prototypes/ADT/Recipes/Lathes/botany.yml
@@ -21,15 +21,6 @@
     Silver: 150
 
 - type: latheRecipe
-  id: ADTHydroponicsTrayAdvancedMachineCircuitboard
-  result: ADTHydroponicsTrayAdvancedMachineCircuitboard
-  completetime: 2
-  materials:
-    Glass: 1000
-    Steel: 500
-    Gold: 500
-
-- type: latheRecipe
   id: ADTBotanistBagOfHolding
   result: ADTBotanistBagOfHolding
   completetime: 5

--- a/Resources/Prototypes/ADT/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/ADT/Recipes/Lathes/electronics.yml
@@ -1,22 +1,4 @@
 - type: latheRecipe
-  parent: BaseCircuitboardRecipe
-  id: ADTIndustrialChargerCircuitboard
-  result: ADTIndustrialChargerCircuitboard
-  completetime: 6
-  materials:
-     Steel: 100
-     Glass: 500
-     Gold: 100
-     Copper: 1000
-     Zinc: 100
-
-- type: latheRecipe
-  parent: MicrowaveMachineCircuitboard
-  id: ADTAdvancedMicrowaveMachineCircuitBoard
-  result: ADTAdvancedMicrowaveMachineCircuitBoard
-  completetime: 2
-
-- type: latheRecipe
   id: ADTColdplateMachineCircuitboard
   result: ADTColdplateMachineCircuitboard
   completetime: 4

--- a/Resources/Prototypes/ADT/Recipes/Lathes/service.yml
+++ b/Resources/Prototypes/ADT/Recipes/Lathes/service.yml
@@ -73,16 +73,6 @@
 
 
 - type: latheRecipe
-  id: ADTAdvancedReagentGrinderMachineCircuitboard
-  result: ADTAdvancedReagentGrinderMachineCircuitboard
-  completetime: 2
-  materials:
-    Glass: 1000
-    Steel: 500
-    Gold: 500
-    Copper: 100
-
-- type: latheRecipe
   id: BoxFolderRed
   result: BoxFolderRed
   completetime: 3

--- a/Resources/Prototypes/ADT/Research/civilianservices.yml
+++ b/Resources/Prototypes/ADT/Research/civilianservices.yml
@@ -43,7 +43,6 @@
   tier: 2
   cost: 12500
   recipeUnlocks:
-    - ADTAdvancedMicrowaveMachineCircuitBoard #Я не против расширения арсенала этой технологии, просто переименуйте её в локализации, если будете добавлять сюда чего-либо
     - ADTCoffeeMachineBluespaceCircuitboard # Окей, братан. Я тебя понял :3
     - ADTKitchenAssemblerMachineCircuitBoard
     - ADTElectricRangeMachineCircuitBoard
@@ -61,26 +60,10 @@
   tier: 2
   cost: 7500
   recipeUnlocks:
-    - ADTHydroponicsTrayAdvancedMachineCircuitboard
     - ADTAdvancedPlantAnalyzer
   position: 1,-1
   requiredTech:
   - Hydroponics
-
-- type: technology
-  id: ADTReagentGrinder
-  name: research-advanced-reagent-grinder
-  icon:
-    sprite: ADT/Structures/Machines/juicer_T2.rsi
-    state: juicer0
-  discipline: CivilianServices
-  tier: 2
-  cost: 5000
-  recipeUnlocks:
-  - ADTAdvancedReagentGrinderMachineCircuitboard
-  requiredTech:
-  - MeatManipulation
-  position: 3,-2
 
 - type: technology
   id: ADTWeaponLauncherHydra

--- a/Resources/Prototypes/ADT/Research/industrial.yml
+++ b/Resources/Prototypes/ADT/Research/industrial.yml
@@ -123,7 +123,6 @@
   cost: 10000
   recipeUnlocks:
     - ADTPowerCellHyperRecipe
-    - ADTIndustrialChargerCircuitboard
   position: -1,-1  # ADT-Tweak I have to move it
   requiredTech:
   - AdvancedPowercells

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -348,7 +348,7 @@
     # ADT-tweak-start
     - ADTBluespaceHarvesterPack
     - ADTArcade
-    - ADTIndustrialCharger
+    # - ADTIndustrialCharger # ADT-Tweak
     - ADTAdvancedThruster
     #- ADTMegaCharger
     - ADTChemDisp

--- a/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
@@ -79,7 +79,7 @@
   id: EngineeringBoards
   recipes:
   - ThermomachineFreezerMachineCircuitBoard
-  - HellfireFreezerMachineCircuitBoard
+  # - HellfireFreezerMachineCircuitBoard # ADT-Tweak
   - PortableScrubberMachineCircuitBoard
   - SolarControlComputerCircuitboard
   - SolarTrackerElectronics

--- a/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
@@ -88,17 +88,19 @@
 - type: latheRecipePack
   id: ScienceBoards
   recipes:
-  - TurboItemRechargerCircuitboard
-  - AutolatheHyperConvectionMachineCircuitboard
-  - ProtolatheHyperConvectionMachineCircuitboard
-  - CircuitImprinterHyperConvectionMachineCircuitboard
+  # ADT-Tweak-Start
+  # - TurboItemRechargerCircuitboard
+  # - AutolatheHyperConvectionMachineCircuitboard
+  # - ProtolatheHyperConvectionMachineCircuitboard
+  # - CircuitImprinterHyperConvectionMachineCircuitboard
+  # ADT-Tweak-End
   - TechDiskComputerCircuitboard
   - FlatpackerMachineCircuitboard
   - SheetifierMachineCircuitboard
   - PowerCageRechargerCircuitboard
   - AnalysisComputerCircuitboard
   - AnomalyVesselCircuitboard
-  - AnomalyVesselExperimentalCircuitboard
+  # - AnomalyVesselExperimentalCircuitboard # ADT-Tweak
   - AnomalySynchronizerCircuitboard
   - ADTBotanicalSeedDNAManipulatorCircuitboard #ADT-Tweak
   - APECircuitboard

--- a/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
@@ -80,8 +80,8 @@
   - JukeboxCircuitBoard
   - DawInstrumentMachineCircuitboard
   # ADT-Tweak-Start
-  - ADTAdvancedMicrowaveMachineCircuitBoard
+  # - ADTAdvancedMicrowaveMachineCircuitBoard
   - ADTCoffeeMachineBluespaceCircuitboard
-  - ADTAdvancedReagentGrinderMachineCircuitboard
-  - ADTHydroponicsTrayAdvancedMachineCircuitboard
+  # - ADTAdvancedReagentGrinderMachineCircuitboard
+  # - ADTHydroponicsTrayAdvancedMachineCircuitboard
   # ADT-Tweak-End

--- a/Resources/Prototypes/Recipes/Lathes/machine_boards.yml
+++ b/Resources/Prototypes/Recipes/Lathes/machine_boards.yml
@@ -120,10 +120,12 @@
   id: ThermomachineFreezerMachineCircuitBoard
   result: ThermomachineFreezerMachineCircuitBoard
 
-- type: latheRecipe
-  parent: [ BaseSilverCircuitboardRecipe, BaseEngineeringMachineRecipeCategory ]
-  id: HellfireFreezerMachineCircuitBoard
-  result: HellfireFreezerMachineCircuitBoard
+# ADT-Tweak-Start
+# - type: latheRecipe
+#   parent: [ BaseSilverCircuitboardRecipe, BaseEngineeringMachineRecipeCategory ]
+#   id: HellfireFreezerMachineCircuitBoard
+#   result: HellfireFreezerMachineCircuitBoard
+# ADT-Tweak-End
 
 - type: latheRecipe
   parent: [ BaseGoldCircuitboardRecipe, BaseEngineeringMachineRecipeCategory ]
@@ -227,14 +229,16 @@
 
 # Anomaly
 - type: latheRecipe
-  parent: [ BaseCircuitboardRecipe, BaseResearchMachineRecipeCategory ]
+  parent: [ BaseGoldCircuitboardRecipe, BaseResearchMachineRecipeCategory ]
   id: AnomalyVesselCircuitboard
   result: AnomalyVesselCircuitboard
 
-- type: latheRecipe
-  parent: [ BaseGoldCircuitboardRecipe, BaseResearchMachineRecipeCategory ]
-  id: AnomalyVesselExperimentalCircuitboard
-  result: AnomalyVesselExperimentalCircuitboard
+# ADT-Tweak-Start
+# - type: latheRecipe
+#   parent: [ BaseGoldCircuitboardRecipe, BaseResearchMachineRecipeCategory ]
+#   id: AnomalyVesselExperimentalCircuitboard
+#   result: AnomalyVesselExperimentalCircuitboard
+# ADT-Tweak-End
 
 - type: latheRecipe
   parent: [ BaseSilverCircuitboardRecipe, BaseResearchMachineRecipeCategory ]
@@ -363,20 +367,24 @@
   id: ProtolatheMachineCircuitboard
   result: ProtolatheMachineCircuitboard
 
-- type: latheRecipe
-  parent: [ BaseGoldCircuitboardRecipe, BaseResearchMachineRecipeCategory ]
-  id: ProtolatheHyperConvectionMachineCircuitboard
-  result: ProtolatheHyperConvectionMachineCircuitboard
+# ADT-Tweak-Start
+# - type: latheRecipe
+#   parent: [ BaseGoldCircuitboardRecipe, BaseResearchMachineRecipeCategory ]
+#   id: ProtolatheHyperConvectionMachineCircuitboard
+#   result: ProtolatheHyperConvectionMachineCircuitboard
+# ADT-Tweak-End
 
 - type: latheRecipe
   parent: [ BaseCircuitboardRecipe, BaseResearchMachineRecipeCategory ]
   id: CircuitImprinterMachineCircuitboard
   result: CircuitImprinterMachineCircuitboard
 
-- type: latheRecipe
-  parent: [ BaseGoldCircuitboardRecipe, BaseResearchMachineRecipeCategory ]
-  id: CircuitImprinterHyperConvectionMachineCircuitboard
-  result: CircuitImprinterHyperConvectionMachineCircuitboard
+# ADT-Tweak-Start
+# - type: latheRecipe
+#   parent: [ BaseGoldCircuitboardRecipe, BaseResearchMachineRecipeCategory ]
+#   id: CircuitImprinterHyperConvectionMachineCircuitboard
+#   result: CircuitImprinterHyperConvectionMachineCircuitboard
+# ADT-Tweak-End
 
 - type: latheRecipe
   parent: [ BaseCircuitboardRecipe, BaseResearchMachineRecipeCategory ]
@@ -408,10 +416,12 @@
   id: AutolatheMachineCircuitboard
   result: AutolatheMachineCircuitboard
 
-- type: latheRecipe
-  parent: [ BaseGoldCircuitboardRecipe, BaseGeneralMachineRecipeCategory ]
-  id: AutolatheHyperConvectionMachineCircuitboard
-  result: AutolatheHyperConvectionMachineCircuitboard
+# ADT-Tweak-Start
+# - type: latheRecipe
+#   parent: [ BaseGoldCircuitboardRecipe, BaseGeneralMachineRecipeCategory ]
+#   id: AutolatheHyperConvectionMachineCircuitboard
+#   result: AutolatheHyperConvectionMachineCircuitboard
+# ADT-Tweak-End
 
 - type: latheRecipe
   parent: [ BaseCircuitboardRecipe, BaseGeneralMachineRecipeCategory ]
@@ -434,10 +444,12 @@
   id: BorgChargerCircuitboard
   result: BorgChargerCircuitboard
 
-- type: latheRecipe
-  parent: [ BaseGoldCircuitboardRecipe, BaseGeneralMachineRecipeCategory ]
-  id: TurboItemRechargerCircuitboard
-  result: TurboItemRechargerCircuitboard
+# ADT-Tweak-Start
+# - type: latheRecipe
+#   parent: [ BaseGoldCircuitboardRecipe, BaseGeneralMachineRecipeCategory ]
+#   id: TurboItemRechargerCircuitboard
+#   result: TurboItemRechargerCircuitboard
+# ADT-Tweak-End
 
 # Comms and Cameras
 - type: latheRecipe

--- a/Resources/Prototypes/Research/experimental.yml
+++ b/Resources/Prototypes/Research/experimental.yml
@@ -132,7 +132,7 @@
   recipeUnlocks:
   - WeaponPistolCHIMP
   - AnomalySynchronizerCircuitboard
-  - AnomalyVesselExperimentalCircuitboard
+  # - AnomalyVesselExperimentalCircuitboard # ADT-Tweak
   technologyPrerequisites:
   - BasicAnomalousResearch
   # ADT Research Console Rework start

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -50,7 +50,7 @@
   cost: 7500
   recipeUnlocks:
   - PowerCellHigh
-  - TurboItemRechargerCircuitboard
+  # - TurboItemRechargerCircuitboard # ADT-Tweak
   - SMESAdvancedMachineCircuitboard
 # ADT Research Console Rework start
   position: 0,-1
@@ -85,9 +85,11 @@
   tier: 1
   cost: 10000
   recipeUnlocks:
-  - AutolatheHyperConvectionMachineCircuitboard
-  - ProtolatheHyperConvectionMachineCircuitboard
-  - CircuitImprinterHyperConvectionMachineCircuitboard
+  # ADT-Tweak-Start
+  # - AutolatheHyperConvectionMachineCircuitboard
+  # - ProtolatheHyperConvectionMachineCircuitboard
+  # - CircuitImprinterHyperConvectionMachineCircuitboard
+  # ADT-Tweak-End
   - SheetifierMachineCircuitboard
 # ADT Research Console Rework start
   position: 1,2
@@ -184,7 +186,7 @@
   tier: 2
   cost: 7500
   recipeUnlocks:
-  - HellfireFreezerMachineCircuitBoard
+  # - HellfireFreezerMachineCircuitBoard # ADT-Tweak
   - PortableScrubberMachineCircuitBoard
   - HolofanProjector
   technologyPrerequisites:

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1043,3 +1043,6 @@ SpawnMobXenoEasy: ADTSpawnMobXenoEasyNoGhost
 
 # ADT 21.08.2026: remove ADTUniversalPipeDispenser
 ADTUniversalPipeDispenser: null
+
+# ADT 31.08.2026
+SiliconChargerIndustrial: BorgCharger


### PR DESCRIPTION
## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- remove: Удалены из исследований РНД и печати латов следующие предметы: турбозарядник, гиперконвекционные латы (автолат, протолат, принтер схем), адский охладитель, экспериментальный сосуд аномалии, крупноволновка 2000, продвинутый гидропонный лоток, продвинутый измельчитель реагентов, промышленное зарядное устройство. Их платы всё ещё можно найти на лаве или на обломках.
- tweak: Сосуд аномалий теперь не имеет сразу прирост 10% к очкам. 
- remove: Убрано Т4 улучшение раздатчика-химикатов на реагенты: уран, плазма, сидерлак.
