### PR TITLE
chem dispenser t4

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Structures/Machines/dispencers.yml
+++ b/Resources/Prototypes/ADT/Entities/Structures/Machines/dispencers.yml
@@ -116,7 +116,7 @@
       #  1: 
       2: { TableSalt: 4, Water: 3, WeldingFuel: 8 }
       3: { Benzene: 10, Hydroxide: 8, Fersilicite: 12 }
-      # 4: { Uranium: 15, Plasma: 12, Siderlac: 15 }
+      4: { Uranium: 15, Plasma: 12 }
       5: { Omnizine: 50, Cognizine: 50, Diethylamine: 10 }
     reagentsEmagged:
       Puncturase: 15


### PR DESCRIPTION

## Чейнджлог
:cl: Inconnu
- tweak: Т4 улучшения для раздатчика химикатов вновь в игре.
- remove: Сидерлак удален из Т4 раздатчика химикатов.