### PR TITLE
Моли кушают овощи

### DIFF
--- a/Resources/Prototypes/Body/Species/moth.yml
+++ b/Resources/Prototypes/Body/Species/moth.yml
@@ -348,9 +348,11 @@
           - ClothMade
           - Paper
           - Pill
-          - Fruit # ADT-tweak: moths can eat fruit
-          - Vegetable # ADT-tweak: moths can eat vegetables
-          - ADTMothFriendlyFood # ADT-tweak: moths can eat bread, pancakes etc.
+          # ADT-Tweak start: моли могут есть фрукты, овощи, и вайтлистнутую еду
+          - Fruit
+          - Vegetable
+          - ADTMothFriendlyFood
+          # ADT-Tweak end
 
 - type: entity
   parent: [OrganBaseLiver, OrganMothInternal, OrganAnimalMetabolizer] # ADT-tweak removed OrganSpriteHumanInternal

--- a/Resources/Prototypes/Body/Species/moth.yml
+++ b/Resources/Prototypes/Body/Species/moth.yml
@@ -349,6 +349,7 @@
           - Paper
           - Pill
           - Fruit # ADT-tweak: moths can eat fruit
+          - Vegetable # ADT-tweak: moths can eat vegetables
           - ADTMothFriendlyFood # ADT-tweak: moths can eat bread, pancakes etc.
 
 - type: entity


### PR DESCRIPTION
## Описание PR
Моли теперь могут кушать овощи

## Почему / Баланс
Должны иметь возможность кушать овощи. Цитата с вики:
> предпочтение же они отдают овощам, фруктам и сыру

## Техническая информация
В `specialDigestible` добавлен `Vegetable`
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Медиа
<img width="619" height="301" alt="image" src="https://github.com/user-attachments/assets/4d5cc3ba-a792-48da-b345-1ce34a3d5915" />

## Чейнджлог
:cl: FriendlyOne
- add: Моли могут кушать овощи