### PR TITLE
Исправление грамматической ошибки в описании приёма БИ ЭС.

### DIFF
--- a/Resources/Locale/ru-RU/ADT/MartialArts/martial-arts.ftl
+++ b/Resources/Locale/ru-RU/ADT/MartialArts/martial-arts.ftl
@@ -71,7 +71,7 @@ ninjutsu-combo-dirty-kill = грязное убийство
 ninjutsu-combo-takedown = удушающий захват
 ninjutsu-combo-assassinate = удар в спину
 
-hellrip-combo-flying-dropkick = детящий дропкик
+hellrip-combo-flying-dropkick = летящий дропкик
 hellrip-combo-head-rip = отрывание головы
 hellrip-combo-tear-down = разрыв
 hellrip-combo-hellish-slam = адский удар


### PR DESCRIPTION
## Описание PR
Изменено название приёма БИ Разрыв Ада 
Детящий дропкик ==> Летящий дропкик

## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс.

В случае, если ваш pull request привязан к запросу из нашего discord сервера, используйте образец, представленный далее.

Ссылка на заказ, предложение или баг-репорт
- [Баг-репорт/Заказ/Предложение](ссылка)--> https://discord.com/channels/901772674865455115/1546224921762467881
Баг-репорт, в названии явная опечатка
## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [ ] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [X] PR закончен и требует просмотра изменений.

- [ ]  Этот PR меняет информацию, которая отображена на вики <!-- wiki-checkbox -->
<!-- Если чекбокс выше отмечен - удалите эти строки-комментарии, но wiki-checkbox не удаляйте и распишите изменения по тегам (аналогично Чейнджлогу):
:wiki: Автор
- add: что добавили
- remove: что убрали
- tweak: что подправили
- fix: что исправили
-->

## Чейнджлог

no cl, no fun
