### PR TITLE
БАФФ стазисок, аве мед

### DIFF
--- a/Content.Server/ADT/Medical/StasisBed/StasisBedRotComponent.cs
+++ b/Content.Server/ADT/Medical/StasisBed/StasisBedRotComponent.cs
@@ -12,6 +12,9 @@ public sealed partial class StasisBedRotComponent : Component
     public float RotStopTier = 2f;
 
     [DataField]
+    public float SlowMultiplier = 0.5f;
+
+    [DataField]
     public float InaprovalineTier = 3f;
 
     [DataField]

--- a/Content.Server/ADT/Medical/StasisBed/StasisBedRotSystem.cs
+++ b/Content.Server/ADT/Medical/StasisBed/StasisBedRotSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Atmos.Rotting;
 using Content.Server.Power.EntitySystems;
 using Content.Shared.ADT.Construction;
 using Content.Shared.ADT.Construction.Events;
@@ -12,6 +13,7 @@ public sealed class StasisBedRotSystem : EntitySystem
 {
     [Dependency] private readonly PowerReceiverSystem _power = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solution = default!;
+    [Dependency] private readonly RottingSystem _rotting = default!;
 
     private float _accumulator;
 
@@ -30,19 +32,37 @@ public sealed class StasisBedRotSystem : EntitySystem
         _accumulator += frameTime;
         if (_accumulator < 1f)
             return;
+
+        var elapsed = TimeSpan.FromSeconds(_accumulator);
         _accumulator = 0f;
 
         var query = EntityQueryEnumerator<StasisBedRotComponent, StrapComponent>();
         while (query.MoveNext(out var uid, out var rot, out var strap))
         {
-            if (rot.Tier < rot.InaprovalineTier || !_power.IsPowered(uid))
+            if (!_power.IsPowered(uid))
                 continue;
 
             foreach (var patient in strap.BuckledEntities)
             {
-                TryStabilizePatient(patient, rot);
+                if (rot.Tier < rot.RotStopTier)
+                    TrySlowRot(patient, rot, elapsed);
+
+                if (rot.Tier >= rot.InaprovalineTier)
+                    TryStabilizePatient(patient, rot);
             }
         }
+    }
+
+    private void TrySlowRot(EntityUid patient, StasisBedRotComponent rot, TimeSpan elapsed)
+    {
+        if (rot.SlowMultiplier is <= 0f or >= 1f
+            || HasComp<RottingComponent>(patient)
+            || !_rotting.IsRotProgressing(patient, null))
+        {
+            return;
+        }
+
+        _rotting.ReduceAccumulator(patient, elapsed * (1f - rot.SlowMultiplier));
     }
 
     private void OnRefreshParts(EntityUid uid, StasisBedRotComponent component, RefreshPartsEvent args)
@@ -63,7 +83,8 @@ public sealed class StasisBedRotSystem : EntitySystem
         if (component.Tier >= component.RotStopTier)
             args.AddUpgradeLine(Loc.GetString("stasis-bed-rot-stopped"));
         else
-            args.AddUpgradeLine(Loc.GetString("stasis-bed-rot-not-stopped", ("tier", component.RotStopTier)));
+            args.AddUpgradeLine(Loc.GetString("stasis-bed-rot-not-stopped",
+                ("percent", (int) ((1f - component.SlowMultiplier) * 100f))));
 
         if (component.Tier >= component.InaprovalineTier)
             args.AddUpgradeLine(Loc.GetString("stasis-bed-inaprovaline", ("amount", component.InaprovalineAmount)));

--- a/Resources/Locale/en-US/ADT/medical/stasis-bed.ftl
+++ b/Resources/Locale/en-US/ADT/medical/stasis-bed.ftl
@@ -1,5 +1,5 @@
 stasis-bed-rot-stopped = [color=#6DFFA5]Body decomposition is stopped.[/color]
-stasis-bed-rot-not-stopped = [color=#FF7A7A]Body decomposition is not stopped[/color] — requires tier {$tier} upgrades.
+stasis-bed-rot-not-stopped = [color=#FFD27A]Body decomposition is slowed by {$percent}%[/color]
 stasis-bed-inaprovaline = Patient is stabilized with inaprovaline ({$amount}u in bloodstream).
 stasis-bed-inaprovaline-unavailable = Inaprovaline stabilization is available from tier {$tier}.
 cryo-pod-metabolism-examine = Patient chemical absorption: [color=#6DFFA5]×{$speed}[/color] (tier {$tier}).

--- a/Resources/Locale/ru-RU/ADT/medical/stasis-bed.ftl
+++ b/Resources/Locale/ru-RU/ADT/medical/stasis-bed.ftl
@@ -1,5 +1,5 @@
 stasis-bed-rot-stopped = [color=#6DFFA5]Разложение тела остановлено.[/color]
-stasis-bed-rot-not-stopped = [color=#FF7A7A]Разложение тела не остановлено[/color] - нужно улучшение до тира {$tier}.
+stasis-bed-rot-not-stopped = [color=#FFD27A]Разложение тела замедлено на {$percent}%[/color]
 stasis-bed-inaprovaline = [color=#6DFFA5]Пациент стабилизируется инапровалином ({$amount}u в кровотоке).[/color]
 stasis-bed-inaprovaline-unavailable = [color=#FF7A7A]Стабилизация инапровалином не активна[/color] - нужно улучшение до тира {$tier}.
 cryo-pod-metabolism-examine = Усвоение химии пациентом: [color=#6DFFA5]×{$speed}[/color] (тир {$tier}).


### PR DESCRIPTION
## Описание PR
Стазисные кровати замедляют гниение на 50%

## Почему / Баланс
После нерфа стазисок, Т1 стазиски стали слишком узкоспециализированные, и было мало сенса ими пользоватся. Теперь Т1 стазиски замедляют гниение, тобеж есть смысл лечить трупы именно на них

Циферку можно покрутить и ослабить

- [Предложение](https://discord.com/channels/901772674865455115/1545755406280687636)

## Техническая информация
В `StasisBedRotComponent` добавлено `SlowMultiplier`, сейчас он 0.5. Каждую секунду, если тело гниет(но не сгнило), `StasisBedRotSystem` откатывает процесс гниения на пол секунды. 

+ Чутка локали
- [X] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [X] PR закончен и требует просмотра изменений.

## Медиа
No media

## Чейнджлог
:cl: FriendlyOne
- add: Т1 стазис кровать замедляет гниение на 50%