### PR TITLE
[TWEAK] Памп

### DIFF
--- a/Resources/Prototypes/ADT/Maps/ADTMaps/adt_pump.yml
+++ b/Resources/Prototypes/ADT/Maps/ADTMaps/adt_pump.yml
@@ -4,8 +4,8 @@
   mapPath: /Maps/ADTMaps/ADTStations/adt_pump.yml
   maxRandomOffset: 0
   randomRotation: false
-  minPlayers: 35
-  maxPlayers: 60
+  minPlayers: 0
+  maxPlayers: 20
   stations:
     Pump:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -26,7 +26,6 @@
   - ADT_Meta
   - ADT_Box
   # - ADT_Train
-  - ADT_Pump
 # Lowpop 20 - 35
   - ADT_Bagel
   - ADT_Packed
@@ -36,6 +35,7 @@
 # Micropop 0 - 20
   - ADT_Reach
   - ADT_Silly
+  - ADT_Pump
 
 # ADT Maps Выведенные на переработку
   # - ADT_Gate пока минока не начнёт нормально работать


### PR DESCRIPTION
## Описание PR
- Переносит памп в раздел микропопа

## Почему / Баланс
- [Предложение](https://discord.com/channels/901772674865455115/1545370860854972507/1545370860854972507)

## Чейнджлог

:cl: Kerfus
- tweak: Pump Station перенесён в категорию микропоп карт.