### PR TITLE
add debts traits

### DIFF
--- a/Content.Server/ADT/Economy/BankCardSystem.cs
+++ b/Content.Server/ADT/Economy/BankCardSystem.cs
@@ -23,6 +23,7 @@ using Robust.Shared.Timing;
 using Content.Shared.CCVar;
 using Robust.Shared.Configuration;
 using Content.Shared.ADT.CCVar;
+using Content.Server.Traits;
 
 namespace Content.Server.ADT.Economy;
 
@@ -56,7 +57,7 @@ public sealed class BankCardSystem : EntitySystem
 
         SubscribeLocalEvent<BankCardComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
-        SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawned);
+        SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawned, after: [typeof(TraitSystem)]);
     }
 
     public override void Update(float frameTime)
@@ -90,7 +91,7 @@ public sealed class BankCardSystem : EntitySystem
         {
             var salary = GetSalary(account.Mind);
             if (salary > 0)
-                TryChangeBalance(account.AccountId, salary);
+                TryChangeBalance(account.AccountId, salary, allowNegative: account.Balance < 0);
         }
 
         _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("salary-pay-announcement"),
@@ -179,7 +180,11 @@ public sealed class BankCardSystem : EntitySystem
             if (!TryComp(mind.Mind, out MindComponent? mindComponent))
                 return;
 
-            bankAccount.Balance = GetSalary(mind.Mind) + 100;
+            var startingBalance = GetSalary(mind.Mind) + 100;
+            if (TryComp<StartingBalanceComponent>(ev.Mob, out var balanceComp))
+                startingBalance = balanceComp.Balance;
+
+            bankAccount.Balance = startingBalance;
             mindComponent.AddMemory(new Memory("PIN", bankAccount.AccountPin.ToString()));
             mindComponent.AddMemory(new Memory(Loc.GetString("character-info-memories-account-number"),
                 bankAccount.AccountId.ToString()));
@@ -259,7 +264,7 @@ public sealed class BankCardSystem : EntitySystem
         return account.Balance;
     }
 
-    public bool TryChangeBalance(int accountId, int amount)
+    public bool TryChangeBalance(int accountId, int amount, bool allowNegative = false)
     {
         if (!TryGetAccount(accountId, out var account))
             return false;
@@ -282,7 +287,7 @@ public sealed class BankCardSystem : EntitySystem
             return false;
         }
 
-        if (account.Balance + amount < 0)
+        if (account.Balance + amount < 0 && !allowNegative)
             return false;
 
         account.Balance += amount;

--- a/Content.Shared/ADT/Economy/StartingBalanceComponent.cs
+++ b/Content.Shared/ADT/Economy/StartingBalanceComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared.ADT.Economy;
+
+[RegisterComponent]
+public sealed partial class StartingBalanceComponent : Component
+{
+    [DataField]
+    public int Balance;
+}

--- a/Content.Shared/ADT/Traits/Effects/StartingBalanceEffect.cs
+++ b/Content.Shared/ADT/Traits/Effects/StartingBalanceEffect.cs
@@ -1,0 +1,17 @@
+using Content.Shared.ADT.Economy;
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared.ADT.Traits.Effects;
+
+public sealed partial class StartingBalanceEffect : BaseTraitEffect
+{
+    [DataField(required: true)]
+    public int Balance;
+
+    public override void Apply(TraitEffectContext ctx)
+    {
+        var comp = ctx.EntMan.EnsureComponent<StartingBalanceComponent>(ctx.Player);
+        comp.Balance = Balance;
+        ctx.EntMan.Dirty(ctx.Player, comp);
+    }
+}

--- a/Resources/Locale/en-US/ADT/traits/disabilities.ftl
+++ b/Resources/Locale/en-US/ADT/traits/disabilities.ftl
@@ -30,3 +30,9 @@ trait-dysgraphia-desc = You have difficulty with writing.
 
 trait-clumsy-name = Clumsy
 trait-clumsy-desc = You are a bit accident-prone.
+
+trait-debts-name = Loan Debts
+trait-debts-description = Your bank account starts the round with zero credits. Your salary comes in as usual.
+
+trait-on-edge-of-bankruptcy-name = On the Edge of Bankruptcy
+trait-on-edge-of-bankruptcy-description = Your bank account starts the round. Your salary comes in as usual and gradually covers the debt.

--- a/Resources/Locale/ru-RU/ADT/traits/disabilities.ftl
+++ b/Resources/Locale/ru-RU/ADT/traits/disabilities.ftl
@@ -42,3 +42,9 @@ trait-paralyzed-desc = Ваши ноги парализованы. Вы не м�
 
 trait-clumsy-name = Неуклюжий
 trait-clumsy-desc = Вы немного склонны к несчастным случаям.
+
+trait-debts-name = Долги по кредитам
+trait-debts-description = Ваш банковский счёт начинает смену без денег.
+
+trait-on-edge-of-bankruptcy-name = На грани банкротства
+trait-on-edge-of-bankruptcy-description = Ваш банковский счёт начинает смену с минусовым счётом. Зарплата приходит как обычно и постепенно покрывает долг.

--- a/Resources/Prototypes/ADT/Traits/disabilities.yml
+++ b/Resources/Prototypes/ADT/Traits/disabilities.yml
@@ -119,6 +119,30 @@
   speciesBlacklist:
   - NovakidSpecies
 
+- type: trait
+  id: Debts
+  name: trait-debts-name
+  description: trait-debts-description
+  category: Disabilities
+  cost: -1
+  effects:
+    - !type:StartingBalanceEffect
+      balance: 0
+  conflicts:
+    - OnEdgeOfBankruptcy
+
+- type: trait
+  id: OnEdgeOfBankruptcy
+  name: trait-on-edge-of-bankruptcy-name
+  description: trait-on-edge-of-bankruptcy-description
+  category: Disabilities
+  cost: -2
+  effects:
+    - !type:StartingBalanceEffect
+      balance: -500
+  conflicts:
+    - Debts
+
 # Система аллергии не работала, трайт давал очко ни за что.
 #- type: trait
 #  id: Allergic


### PR DESCRIPTION
## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- add: Новый негативный трейт "Долги по кредитам" - игрок появляется на станции без денег на собственном счету.
- add: Новый негативный трейт "На грани банкротства" - игрок появляется с минусовым балансом на своём счету.