### PR TITLE
Фикс пицц

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Objects/Consumable/Food/Baked/pizza.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Consumable/Food/Baked/pizza.yml
@@ -92,7 +92,6 @@
 
 
 
-# ADT-Tweak start: общие базы для пицц, мясные несут тег Meat
 - type: entity
   parent: FoodInjectableBase
   id: ADTFoodPizzaBase
@@ -131,7 +130,6 @@
     tags:
     - Pizza
     - Meat
-# ADT-Tweak end
 
 - type: entity
   parent: ADTFoodPizzaMeatBase
@@ -146,7 +144,6 @@
 
 
 
-# ADT-Tweak start: общие базы для кусков пиццы
 - type: entity
   parent: FoodInjectableBase
   id: ADTFoodPizzaSliceBase
@@ -183,7 +180,6 @@
     - Pizza
     - Slice
     - Meat
-# ADT-Tweak end
 
 - type: entity
   parent: ADTFoodPizzaMeatSliceBase

--- a/Resources/Prototypes/ADT/Entities/Objects/Consumable/Food/Baked/pizza.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Consumable/Food/Baked/pizza.yml
@@ -92,20 +92,18 @@
 
 
 
+# ADT-Tweak start: общие базы для пицц, мясные несут тег Meat
 - type: entity
   parent: FoodInjectableBase
-  id: ADTFoodPizzaBBQ
-  name: bbqPizza
-  description: A bbq pizza
+  id: ADTFoodPizzaBase
+  abstract: true
   components:
   - type: FlavorProfile
     flavors:
       - oily
       - bread
-  - type: Edible
   - type: Sprite
     sprite: ADT/Objects/Consumable/Food/Baked/prazatpizza.rsi
-    state: bbq
   - type: SolutionContainerManager
     solutions:
       food:
@@ -115,7 +113,6 @@
           Quantity: 30
   - type: SliceableFood
     count: 8
-    slice: ADTFoodPizzaBBQSlice
   - type: Item
     size: Normal
     shape:
@@ -125,22 +122,43 @@
     - Pizza
     - ReptilianFood
 
-
+- type: entity
+  parent: ADTFoodPizzaBase
+  id: ADTFoodPizzaMeatBase
+  abstract: true
+  components:
+  - type: Tag
+    tags:
+    - Pizza
+    - ReptilianFood
+    - Meat
+# ADT-Tweak end
 
 - type: entity
+  parent: ADTFoodPizzaMeatBase
+  id: ADTFoodPizzaBBQ
+  name: bbqPizza
+  description: A bbq pizza
+  components:
+  - type: Sprite
+    state: bbq
+  - type: SliceableFood
+    slice: ADTFoodPizzaBBQSlice
+
+
+
+# ADT-Tweak start: общие базы для кусков пиццы
+- type: entity
   parent: FoodInjectableBase
-  id: ADTFoodPizzaBBQSlice
-  name: slice of bbq pizza
-  description: A slice of bbq pizza
+  id: ADTFoodPizzaSliceBase
+  abstract: true
   components:
   - type: FlavorProfile
     flavors:
       - oily
       - bread
-  - type: Edible
   - type: Sprite
     sprite: ADT/Objects/Consumable/Food/Baked/prazatpizza.rsi
-    state: bbq-slice
   - type: SolutionContainerManager
     solutions:
       food:
@@ -156,12 +174,34 @@
     - ReptilianFood
     - Slice
 
+- type: entity
+  parent: ADTFoodPizzaSliceBase
+  id: ADTFoodPizzaMeatSliceBase
+  abstract: true
+  components:
+  - type: Tag
+    tags:
+    - Pizza
+    - ReptilianFood
+    - Slice
+    - Meat
+# ADT-Tweak end
+
+- type: entity
+  parent: ADTFoodPizzaMeatSliceBase
+  id: ADTFoodPizzaBBQSlice
+  name: slice of bbq pizza
+  description: A slice of bbq pizza
+  components:
+  - type: Sprite
+    state: bbq-slice
+
 
 
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQ
+  parent: ADTFoodPizzaMeatBase
   id: ADTFoodPizzaBolognese
   name: bolognesePizza
   description: A bolognesse pizza
@@ -176,7 +216,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQSlice
+  parent: ADTFoodPizzaMeatSliceBase
   id: ADTFoodPizzaBologneseSlice
   name: slice of bolognesse pizza
   description: A slice of bolognesse pizza
@@ -189,7 +229,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQ
+  parent: ADTFoodPizzaMeatBase
   id: ADTFoodPizzaCaesar
   name: caesar pizza
   description: A caesar pizza
@@ -204,7 +244,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQSlice
+  parent: ADTFoodPizzaMeatSliceBase
   id: ADTFoodPizzaCaesarSlice
   name: slice of caesar pizza
   description: A slice of caesar pizza
@@ -215,7 +255,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQ
+  parent: ADTFoodPizzaBase
   id: ADTFoodPizzaCheese
   name: cheese pizza
   description: A cheese pizza
