### PR TITLE
РЕВОРК диеты молей

### DIFF
--- a/Content.Shared/Body/Components/StomachComponent.cs
+++ b/Content.Shared/Body/Components/StomachComponent.cs
@@ -25,4 +25,12 @@ public sealed partial class StomachComponent : Component
     /// </summary>
     [DataField]
     public bool IsSpecialDigestibleExclusive = true;
+
+    // ADT-Tweak start
+    /// <summary>
+    /// Items matching this whitelist are never digestible by this stomach, overriding everything else.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? SpecialDigestibleBlacklist = null;
+    // ADT-Tweak end
 }

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
@@ -198,9 +198,10 @@ public sealed partial class IngestionSystem : EntitySystem
         {
             foreach (var ent in stomachs)
             {
-                // ADT-Tweak: чёрный список желудка важнее белого
+                // ADT-Tweak-Start: чёрный список желудка важнее белого
                 if (_whitelistSystem.IsWhitelistPass(ent.Comp.SpecialDigestibleBlacklist, food))
                     continue;
+                // ADT-Tweak-End
                 // We need one stomach that can digest our special food.
                 if (_whitelistSystem.IsWhitelistPass(ent.Comp.SpecialDigestible, food))
                     return true;
@@ -210,9 +211,10 @@ public sealed partial class IngestionSystem : EntitySystem
         {
             foreach (var ent in stomachs)
             {
-                // ADT-Tweak: чёрный список желудка важнее белого
+                // ADT-Tweak-Start: чёрный список желудка важнее белого
                 if (_whitelistSystem.IsWhitelistPass(ent.Comp.SpecialDigestibleBlacklist, food))
                     continue;
+                // ADT-Tweak-End
                 // We need one stomach that can digest normal food.
                 if (ent.Comp.SpecialDigestible == null
                     || !ent.Comp.IsSpecialDigestibleExclusive
@@ -242,9 +244,10 @@ public sealed partial class IngestionSystem : EntitySystem
         if (ev.Universal)
             return true;
 
-        // ADT-Tweak: чёрный список желудка важнее белого
+        // ADT-Tweak-Start: чёрный список желудка важнее белого
         if (_whitelistSystem.IsWhitelistPass(stomach.Comp.SpecialDigestibleBlacklist, food))
             return false;
+        // ADT-Tweak-End
 
         if (ev.SpecialDigestion)
             return _whitelistSystem.IsWhitelistPass(stomach.Comp.SpecialDigestible, food);

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
@@ -198,6 +198,9 @@ public sealed partial class IngestionSystem : EntitySystem
         {
             foreach (var ent in stomachs)
             {
+                // ADT-Tweak: чёрный список желудка важнее белого
+                if (_whitelistSystem.IsWhitelistPass(ent.Comp.SpecialDigestibleBlacklist, food))
+                    continue;
                 // We need one stomach that can digest our special food.
                 if (_whitelistSystem.IsWhitelistPass(ent.Comp.SpecialDigestible, food))
                     return true;
@@ -207,6 +210,9 @@ public sealed partial class IngestionSystem : EntitySystem
         {
             foreach (var ent in stomachs)
             {
+                // ADT-Tweak: чёрный список желудка важнее белого
+                if (_whitelistSystem.IsWhitelistPass(ent.Comp.SpecialDigestibleBlacklist, food))
+                    continue;
                 // We need one stomach that can digest normal food.
                 if (ent.Comp.SpecialDigestible == null
                     || !ent.Comp.IsSpecialDigestibleExclusive
@@ -235,6 +241,10 @@ public sealed partial class IngestionSystem : EntitySystem
 
         if (ev.Universal)
             return true;
+
+        // ADT-Tweak: чёрный список желудка важнее белого
+        if (_whitelistSystem.IsWhitelistPass(stomach.Comp.SpecialDigestibleBlacklist, food))
+            return false;
 
         if (ev.SpecialDigestion)
             return _whitelistSystem.IsWhitelistPass(stomach.Comp.SpecialDigestible, food);

--- a/Resources/Prototypes/Body/Species/moth.yml
+++ b/Resources/Prototypes/Body/Species/moth.yml
@@ -348,7 +348,7 @@
           - ClothMade
           - Paper
           - Pill
-          # ADT-Tweak start: моли едят любую еду, кроме мяса
+          # ADT-Tweak start: моли едят любую еду, кроме мяса и снеков
           - Fruit
           - Vegetable
           - ADTMothFriendlyFood
@@ -356,6 +356,7 @@
       specialDigestibleBlacklist:
         tags:
           - Meat
+          - FoodSnack
       # ADT-Tweak end
 
 - type: entity

--- a/Resources/Prototypes/Body/Species/moth.yml
+++ b/Resources/Prototypes/Body/Species/moth.yml
@@ -348,11 +348,15 @@
           - ClothMade
           - Paper
           - Pill
-          # ADT-Tweak start: моли могут есть фрукты, овощи, и вайтлистнутую еду
+          # ADT-Tweak start: моли едят любую еду, кроме мяса
           - Fruit
           - Vegetable
           - ADTMothFriendlyFood
-          # ADT-Tweak end
+      isSpecialDigestibleExclusive: false
+      specialDigestibleBlacklist:
+        tags:
+          - Meat
+      # ADT-Tweak end
 
 - type: entity
   parent: [OrganBaseLiver, OrganMothInternal, OrganAnimalMetabolizer] # ADT-tweak removed OrganSpriteHumanInternal


### PR DESCRIPTION
## Описание PR
Моли теперь едят всю еду, кроме снеков(еды из автоматов) и еды с мясом(еда с тегом `Meat`)

## Почему / Баланс
По лору, единственное, что моли не могут есть - мясо. Также, они не могут есть снеки(еду из автоматов), сделано это как балансное решение, ведь они все еще могут есть одежду
- [Предложение](https://discord.com/channels/901772674865455115/1545893767771594793)

В будущем с этим можно сделать что-то интереснее, как отравление мясом, или сниженное насыщение снеками, но это для отдельной предложки

## Техническая информация
В `StomachComponent` добавлен `SpecialDigestibleBlacklist`, который по дефолту отключен. 

При попытке съесть что-то, идет проверка на блеклист. Блеклист имеет приоритет над вайтлистом(тобеж моль не может есть овощное блюдо с мясом).

Молям добавлен `specialDigestibleBlacklist` для `Meat`, `FoodSnack`
- [X] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [X] PR закончен и требует просмотра изменений.

## Важно
Теперь моли зависят от правильно поставленных тегов еды. В _большинстве случаев_ теги проставлены правильно. Отдельные моменты с фалс позитивами\негативами можно будет пофиксить, и от этого будет лучше всем, например, еда, в которой есть мясо при приготовлении, но нету тега `Meat` не может поедаться унатхами

## Чейнджлог
:cl: FriendlyOne
- tweak: Моли теперь едят всю еду, кроме снеков и еды с мясом