@@ -230,7 +270,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQSlice
+  parent: ADTFoodPizzaSliceBase
   id: ADTFoodPizzaCheeseSlice
   name: slice of cheese pizza
   description: A slice of cheese pizza
@@ -240,7 +280,7 @@
     state: cheese-slice
 
 - type: entity
-  parent: ADTFoodPizzaBBQ
+  parent: ADTFoodPizzaBase
   id: ADTFoodPizzaChicago
   name: chicago pizza
   description: A Chicago pizza
@@ -255,7 +295,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQSlice
+  parent: ADTFoodPizzaSliceBase
   id: ADTFoodPizzaChicagoSlice
   name: slice of chicago pizza
   description: A slice of chicago pizza
@@ -266,7 +306,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQ
+  parent: ADTFoodPizzaMeatBase
   id: ADTFoodPizzaChicken
   name: chicken pizza
   description: A chicken pizza
@@ -281,7 +321,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQSlice
+  parent: ADTFoodPizzaMeatSliceBase
   id: ADTFoodPizzaChickenSlice
   name: slice of chicken pizza
   description: A slice of chicken pizza
@@ -292,7 +332,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQ
+  parent: ADTFoodPizzaMeatBase
   id: ADTFoodPizzaClassic
   name: classic pizza
   description: A classic pizza
@@ -307,7 +347,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQSlice
+  parent: ADTFoodPizzaMeatSliceBase
   id: ADTFoodPizzaClassicSlice
   name: slice of classic pizza
   description: A slice of classic pizza
@@ -319,7 +359,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQ
+  parent: ADTFoodPizzaMeatBase
   id: ADTFoodPizzaDiablo
   name: diablo pizza
   description: The diablo pizza
@@ -334,7 +374,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQSlice
+  parent: ADTFoodPizzaMeatSliceBase
   id: ADTFoodPizzaDiabloSlice
   name: slice of diablo pizza
   description: A slice of diablo pizza
@@ -345,7 +385,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQ
+  parent: ADTFoodPizzaBase
   id: ADTFoodPizzaFourcheese
   name: four cheese pizza
   description: A four cheese pizza
@@ -360,7 +400,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQSlice
+  parent: ADTFoodPizzaSliceBase
   id: ADTFoodPizzaFourcheeseSlice
   name: slice of four cheese pizza
   description: A slice of four cheese pizza
@@ -372,7 +412,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQ
+  parent: ADTFoodPizzaMeatBase
   id: ADTFoodPizzaMexican
   name: mexican pizza
   description: A mexican pizza
@@ -387,7 +427,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQSlice
+  parent: ADTFoodPizzaMeatSliceBase
   id: ADTFoodPizzaMexicanSlice
   name: slice of mexican pizza
   description: A slice of mexican pizza
@@ -399,7 +439,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQ
+  parent: ADTFoodPizzaMeatBase
   id: ADTFoodPizzaMushroomchicken
   name: mushroom chicken pizza
   description: A mushroom chicken pizza
@@ -414,7 +454,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQSlice
+  parent: ADTFoodPizzaMeatSliceBase
   id: ADTFoodPizzaMushroomchickenSlice
   name: slice of mushroom chicken pizza
   description: A slice of mushroom chicken pizza
@@ -425,7 +465,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQ
+  parent: ADTFoodPizzaMeatBase
   id: ADTFoodPizzaSea
   name: sea pizza
   description: A sea pizza
@@ -440,7 +480,7 @@
 
 
 - type: entity
-  parent: ADTFoodPizzaBBQSlice
+  parent: ADTFoodPizzaMeatSliceBase
   id: ADTFoodPizzaSeaSlice
   name: slice of sea pizza
   description: A slice of sea pizza

--- a/Resources/Prototypes/ADT/Entities/Objects/Consumable/Food/Baked/pizza.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Consumable/Food/Baked/pizza.yml
@@ -130,7 +130,6 @@
   - type: Tag
     tags:
     - Pizza
-    - ReptilianFood
     - Meat
 # ADT-Tweak end
 
@@ -182,7 +181,6 @@
   - type: Tag
     tags:
     - Pizza
-    - ReptilianFood
     - Slice
     - Meat
 # ADT-Tweak end


### PR DESCRIPTION
## Описание PR
АДТшные пиццы теперь имеют правильные теги мяса

## Почему / Баланс
Баланс не меняется, фикс тегов. Например, у пицц с мясом не было тега `Meat`

## Техническая информация
Добавлено 4 парента для пицц: `ADTFoodPizzaBase` / `ADTFoodPizzaMeatBase`, `ADTFoodPizzaSliceBase` /
`ADTFoodPizzaMeatSliceBase`. Теперь не нужно добавлять тег мяса отдельно детям. Плюсом, таким образом были пофикшены пиццы, у которых не было тега мяса, а не было тега мяса у всех, ведь пиццы наследовали пиццу барбекю.
- [X] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [X] PR закончен и требует просмотра изменений.

### Изменения в основном невидимые для юзера, следственно no cl, no fun

## Чейнджлог
no cl, no fun
